### PR TITLE
Rename bytes variables to b

### DIFF
--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -128,11 +128,11 @@ func ParseManifestFromFile(
 	var mfest Manifest
 	var rd RenamesDenormalized
 	var srcRegistry *RegistryContext
-	bytes, err := ioutil.ReadFile(filePath)
+	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return mfest, rd, srcRegistry, err
 	}
-	mfest, err = ParseManifest(bytes)
+	mfest, err = ParseManifest(b)
 	if err != nil {
 		return mfest, rd, srcRegistry, err
 	}
@@ -153,9 +153,9 @@ func ParseManifestFromFile(
 
 // ParseManifest parses a Manifest from a byteslice. This function is separate
 // from ParseManifestFromFile() so that it can be tested independently.
-func ParseManifest(bytes []byte) (Manifest, error) {
+func ParseManifest(b []byte) (Manifest, error) {
 	var m Manifest
-	if err := yaml.UnmarshalStrict(bytes, &m); err != nil {
+	if err := yaml.UnmarshalStrict(b, &m); err != nil {
 		return m, err
 	}
 

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -245,8 +245,8 @@ images:
 	// nolint[lll]
 	// Test only the JSON unmarshalling logic.
 	for _, test := range tests {
-		bytes := []byte(test.input)
-		imageManifest, err := ParseManifest(bytes)
+		b := []byte(test.input)
+		imageManifest, err := ParseManifest(b)
 
 		// Check the error as well (at the very least, we can check that the
 		// error was nil).
@@ -277,8 +277,8 @@ images:
 - ["gcr.io/foo/banana", "gcr.io/bar/carrot"]`,
 			}
 			for _, validInput := range shouldBeValid {
-				bytes := []byte(test.input + validInput)
-				_, err := ParseManifest(bytes)
+				b := []byte(test.input + validInput)
+				_, err := ParseManifest(b)
 				checkError(
 					t,
 					err,
@@ -328,8 +328,8 @@ could not find source registry in '[gcr.io/bar/banana gcr.io/cat/subdir/A/banana
 				},
 			}
 			for _, invalid := range shouldBeInvalid {
-				bytes := []byte(test.input + invalid.input)
-				_, got := ParseManifest(bytes)
+				b := []byte(test.input + invalid.input)
+				_, got := ParseManifest(b)
 				eqErr := checkEqual(got, invalid.err)
 				checkError(
 					t,


### PR DESCRIPTION
This avoids shadowing the bytes package.