### PR TITLE
add '-no-service-account' flag

### DIFF
--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -300,6 +300,228 @@ func TestParseImageTag(t *testing.T) {
 	}
 }
 
+func TestCommandGeneration(t *testing.T) {
+	svcAcc := "robot"
+	var srcRegName RegistryName = "gcr.io/bar"
+	var destRegName RegistryName = "gcr.io/foo"
+	var imgName ImageName = "baz"
+	var digest Digest = "sha256:000"
+	var tag Tag = "1.0"
+	var tp TagOp
+
+	testName := "GetRegistryListingCmd"
+	got := GetRegistryListingCmd(
+		svcAcc,
+		true,
+		string(destRegName))
+	expected := []string{
+		"gcloud",
+		"--account=robot",
+		"container",
+		"images",
+		"list",
+		fmt.Sprintf("--repository=%s", destRegName),
+		"--format=json"}
+	eqErr := checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	got = GetRegistryListingCmd(
+		svcAcc,
+		false,
+		string(destRegName))
+	expected = []string{
+		"gcloud",
+		"container",
+		"images",
+		"list",
+		fmt.Sprintf("--repository=%s", destRegName),
+		"--format=json"}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	testName = "GetRegistryListTagsCmd"
+	got = GetRegistryListTagsCmd(
+		svcAcc,
+		true,
+		string(destRegName),
+		string(imgName))
+	expected = []string{
+		"gcloud",
+		"--account=robot",
+		"container",
+		"images",
+		"list-tags",
+		fmt.Sprintf("%s/%s", destRegName, imgName),
+		"--format=json"}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	got = GetRegistryListTagsCmd(
+		svcAcc,
+		false,
+		string(destRegName),
+		string(imgName))
+	expected = []string{
+		"gcloud",
+		"container",
+		"images",
+		"list-tags",
+		fmt.Sprintf("%s/%s", destRegName, imgName),
+		"--format=json"}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	testName = "GetDeleteCmd"
+	got = GetDeleteCmd(
+		svcAcc,
+		true,
+		destRegName,
+		imgName,
+		digest)
+	expected = []string{
+		"gcloud",
+		"--account=robot",
+		"container",
+		"images",
+		"delete",
+		ToFQIN(destRegName, imgName, digest),
+		"--format=json"}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	got = GetDeleteCmd(
+		svcAcc,
+		false,
+		destRegName,
+		imgName,
+		digest)
+	expected = []string{
+		"gcloud",
+		"container",
+		"images",
+		"delete",
+		ToFQIN(destRegName, imgName, digest),
+		"--format=json"}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	testName = "GetWriteCmd (Add)"
+	tp = Add
+	got = GetWriteCmd(
+		svcAcc,
+		true,
+		srcRegName,
+		destRegName,
+		imgName,
+		digest,
+		tag,
+		tp)
+	expected = []string{
+		"gcloud",
+		"--account=robot",
+		"--quiet",
+		"--verbosity=debug",
+		"container",
+		"images",
+		"add-tag",
+		ToFQIN(srcRegName, imgName, digest),
+		ToPQIN(destRegName, imgName, tag)}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	got = GetWriteCmd(
+		svcAcc,
+		false,
+		srcRegName,
+		destRegName,
+		imgName,
+		digest,
+		tag,
+		tp)
+	expected = []string{
+		"gcloud",
+		"--quiet",
+		"--verbosity=debug",
+		"container",
+		"images",
+		"add-tag",
+		ToFQIN(srcRegName, imgName, digest),
+		ToPQIN(destRegName, imgName, tag)}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	testName = "GetWriteCmd (Delete)"
+	tp = Delete
+	got = GetWriteCmd(
+		svcAcc,
+		true,
+		srcRegName,
+		destRegName,
+		imgName,
+		digest,
+		tag,
+		tp)
+	expected = []string{
+		"gcloud",
+		"--account=robot",
+		"--quiet",
+		"container",
+		"images",
+		"untag",
+		ToPQIN(destRegName, imgName, tag)}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+
+	got = GetWriteCmd(
+		svcAcc,
+		false,
+		srcRegName,
+		destRegName,
+		imgName,
+		digest,
+		tag,
+		tp)
+	expected = []string{
+		"gcloud",
+		"--quiet",
+		"container",
+		"images",
+		"untag",
+		ToPQIN(destRegName, imgName, tag)}
+	eqErr = checkEqual(got, expected)
+	checkError(
+		t,
+		eqErr,
+		fmt.Sprintf("Test: %v (cmd string)\n", testName))
+}
+
 func TestSyncContext(t *testing.T) {
 	const fakeRegName RegistryName = "gcr.io/foo"
 	var tests = []struct {

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -44,11 +44,12 @@ type CapturedRequests map[PromotionRequest]int
 
 // SyncContext is the main data structure for performing the promotion.
 type SyncContext struct {
-	Verbosity       int
-	Threads         int
-	DeleteExtraTags bool
-	DryRun          bool
-	Inv             MasterInventory
+	Verbosity         int
+	Threads           int
+	DeleteExtraTags   bool
+	DryRun            bool
+	UseServiceAccount bool
+	Inv               MasterInventory
 }
 
 // MasterInventory stores multiple RegInvImage elements, keyed by RegistryName.


### PR DESCRIPTION
    This allows requests to gcloud to be executed without the
    "--account=..." flag. The use case for this flag is for dry runs against
    publicly readable GCRs (to guarantee that we will not be making any
    modifications; it also allows us to avoid mounting any service account
    secrets, which has been the norm so far for all cases, even for dry
    runs). See also kubernetes/test-infra#11414.

    We keep the existing functionality of '-dry-run' independent of this
    flag; this is for the use case where we want to run '-dry-run' against
    private registries that are _not_ publicly readable.

    To summarize:
            - use '-dry-run -no-service-account' for doing dry runs against publicly readable registries
            - use '-dry-run' for doing dry runs against private registries