### PR TITLE
allow promoting to multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Registry (src registry) to another (dest registry), by reading a Manifest file
 Example Manifest:
 
 ```
+src: gcr.io/myproject-staging-area
 registries:
-  src: gcr.io/myproject-staging-area
-  dest: gcr.io/myproject-production
-service-account: foo@google-containers.iam.gserviceaccount.com
+- name: gcr.io/myproject-staging-area
+  service-account: foo@google-containers.iam.gserviceaccount.com
+- name: gcr.io/myproject-production
+  service-account: foo@google-containers.iam.gserviceaccount.com
 images:
 - name: apple
   dmap:

--- a/cip.go
+++ b/cip.go
@@ -91,9 +91,8 @@ func main() {
 		rc reg.RegistryContext, imgName reg.ImageName) stream.Producer {
 		var sp stream.Subprocess
 		sp.CmdInvocation = reg.GetRegistryListTagsCmd(
-			rc.ServiceAccount,
+			rc,
 			sc.UseServiceAccount,
-			string(rc.Name),
 			string(imgName))
 		return &sp
 	}
@@ -109,10 +108,9 @@ func main() {
 		digest reg.Digest, tag reg.Tag, tp reg.TagOp) stream.Producer {
 		var sp stream.Subprocess
 		sp.CmdInvocation = reg.GetWriteCmd(
-			destRC.ServiceAccount,
+			destRC,
 			sc.UseServiceAccount,
 			srcRegistry,
-			destRC.Name,
 			imageName,
 			digest,
 			tag,
@@ -133,9 +131,8 @@ func main() {
 			digest reg.Digest) stream.Producer {
 			var sp stream.Subprocess
 			sp.CmdInvocation = reg.GetDeleteCmd(
-				dest.ServiceAccount,
+				dest,
 				sc.UseServiceAccount,
-				dest.Name,
 				imageName,
 				digest)
 			return &sp

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1119,10 +1119,9 @@ func MaybeUseServiceAccount(
 // GetWriteCmd generates a gcloud command that is used to make modifications to
 // a Docker Registry.
 func GetWriteCmd(
-	serviceAccount string,
+	dest RegistryContext,
 	useServiceAccount bool,
 	srcRegistry RegistryName,
-	destRegistry RegistryName,
 	image ImageName,
 	digest Digest,
 	tag Tag,
@@ -1141,29 +1140,28 @@ func GetWriteCmd(
 			"images",
 			"add-tag",
 			ToFQIN(srcRegistry, image, digest),
-			ToPQIN(destRegistry, image, tag)}
+			ToPQIN(dest.Name, image, tag)}
 	case Delete:
 		cmd = []string{"gcloud",
 			"--quiet",
 			"container",
 			"images",
 			"untag",
-			ToPQIN(destRegistry, image, tag)}
+			ToPQIN(dest.Name, image, tag)}
 	}
 	// Use the service account if it is desired.
-	return MaybeUseServiceAccount(serviceAccount, useServiceAccount, cmd)
+	return MaybeUseServiceAccount(dest.ServiceAccount, useServiceAccount, cmd)
 }
 
 // GetDeleteCmd generates the cloud command used to delete images (used for
 // garbage collection).
 func GetDeleteCmd(
-	serviceAccount string,
+	rc RegistryContext,
 	useServiceAccount bool,
-	registryName RegistryName,
 	img ImageName,
 	digest Digest) []string {
 
-	fqin := ToFQIN(registryName, img, digest)
+	fqin := ToFQIN(rc.Name, img, digest)
 	cmd := []string{
 		"gcloud",
 		"container",
@@ -1171,7 +1169,7 @@ func GetDeleteCmd(
 		"delete",
 		fqin,
 		"--format=json"}
-	return MaybeUseServiceAccount(serviceAccount, useServiceAccount, cmd)
+	return MaybeUseServiceAccount(rc.ServiceAccount, useServiceAccount, cmd)
 }
 
 // GetRegistryListingCmd generates the invocation for retrieving all images in a
@@ -1191,15 +1189,14 @@ func GetRegistryListingCmd(
 // GetRegistryListTagsCmd generates the invocation for retrieving all digests
 // (and tags on them) for a given image.
 func GetRegistryListTagsCmd(
-	serviceAccount string,
+	rc RegistryContext,
 	useServiceAccount bool,
-	registryName string,
 	img string) []string {
 	cmd := []string{
 		"gcloud",
 		"container",
 		"images",
 		"list-tags",
-		fmt.Sprintf("%s/%s", registryName, img), "--format=json"}
-	return MaybeUseServiceAccount(serviceAccount, useServiceAccount, cmd)
+		fmt.Sprintf("%s/%s", rc.Name, img), "--format=json"}
+	return MaybeUseServiceAccount(rc.ServiceAccount, useServiceAccount, cmd)
 }

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -35,7 +35,8 @@ import (
 func MakeSyncContext(
 	mi MasterInventory,
 	verbosity, threads int,
-	deleteExtraTags, dryRun, useSvcAcc bool) SyncContext {
+	deleteExtraTags, dryRun, useSvcAcc bool,
+	rcs []RegistryContext) SyncContext {
 
 	return SyncContext{
 		Verbosity:         verbosity,
@@ -43,7 +44,8 @@ func MakeSyncContext(
 		DeleteExtraTags:   deleteExtraTags,
 		DryRun:            dryRun,
 		UseServiceAccount: useSvcAcc,
-		Inv:               mi}
+		Inv:               mi,
+		RegistryContexts:  rcs}
 }
 
 // Basic logging.
@@ -279,16 +281,16 @@ func getJSONSFromProcess(req stream.ExternalRequest) (json.Objects, Errors) {
 
 // ReadImageNames only works for streams that interpret json.
 func (sc *SyncContext) ReadImageNames(
-	mkProducer func(RegistryName) stream.Producer) {
+	mkProducer func(RegistryContext) stream.Producer) {
 	// Collect all images in sc.Inv (the src and dest reqgistry names found in
 	// the manifest).
 	var populateRequests PopulateRequests = func(
 		sc *SyncContext, reqs chan<- stream.ExternalRequest) {
 
-		for registryName := range sc.Inv {
+		for _, rc := range sc.RegistryContexts {
 			var req stream.ExternalRequest
-			req.RequestParams = registryName
-			req.StreamProducer = mkProducer(registryName)
+			req.RequestParams = rc.Name
+			req.StreamProducer = mkProducer(rc)
 			reqs <- req
 		}
 	}
@@ -340,20 +342,25 @@ func (sc *SyncContext) ReadImageNames(
 // gcr.io/louhi-gke-k8s/etcd --format=json` For each image name, retrieve all
 // digests and corresponding tags (if any).
 func (sc *SyncContext) ReadDigestsAndTags(
-	mkProducer func(RegistryName, ImageName) stream.Producer) {
+	mkProducer func(RegistryContext, ImageName) stream.Producer) {
 
 	var populateRequests PopulateRequests = func(
 		sc *SyncContext,
 		reqs chan<- stream.ExternalRequest) {
 
 		for registryName, imagesMap := range sc.Inv {
-			for imgName := range imagesMap {
-				var req stream.ExternalRequest
-				req.StreamProducer = mkProducer(registryName, imgName)
-				req.RequestParams = DigestTagsContext{
-					ImageName:    imgName,
-					RegistryName: registryName}
-				reqs <- req
+			for _, rc := range sc.RegistryContexts {
+				if registryName == rc.Name {
+					for imgName := range imagesMap {
+						var req stream.ExternalRequest
+						req.StreamProducer = mkProducer(rc, imgName)
+						req.RequestParams = DigestTagsContext{
+							ImageName:    imgName,
+							RegistryName: registryName}
+						reqs <- req
+					}
+					break
+				}
 			}
 		}
 	}
@@ -531,7 +538,7 @@ func ToPQIN(registryName RegistryName, imageName ImageName, tag Tag) string {
 
 // ShowLostImages logs all images in Manifest which are missing from src.
 func (sc *SyncContext) ShowLostImages(mfest Manifest) {
-	src := sc.Inv[mfest.Registries.Src].ToRegInvImageDigest()
+	src := sc.Inv[mfest.Src].ToRegInvImageDigest()
 
 	// lost = all images that cannot be found from src.
 	lost := mfest.ToRegInvImageDigest().Minus(src)
@@ -539,10 +546,10 @@ func (sc *SyncContext) ShowLostImages(mfest Manifest) {
 		sc.Errorf(
 			"Lost images (all images in Manifest that cannot be found"+
 				" from src registry %v):\n",
-			mfest.Registries.Src)
+			mfest.Src)
 		for imageDigest := range lost {
 			fqin := ToFQIN(
-				mfest.Registries.Src,
+				mfest.Src,
 				imageDigest.ImageName,
 				imageDigest.Digest)
 			sc.Errorf(
@@ -553,37 +560,38 @@ func (sc *SyncContext) ShowLostImages(mfest Manifest) {
 		sc.Infof(
 			"Lost images (all images in Manifest that cannot be found from"+
 				" src registry %v):\n  <none>\n",
-			mfest.Registries.Src)
+			mfest.Src)
 	}
 }
 
 func (sc *SyncContext) mkPopReq(
 	mfest Manifest, // seems odd
+	destRC RegistryContext,
 	thing RegInvImageTag,
 	tp TagOp,
 	oldDigest Digest,
 	mkProducer func( // seems odd
 		RegistryName,
-		RegistryName,
+		RegistryContext,
 		ImageName,
 		Digest,
 		Tag,
 		TagOp) stream.Producer,
 	reqs chan<- stream.ExternalRequest) {
 
-	dest := sc.Inv[mfest.Registries.Dest]
+	dest := sc.Inv[destRC.Name]
 	for imageTag, digest := range thing {
 		var req stream.ExternalRequest
 		req.StreamProducer = mkProducer(
-			mfest.Registries.Src,
-			mfest.Registries.Dest,
+			mfest.Src,
+			destRC,
 			imageTag.ImageName,
 			digest,
 			imageTag.Tag,
 			tp)
 		tpStr := ""
 		fqin := ToFQIN(
-			mfest.Registries.Dest,
+			destRC.Name,
 			imageTag.ImageName,
 			digest)
 		movePointerOnly := false
@@ -614,10 +622,10 @@ func (sc *SyncContext) mkPopReq(
 `,
 				tpStr,
 				imageTag.Tag,
-				mfest.Registries.Dest,
+				destRC.Name,
 				imageTag.ImageName,
 				oldDigest,
-				mfest.Registries.Dest,
+				destRC.Name,
 				imageTag.ImageName, digest)
 			if movePointerOnly {
 				msg += fmt.Sprintf(
@@ -636,7 +644,9 @@ func (sc *SyncContext) mkPopReq(
 		// HTTP "headers".
 		req.RequestParams = PromotionRequest{
 			tp,
-			mfest.Registries,
+			mfest.Src,
+			destRC.Name,
+			destRC.ServiceAccount,
 			imageTag.ImageName,
 			digest,
 			oldDigest,
@@ -654,83 +664,91 @@ func mkPopulateRequestsForPromotion(
 	promotionCandidatesIT RegInvImageTag,
 	mkProducer func(
 		RegistryName,
-		RegistryName,
+		RegistryContext,
 		ImageName,
 		Digest,
 		Tag,
 		TagOp) stream.Producer,
 ) PopulateRequests {
 	return func(sc *SyncContext, reqs chan<- stream.ExternalRequest) {
-		destIT := sc.Inv[mfest.Registries.Dest].ToRegInvImageTag()
-		// For all promotionCandidates that are not already in the destination,
-		// their promotion type is "Add".
-		sc.mkPopReq(
-			mfest,
-			promotionCandidatesIT.Minus(destIT),
-			Add,
-			"",
-			mkProducer,
-			reqs)
-		// Audit the intersection (make sure already-existing tags are pointing
-		// to the digest specified in the manifest).
-		toAudit := promotionCandidatesIT.Intersection(destIT)
-		for imageTag, digest := range toAudit {
-			if liveDigest, ok := destIT[imageTag]; ok {
-				// dest has this imageTag already; need to audit.
-				pqin := ToPQIN(
-					mfest.Registries.Dest,
-					imageTag.ImageName,
-					imageTag.Tag)
-				if digest == liveDigest {
-					// NOP if dest's imageTag is already pointing to the same
-					// digest as in the manifest.
-
-					sc.Infof(
-						"skipping: image '%v' already points to the same"+
-							" digest (%v) as in the Manifest\n",
-						pqin,
-						digest)
-					continue
-				} else {
-					// Dest's tag is pointing to the wrong digest! Need to move
-					// the tag.
-					sc.Warnf(
-						"Warning: image '%v' is pointing to the wrong digest"+
-							"\n       got: %v\n  expected: %v\n",
-						pqin,
-						liveDigest,
-						digest)
-					sc.mkPopReq(
-						mfest,
-						RegInvImageTag{imageTag: digest},
-						Move,
-						liveDigest,
-						mkProducer,
-						reqs)
-				}
+		for _, registry := range mfest.Registries {
+			if registry.Name == mfest.Src {
+				continue
 			}
-		}
-		mfestIT := mfest.ToRegInvImageTag()
-		if sc.DeleteExtraTags {
+			destIT := sc.Inv[registry.Name].ToRegInvImageTag()
+			// For all promotionCandidates that are not already in the
+			// destination, their promotion type is "Add".
 			sc.mkPopReq(
 				mfest,
-				destIT.Minus(mfestIT),
-				Delete,
+				registry,
+				promotionCandidatesIT.Minus(destIT),
+				Add,
 				"",
 				mkProducer,
 				reqs)
-		} else {
-			// Warn the user about extra tags:
-			xtras := make([]string, 0)
-			for imageTag := range destIT.Minus(promotionCandidatesIT) {
-				xtras = append(xtras, fmt.Sprintf(
-					"%s:%s",
-					imageTag.ImageName,
-					imageTag.Tag))
+			// Audit the intersection (make sure already-existing tags are
+			// pointing to the digest specified in the manifest).
+			toAudit := promotionCandidatesIT.Intersection(destIT)
+			for imageTag, digest := range toAudit {
+				if liveDigest, ok := destIT[imageTag]; ok {
+					// dest has this imageTag already; need to audit.
+					pqin := ToPQIN(
+						registry.Name,
+						imageTag.ImageName,
+						imageTag.Tag)
+					if digest == liveDigest {
+						// NOP if dest's imageTag is already pointing to the
+						// same digest as in the manifest.
+
+						sc.Infof(
+							"skipping: image '%v' already points to the same"+
+								" digest (%v) as in the Manifest\n",
+							pqin,
+							digest)
+						continue
+					} else {
+						// Dest's tag is pointing to the wrong digest! Need to
+						// move the tag.
+						sc.Warnf(
+							"Warning: image '%v' is pointing to the wrong"+
+								" digest\n       got: %v\n  expected: %v\n",
+							pqin,
+							liveDigest,
+							digest)
+						sc.mkPopReq(
+							mfest,
+							registry,
+							RegInvImageTag{imageTag: digest},
+							Move,
+							liveDigest,
+							mkProducer,
+							reqs)
+					}
+				}
 			}
-			sort.Strings(xtras)
-			for _, img := range xtras {
-				sc.Warnf("Warning: extra tag found in dest: %s\n", img)
+			mfestIT := mfest.ToRegInvImageTag()
+			if sc.DeleteExtraTags {
+				sc.mkPopReq(
+					mfest,
+					registry,
+					destIT.Minus(mfestIT),
+					Delete,
+					"",
+					mkProducer,
+					reqs)
+			} else {
+				// Warn the user about extra tags:
+				xtras := make([]string, 0)
+				for imageTag := range destIT.Minus(promotionCandidatesIT) {
+					xtras = append(xtras, fmt.Sprintf(
+						"%s:%s",
+						imageTag.ImageName,
+						imageTag.Tag))
+				}
+				sort.Strings(xtras)
+				for _, img := range xtras {
+					sc.Warnf("Warning: extra tag found in dest: %s\n", img)
+				}
 			}
 		}
 	}
@@ -740,7 +758,7 @@ func mkPopulateRequestsForPromotion(
 func (sc *SyncContext) GetPromotionCandidatesIT(
 	mfest Manifest) RegInvImageTag {
 
-	src := sc.Inv[mfest.Registries.Src]
+	src := sc.Inv[mfest.Src]
 
 	// promotionCandidates = all images in the manifest that can be found from
 	// src. But, this is filtered later to remove those ones that are already in
@@ -749,7 +767,7 @@ func (sc *SyncContext) GetPromotionCandidatesIT(
 		src.ToRegInvImageDigest())
 	sc.Infof(
 		"To promote (intersection of Manifest and src registry %v):\n%v",
-		mfest.Registries.Src,
+		mfest.Src,
 		promotionCandidates.PrettyValue())
 
 	if len(promotionCandidates) > 0 {
@@ -777,7 +795,7 @@ func (sc *SyncContext) Promote(
 	mfest Manifest,
 	mkProducer func(
 		RegistryName,
-		RegistryName,
+		RegistryContext,
 		ImageName,
 		Digest,
 		Tag,
@@ -901,8 +919,8 @@ func (op *TagOp) PrettyValue() string {
 func (pr *PromotionRequest) PrettyValue() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%v -> %v: Tag: '%v' <%v> %v@%v",
-		string(pr.Registries.Src),
-		string(pr.Registries.Dest),
+		string(pr.RegistrySrc),
+		string(pr.RegistryDest),
 		string(pr.Tag),
 		pr.TagOp.PrettyValue(),
 		string(pr.ImageName),
@@ -941,32 +959,40 @@ func MkRequestCapturer(captured *CapturedRequests) ProcessRequest {
 }
 
 // GarbageCollect deletes all images that are not referenced by Docker tags.
+// nolint[gocyclo]
 func (sc *SyncContext) GarbageCollect(
 	mfest Manifest,
-	mkProducer func(RegistryName, ImageName, Digest) stream.Producer,
+	mkProducer func(RegistryContext, ImageName, Digest) stream.Producer,
 	customProcessRequest *ProcessRequest) {
 
 	var populateRequests PopulateRequests = func(
 		sc *SyncContext,
 		reqs chan<- stream.ExternalRequest) {
 
-		for imageName, digestTags := range sc.Inv[mfest.Registries.Dest] {
-			for digest, tagArray := range digestTags {
-				if len(tagArray) == 0 {
-					var req stream.ExternalRequest
-					req.StreamProducer = mkProducer(
-						mfest.Registries.Dest,
-						imageName,
-						digest)
-					req.RequestParams = PromotionRequest{
-						Delete,
-						mfest.Registries,
-						imageName,
-						digest,
-						"",
-						"",
+		for _, registry := range mfest.Registries {
+			if registry.Name == mfest.Src {
+				continue
+			}
+			for imageName, digestTags := range sc.Inv[registry.Name] {
+				for digest, tagArray := range digestTags {
+					if len(tagArray) == 0 {
+						var req stream.ExternalRequest
+						req.StreamProducer = mkProducer(
+							registry,
+							imageName,
+							digest)
+						req.RequestParams = PromotionRequest{
+							Delete,
+							mfest.Src,
+							registry.Name,
+							registry.ServiceAccount,
+							imageName,
+							digest,
+							"",
+							"",
+						}
+						reqs <- req
 					}
-					reqs <- req
 				}
 			}
 		}
@@ -1091,16 +1117,15 @@ func GetDeleteCmd(
 // GetRegistryListingCmd generates the invocation for retrieving all images in a
 // GCR.
 func GetRegistryListingCmd(
-	serviceAccount string,
-	useServiceAccount bool,
-	r string) []string {
+	rc RegistryContext,
+	useServiceAccount bool) []string {
 	cmd := []string{
 		"gcloud",
 		"container",
 		"images",
 		"list",
-		fmt.Sprintf("--repository=%s", r), "--format=json"}
-	return MaybeUseServiceAccount(serviceAccount, useServiceAccount, cmd)
+		fmt.Sprintf("--repository=%s", rc.Name), "--format=json"}
+	return MaybeUseServiceAccount(rc.ServiceAccount, useServiceAccount, cmd)
 }
 
 // GetRegistryListTagsCmd generates the invocation for retrieving all digests

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -300,9 +300,10 @@ func TestParseImageTag(t *testing.T) {
 }
 
 func TestCommandGeneration(t *testing.T) {
-	svcAcc := "robot"
+	destRC := RegistryContext{
+		Name:           "gcr.io/foo",
+		ServiceAccount: "robot"}
 	var srcRegName RegistryName = "gcr.io/bar"
-	var destRegName RegistryName = "gcr.io/foo"
 	var imgName ImageName = "baz"
 	var digest Digest = "sha256:000"
 	var tag Tag = "1.0"
@@ -310,16 +311,15 @@ func TestCommandGeneration(t *testing.T) {
 
 	testName := "GetRegistryListingCmd"
 	got := GetRegistryListingCmd(
-		svcAcc,
-		true,
-		string(destRegName))
+		destRC,
+		true)
 	expected := []string{
 		"gcloud",
 		"--account=robot",
 		"container",
 		"images",
 		"list",
-		fmt.Sprintf("--repository=%s", destRegName),
+		fmt.Sprintf("--repository=%s", destRC.Name),
 		"--format=json"}
 	eqErr := checkEqual(got, expected)
 	checkError(
@@ -328,15 +328,14 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetRegistryListingCmd(
-		svcAcc,
-		false,
-		string(destRegName))
+		destRC,
+		false)
 	expected = []string{
 		"gcloud",
 		"container",
 		"images",
 		"list",
-		fmt.Sprintf("--repository=%s", destRegName),
+		fmt.Sprintf("--repository=%s", destRC.Name),
 		"--format=json"}
 	eqErr = checkEqual(got, expected)
 	checkError(
@@ -346,9 +345,9 @@ func TestCommandGeneration(t *testing.T) {
 
 	testName = "GetRegistryListTagsCmd"
 	got = GetRegistryListTagsCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		true,
-		string(destRegName),
+		string(destRC.Name),
 		string(imgName))
 	expected = []string{
 		"gcloud",
@@ -356,7 +355,7 @@ func TestCommandGeneration(t *testing.T) {
 		"container",
 		"images",
 		"list-tags",
-		fmt.Sprintf("%s/%s", destRegName, imgName),
+		fmt.Sprintf("%s/%s", destRC.Name, imgName),
 		"--format=json"}
 	eqErr = checkEqual(got, expected)
 	checkError(
@@ -365,16 +364,16 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetRegistryListTagsCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		false,
-		string(destRegName),
+		string(destRC.Name),
 		string(imgName))
 	expected = []string{
 		"gcloud",
 		"container",
 		"images",
 		"list-tags",
-		fmt.Sprintf("%s/%s", destRegName, imgName),
+		fmt.Sprintf("%s/%s", destRC.Name, imgName),
 		"--format=json"}
 	eqErr = checkEqual(got, expected)
 	checkError(
@@ -384,9 +383,9 @@ func TestCommandGeneration(t *testing.T) {
 
 	testName = "GetDeleteCmd"
 	got = GetDeleteCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		true,
-		destRegName,
+		destRC.Name,
 		imgName,
 		digest)
 	expected = []string{
@@ -395,7 +394,7 @@ func TestCommandGeneration(t *testing.T) {
 		"container",
 		"images",
 		"delete",
-		ToFQIN(destRegName, imgName, digest),
+		ToFQIN(destRC.Name, imgName, digest),
 		"--format=json"}
 	eqErr = checkEqual(got, expected)
 	checkError(
@@ -404,9 +403,9 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetDeleteCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		false,
-		destRegName,
+		destRC.Name,
 		imgName,
 		digest)
 	expected = []string{
@@ -414,7 +413,7 @@ func TestCommandGeneration(t *testing.T) {
 		"container",
 		"images",
 		"delete",
-		ToFQIN(destRegName, imgName, digest),
+		ToFQIN(destRC.Name, imgName, digest),
 		"--format=json"}
 	eqErr = checkEqual(got, expected)
 	checkError(
@@ -425,10 +424,10 @@ func TestCommandGeneration(t *testing.T) {
 	testName = "GetWriteCmd (Add)"
 	tp = Add
 	got = GetWriteCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		true,
 		srcRegName,
-		destRegName,
+		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -442,7 +441,7 @@ func TestCommandGeneration(t *testing.T) {
 		"images",
 		"add-tag",
 		ToFQIN(srcRegName, imgName, digest),
-		ToPQIN(destRegName, imgName, tag)}
+		ToPQIN(destRC.Name, imgName, tag)}
 	eqErr = checkEqual(got, expected)
 	checkError(
 		t,
@@ -450,10 +449,10 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetWriteCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		false,
 		srcRegName,
-		destRegName,
+		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -466,7 +465,7 @@ func TestCommandGeneration(t *testing.T) {
 		"images",
 		"add-tag",
 		ToFQIN(srcRegName, imgName, digest),
-		ToPQIN(destRegName, imgName, tag)}
+		ToPQIN(destRC.Name, imgName, tag)}
 	eqErr = checkEqual(got, expected)
 	checkError(
 		t,
@@ -476,10 +475,10 @@ func TestCommandGeneration(t *testing.T) {
 	testName = "GetWriteCmd (Delete)"
 	tp = Delete
 	got = GetWriteCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		true,
 		srcRegName,
-		destRegName,
+		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -491,7 +490,7 @@ func TestCommandGeneration(t *testing.T) {
 		"container",
 		"images",
 		"untag",
-		ToPQIN(destRegName, imgName, tag)}
+		ToPQIN(destRC.Name, imgName, tag)}
 	eqErr = checkEqual(got, expected)
 	checkError(
 		t,
@@ -499,10 +498,10 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetWriteCmd(
-		svcAcc,
+		destRC.ServiceAccount,
 		false,
 		srcRegName,
-		destRegName,
+		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -513,7 +512,7 @@ func TestCommandGeneration(t *testing.T) {
 		"container",
 		"images",
 		"untag",
-		ToPQIN(destRegName, imgName, tag)}
+		ToPQIN(destRC.Name, imgName, tag)}
 	eqErr = checkEqual(got, expected)
 	checkError(
 		t,
@@ -613,11 +612,17 @@ func TestSyncContext(t *testing.T) {
 		// Destination registry is a placeholder, because ReadImageNames acts on
 		// 2 registries (src and dest) at once.
 		sc := SyncContext{
+			RegistryContexts: []RegistryContext{
+				{
+					Name:           fakeRegName,
+					ServiceAccount: "robot",
+				},
+			},
 			Inv: map[RegistryName]RegInvImage{fakeRegName: nil}}
 		// test is used to pin the "test" variable from the outer "range"
 		// scope (see scopelint).
 		test := test
-		mkFakeStream1 := func(regName RegistryName) stream.Producer {
+		mkFakeStream1 := func(rc RegistryContext) stream.Producer {
 			var sr stream.Fake
 			sr.Bytes = []byte(test.input)
 			return &sr
@@ -631,11 +636,11 @@ func TestSyncContext(t *testing.T) {
 		// Check 2nd round of API calls to get all digests and tags for each
 		// image.
 		mkFakeStream := func(
-			registryName RegistryName,
+			rc RegistryContext,
 			imgName ImageName) stream.Producer {
 
 			var sr stream.Fake
-			regImage := string(registryName) + "/" + string(imgName)
+			regImage := string(rc.Name) + "/" + string(imgName)
 			// Fetch the "stream" from a predefined set of responses.
 			stream, ok := test.input2[regImage]
 			if ok {
@@ -953,9 +958,17 @@ func TestPromotion(t *testing.T) {
 	//
 	// We could make it even more "powerful" by storing a histogram instead of a
 	// set. Then we can check that all requests were generated exactly 1 time.
-	registries := RegistryNames{
-		Src:  "gcr.io/foo",
-		Dest: "gcr.io/bar"}
+	srcRegName := RegistryName("gcr.io/foo")
+	destRegName := RegistryName("gcr.io/bar")
+	destRC := RegistryContext{
+		Name:           destRegName,
+		ServiceAccount: "robot",
+	}
+	srcRC := RegistryContext{
+		Name:           srcRegName,
+		ServiceAccount: "robot",
+	}
+	registries := []RegistryContext{destRC, srcRC}
 	var tests = []struct {
 		name         string
 		inputM       Manifest
@@ -972,6 +985,7 @@ func TestPromotion(t *testing.T) {
 		{
 			"No promotion; tag is already promoted",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -993,6 +1007,7 @@ func TestPromotion(t *testing.T) {
 		{
 			"Promote 1 tag; image digest does not exist in dest",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1008,15 +1023,18 @@ func TestPromotion(t *testing.T) {
 						"b": DigestTags{
 							"sha256:111": TagSlice{}}}}},
 			CapturedRequests{PromotionRequest{
-				TagOp:      Add,
-				Registries: registries,
-				ImageName:  "a",
-				Digest:     "sha256:000",
-				Tag:        "0.9"}: 1},
+				TagOp:          Add,
+				RegistrySrc:    srcRegName,
+				RegistryDest:   registries[0].Name,
+				ServiceAccount: registries[0].ServiceAccount,
+				ImageName:      "a",
+				Digest:         "sha256:000",
+				Tag:            "0.9"}: 1},
 		},
 		{
 			"Promote 1 tag; image digest already exists in dest",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1032,16 +1050,19 @@ func TestPromotion(t *testing.T) {
 						"a": DigestTags{
 							"sha256:111": TagSlice{}}}}},
 			CapturedRequests{PromotionRequest{
-				TagOp:      Add,
-				Registries: registries,
-				ImageName:  "a",
-				Digest:     "sha256:000",
-				Tag:        "0.9"}: 1},
+				TagOp:          Add,
+				RegistrySrc:    srcRegName,
+				RegistryDest:   registries[0].Name,
+				ServiceAccount: registries[0].ServiceAccount,
+				ImageName:      "a",
+				Digest:         "sha256:000",
+				Tag:            "0.9"}: 1},
 		},
 		{
 			// nolint[lll]
 			"Promote 1 tag; tag already exists in dest but is pointing to a different digest (move tag)",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1057,17 +1078,20 @@ func TestPromotion(t *testing.T) {
 						"a": DigestTags{
 							"sha256:111": TagSlice{"0.9"}}}}},
 			CapturedRequests{PromotionRequest{
-				TagOp:      Move,
-				Registries: registries,
-				ImageName:  "a",
-				Digest:     "sha256:000",
-				DigestOld:  "sha256:111",
-				Tag:        "0.9"}: 1},
+				TagOp:          Move,
+				RegistrySrc:    srcRegName,
+				RegistryDest:   registries[0].Name,
+				ServiceAccount: registries[0].ServiceAccount,
+				ImageName:      "a",
+				Digest:         "sha256:000",
+				DigestOld:      "sha256:111",
+				Tag:            "0.9"}: 1},
 		},
 		{
 			// nolint[lll]
 			"NOP; dest has extra tag, but NOP because -delete-extra-tags NOT specified",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1089,6 +1113,7 @@ func TestPromotion(t *testing.T) {
 			// nolint[lll]
 			"Delete 1 tag; dest has extra tag (if -delete-extra-tags specified)",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1105,16 +1130,19 @@ func TestPromotion(t *testing.T) {
 						"a": DigestTags{
 							"sha256:000": TagSlice{"0.9", "extra-tag"}}}}},
 			CapturedRequests{PromotionRequest{
-				TagOp:      Delete,
-				Registries: registries,
-				ImageName:  "a",
-				Digest:     "sha256:000",
-				Tag:        "extra-tag"}: 1},
+				TagOp:          Delete,
+				RegistrySrc:    srcRegName,
+				RegistryDest:   registries[0].Name,
+				ServiceAccount: registries[0].ServiceAccount,
+				ImageName:      "a",
+				Digest:         "sha256:000",
+				Tag:            "extra-tag"}: 1},
 		},
 		{
 			// nolint[lll]
 			"NOP (src registry does not have any of the images we want to promote)",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1147,7 +1175,149 @@ func TestPromotion(t *testing.T) {
 	processRequestFake := MkRequestCapturer(&captured)
 
 	nopStream := func(
-		srcRegistry, destRegistry RegistryName,
+		srcRegistry RegistryName,
+		rc RegistryContext,
+		imageName ImageName,
+		digest Digest,
+		tag Tag,
+		tp TagOp) stream.Producer {
+
+		// We don't even need a stream producer, because we are not creating
+		// subprocesses that generate JSON or any other output; the vanilla
+		// "mkReq" in Promote() already stores all the info we need to check.
+		return nil
+	}
+
+	for _, test := range tests {
+		// Reset captured for each test.
+		captured = make(CapturedRequests)
+		test.inputSc.Promote(
+			test.inputM,
+			nopStream,
+			&processRequestFake)
+		err := checkEqual(captured, test.expectedReqs)
+		checkError(t, err, fmt.Sprintf("checkError: test: %v\n", test.name))
+	}
+}
+
+func TestPromotionMulti(t *testing.T) {
+	srcRegName := RegistryName("gcr.io/foo")
+	destRegName1 := RegistryName("gcr.io/bar")
+	destRegName2 := RegistryName("gcr.io/qux")
+	destRC := RegistryContext{
+		Name:           destRegName1,
+		ServiceAccount: "robotDest1",
+	}
+	destRC2 := RegistryContext{
+		Name:           destRegName2,
+		ServiceAccount: "robotDest2",
+	}
+	srcRC := RegistryContext{
+		Name:           srcRegName,
+		ServiceAccount: "robotSrc",
+	}
+	registries := []RegistryContext{srcRC, destRC, destRC2}
+	var tests = []struct {
+		name         string
+		inputM       Manifest
+		inputSc      SyncContext
+		expectedReqs CapturedRequests
+	}{
+		{
+			// nolint[lll]
+			"Add 1 tag for 2 registries",
+			Manifest{
+				Src:        srcRegName,
+				Registries: registries,
+				Images: []Image{
+					{
+						ImageName: "a",
+						Dmap: DigestTags{
+							"sha256:000": TagSlice{"0.9", "1.0"}}}}},
+			SyncContext{
+				DeleteExtraTags: true,
+				Inv: MasterInventory{
+					"gcr.io/foo": RegInvImage{
+						"a": DigestTags{
+							"sha256:000": TagSlice{"0.9"}}},
+					"gcr.io/bar": RegInvImage{
+						"a": DigestTags{
+							"sha256:000": TagSlice{"0.9"}}},
+					"gcr.io/qux": RegInvImage{
+						"a": DigestTags{
+							"sha256:000": TagSlice{"0.9"}}}}},
+			CapturedRequests{
+				PromotionRequest{
+					TagOp:          Add,
+					RegistrySrc:    srcRegName,
+					RegistryDest:   registries[1].Name,
+					ServiceAccount: registries[1].ServiceAccount,
+					ImageName:      "a",
+					Digest:         "sha256:000",
+					Tag:            "1.0"}: 1,
+				PromotionRequest{
+					TagOp:          Add,
+					RegistrySrc:    srcRegName,
+					RegistryDest:   registries[2].Name,
+					ServiceAccount: registries[2].ServiceAccount,
+					ImageName:      "a",
+					Digest:         "sha256:000",
+					Tag:            "1.0"}: 1,
+			},
+		},
+		{
+			// nolint[lll]
+			"Add 1 tag for 1 registry, but remove a tag for another",
+			Manifest{
+				Src:        srcRegName,
+				Registries: registries,
+				Images: []Image{
+					{
+						ImageName: "a",
+						Dmap: DigestTags{
+							"sha256:000": TagSlice{"0.9", "1.0"}}}}},
+			SyncContext{
+				DeleteExtraTags: true,
+				Inv: MasterInventory{
+					"gcr.io/foo": RegInvImage{
+						"a": DigestTags{
+							"sha256:000": TagSlice{"0.9"}}},
+					"gcr.io/bar": RegInvImage{
+						"a": DigestTags{
+							"sha256:000": TagSlice{"0.9"}}},
+					"gcr.io/qux": RegInvImage{
+						"a": DigestTags{
+							"sha256:000": TagSlice{
+								"0.9", "1.0", "extra-tag"}}}}},
+			CapturedRequests{
+				PromotionRequest{
+					TagOp:          Add,
+					RegistrySrc:    srcRegName,
+					RegistryDest:   registries[1].Name,
+					ServiceAccount: registries[1].ServiceAccount,
+					ImageName:      "a",
+					Digest:         "sha256:000",
+					Tag:            "1.0"}: 1,
+				PromotionRequest{
+					TagOp:          Delete,
+					RegistrySrc:    srcRegName,
+					RegistryDest:   registries[2].Name,
+					ServiceAccount: registries[2].ServiceAccount,
+					ImageName:      "a",
+					Digest:         "sha256:000",
+					Tag:            "extra-tag"}: 1,
+			},
+		},
+	}
+
+	// captured is sort of a "global variable" because processRequestFake
+	// closes over it.
+	captured := make(CapturedRequests)
+	processRequestFake := MkRequestCapturer(&captured)
+
+	nopStream := func(
+		srcRegistry RegistryName,
+		rc RegistryContext,
 		imageName ImageName,
 		digest Digest,
 		tag Tag,
@@ -1172,9 +1342,14 @@ func TestPromotion(t *testing.T) {
 }
 
 func TestGarbageCollection(t *testing.T) {
-	registries := RegistryNames{
-		Src:  "gcr.io/foo",
-		Dest: "gcr.io/bar"}
+	srcRegName := RegistryName("gcr.io/foo")
+	destRegName := RegistryName("gcr.io/bar")
+	registries := []RegistryContext{
+		{
+			Name:           destRegName,
+			ServiceAccount: "robot",
+		},
+	}
 	var tests = []struct {
 		name         string
 		inputM       Manifest
@@ -1184,6 +1359,7 @@ func TestGarbageCollection(t *testing.T) {
 		{
 			"No garbage collection (no empty digests)",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1212,6 +1388,7 @@ func TestGarbageCollection(t *testing.T) {
 			// nolint[lll]
 			"Simple garbage collection (delete ALL images in dest that are untagged))",
 			Manifest{
+				Src:        srcRegName,
 				Registries: registries,
 				Images: []Image{
 					{
@@ -1241,17 +1418,21 @@ func TestGarbageCollection(t *testing.T) {
 					}}},
 			CapturedRequests{
 				PromotionRequest{
-					TagOp:      Delete,
-					Registries: registries,
-					ImageName:  "a",
-					Digest:     "sha256:111",
-					Tag:        ""}: 1,
+					TagOp:          Delete,
+					RegistrySrc:    srcRegName,
+					RegistryDest:   registries[0].Name,
+					ServiceAccount: registries[0].ServiceAccount,
+					ImageName:      "a",
+					Digest:         "sha256:111",
+					Tag:            ""}: 1,
 				PromotionRequest{
-					TagOp:      Delete,
-					Registries: registries,
-					ImageName:  "z",
-					Digest:     "sha256:000",
-					Tag:        ""}: 1,
+					TagOp:          Delete,
+					RegistrySrc:    srcRegName,
+					RegistryDest:   registries[0].Name,
+					ServiceAccount: registries[0].ServiceAccount,
+					ImageName:      "z",
+					Digest:         "sha256:000",
+					Tag:            ""}: 1,
 			},
 		},
 	}
@@ -1282,7 +1463,7 @@ func TestGarbageCollection(t *testing.T) {
 		// Reset captured for each test.
 		captured = make(CapturedRequests)
 		nopStream := func(
-			destRegistry RegistryName,
+			destRC RegistryContext,
 			imageName ImageName,
 			digest Digest) stream.Producer {
 			return nil

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -146,7 +146,7 @@ func TestParseRegistryManifest(t *testing.T) {
 		{
 			"Basic manifest",
 			// nolint[lll]
-			`src: gcr.io/foo
+			`src-registry: gcr.io/foo
 registries:
 - name: gcr.io/bar
   service-account: foobar@google-containers.iam.gserviceaccount.com
@@ -161,7 +161,7 @@ images:
     "sha256:07353f7b26327f0d933515a22b1de587b040d3d85c464ea299c1b9f242529326": [ "1.8.3" ]  # Branches: ['master']
 `,
 			Manifest{
-				Src: "gcr.io/foo",
+				SrcRegistry: "gcr.io/foo",
 				Registries: []RegistryContext{
 					{
 						Name: "gcr.io/bar",
@@ -195,7 +195,7 @@ images:
 		{
 			"Missing src registry in registries (invalid)",
 			// nolint[lll]
-			`src: gcr.io/alpha
+			`src-registry: gcr.io/alpha
 registries:
 - name: gcr.io/bar
   service-account: foobar@google-containers.iam.gserviceaccount.com
@@ -1012,8 +1012,8 @@ func TestPromotion(t *testing.T) {
 		{
 			"No promotion; tag is already promoted",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1034,8 +1034,8 @@ func TestPromotion(t *testing.T) {
 		{
 			"Promote 1 tag; image digest does not exist in dest",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1061,8 +1061,8 @@ func TestPromotion(t *testing.T) {
 		{
 			"Promote 1 tag; image digest already exists in dest",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1089,8 +1089,8 @@ func TestPromotion(t *testing.T) {
 			// nolint[lll]
 			"Promote 1 tag; tag already exists in dest but is pointing to a different digest (move tag)",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1118,8 +1118,8 @@ func TestPromotion(t *testing.T) {
 			// nolint[lll]
 			"NOP; dest has extra tag, but NOP because -delete-extra-tags NOT specified",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1140,8 +1140,8 @@ func TestPromotion(t *testing.T) {
 			// nolint[lll]
 			"Delete 1 tag; dest has extra tag (if -delete-extra-tags specified)",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1169,8 +1169,8 @@ func TestPromotion(t *testing.T) {
 			// nolint[lll]
 			"NOP (src registry does not have any of the images we want to promote)",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1254,8 +1254,8 @@ func TestPromotionMulti(t *testing.T) {
 			// nolint[lll]
 			"Add 1 tag for 2 registries",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1296,8 +1296,8 @@ func TestPromotionMulti(t *testing.T) {
 			// nolint[lll]
 			"Add 1 tag for 1 registry, but remove a tag for another",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1386,8 +1386,8 @@ func TestGarbageCollection(t *testing.T) {
 		{
 			"No garbage collection (no empty digests)",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1415,8 +1415,8 @@ func TestGarbageCollection(t *testing.T) {
 			// nolint[lll]
 			"Simple garbage collection (delete ALL images in dest that are untagged))",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",
@@ -1529,8 +1529,8 @@ func TestGarbageCollectionMulti(t *testing.T) {
 			// nolint[lll]
 			"Simple garbage collection (delete ALL images in all dests that are untagged))",
 			Manifest{
-				Src:        srcRegName,
-				Registries: registries,
+				SrcRegistry: srcRegName,
+				Registries:  registries,
 				Images: []Image{
 					{
 						ImageName: "a",

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -380,9 +380,8 @@ func TestCommandGeneration(t *testing.T) {
 
 	testName = "GetRegistryListTagsCmd"
 	got = GetRegistryListTagsCmd(
-		destRC.ServiceAccount,
+		destRC,
 		true,
-		string(destRC.Name),
 		string(imgName))
 	expected = []string{
 		"gcloud",
@@ -399,9 +398,8 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetRegistryListTagsCmd(
-		destRC.ServiceAccount,
+		destRC,
 		false,
-		string(destRC.Name),
 		string(imgName))
 	expected = []string{
 		"gcloud",
@@ -418,9 +416,8 @@ func TestCommandGeneration(t *testing.T) {
 
 	testName = "GetDeleteCmd"
 	got = GetDeleteCmd(
-		destRC.ServiceAccount,
+		destRC,
 		true,
-		destRC.Name,
 		imgName,
 		digest)
 	expected = []string{
@@ -438,9 +435,8 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetDeleteCmd(
-		destRC.ServiceAccount,
+		destRC,
 		false,
-		destRC.Name,
 		imgName,
 		digest)
 	expected = []string{
@@ -459,10 +455,9 @@ func TestCommandGeneration(t *testing.T) {
 	testName = "GetWriteCmd (Add)"
 	tp = Add
 	got = GetWriteCmd(
-		destRC.ServiceAccount,
+		destRC,
 		true,
 		srcRegName,
-		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -484,10 +479,9 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetWriteCmd(
-		destRC.ServiceAccount,
+		destRC,
 		false,
 		srcRegName,
-		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -510,10 +504,9 @@ func TestCommandGeneration(t *testing.T) {
 	testName = "GetWriteCmd (Delete)"
 	tp = Delete
 	got = GetWriteCmd(
-		destRC.ServiceAccount,
+		destRC,
 		true,
 		srcRegName,
-		destRC.Name,
 		imgName,
 		digest,
 		tag,
@@ -533,10 +526,9 @@ func TestCommandGeneration(t *testing.T) {
 		fmt.Sprintf("Test: %v (cmd string)\n", testName))
 
 	got = GetWriteCmd(
-		destRC.ServiceAccount,
+		destRC,
 		false,
 		srcRegName,
-		destRC.Name,
 		imgName,
 		digest,
 		tag,

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -50,6 +50,7 @@ type SyncContext struct {
 	DryRun            bool
 	UseServiceAccount bool
 	Inv               MasterInventory
+	RegistryContexts  []RegistryContext
 }
 
 // MasterInventory stores multiple RegInvImage elements, keyed by RegistryName.
@@ -120,20 +121,31 @@ const (
 // PromotionRequest contains all the information required for any type of
 // promotion (or demotion!) (involving any TagOp).
 type PromotionRequest struct {
-	TagOp      TagOp
-	Registries RegistryNames
-	ImageName  ImageName
-	Digest     Digest
-	DigestOld  Digest // Only for tag moves.
-	Tag        Tag
+	TagOp          TagOp
+	RegistrySrc    RegistryName
+	RegistryDest   RegistryName
+	ServiceAccount string
+	ImageName      ImageName
+	Digest         Digest
+	DigestOld      Digest // Only for tag moves.
+	Tag            Tag
 }
 
 // Manifest stores the information in a manifest file (describing the
 // desired state of a Docker Registry).
 type Manifest struct {
-	Registries     RegistryNames
-	ServiceAccount string  `yaml:"service-account,omitempty"`
-	Images         []Image `yaml:"images,omitempty"`
+	// Registries contains the source and destination (Src/Dest) registry names.
+	// It is possible that in the future, we support promoting to multiple
+	// registries, in which case we would have more than just Src/Dest.
+	Registries []RegistryContext
+	// Src contains the RegistryName which will be set as the source registry.
+	// All other registries in Registries will be treated as destination
+	// registries.
+	//
+	// TODO: check that RegistryName is present in a RegistryContext in
+	// Registries.
+	Src    RegistryName
+	Images []Image `yaml:"images,omitempty"`
 }
 
 // Image holds information about an image. It's like an "Object" in the OOP
@@ -150,12 +162,11 @@ type Image struct {
 // namespaced by the image name).
 type DigestTags map[Digest]TagSlice
 
-// RegistryNames contains the source and destination (Src/Dest) registry names.
-// It is possible that in the future, we support promoting to multiple
-// registries, in which case we would have more than just Src/Dest.
-type RegistryNames struct {
-	Src  RegistryName
-	Dest RegistryName
+// RegistryContext holds information about a registry, to be written in a
+// manifest file.
+type RegistryContext struct {
+	Name           RegistryName
+	ServiceAccount string `yaml:"service-account,omitempty"`
 }
 
 // RegistryName is the leading part of an image name that includes the domain;

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -144,8 +144,8 @@ type Manifest struct {
 	//
 	// TODO: check that RegistryName is present in a RegistryContext in
 	// Registries.
-	Src    RegistryName
-	Images []Image `yaml:"images,omitempty"`
+	SrcRegistry RegistryName `yaml:"src-registry"`
+	Images      []Image      `yaml:"images,omitempty"`
 }
 
 // Image holds information about an image. It's like an "Object" in the OOP


### PR DESCRIPTION
Title says it all. This basically allows 'mirroring' because each destination registry will be compared the same way against the `src-registry` field. Requires a small tweak to the manifest file, but otherwise works as expected (see added tests).