### PR TITLE
Simplify code around reading from registries

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -188,7 +188,9 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	sc.ReadRepository(reg.MkReadRepositoryCmdReal)
+	if err := sc.ReadRepository(reg.FetchTags); err != nil {
+		klog.Fatalf("error reading repository: %v", err)
+	}
 
 	if len(*snapshotPtr) > 0 {
 		rii := sc.Inv[mfest.Registries[0].Name]
@@ -242,7 +244,10 @@ func main() {
 		sc.Infof("---------- BEGIN GARBAGE COLLECTION: %s ----------\n",
 			*manifestPtr)
 		// Re-read the state of the world.
-		sc.ReadRepository(reg.MkReadRepositoryCmdReal)
+		if err := sc.ReadRepository(reg.FetchTags); err != nil {
+			klog.Fatalf("error reading repository: %v", err)
+		}
+
 		// Garbage-collect all untagged images in dest registry.
 		mkTagDeletionCmd := func(
 			dest reg.RegistryContext,

--- a/test/e2e.go
+++ b/test/e2e.go
@@ -165,7 +165,9 @@ func testSetup(cwd string, mfest reg.Manifest) error {
 		klog.Fatal(err)
 	}
 
-	sc.ReadRepository(reg.MkReadRepositoryCmdReal)
+	if err := sc.ReadRepository(reg.FetchTags); err != nil {
+		klog.Fatalf("error reading repository: %v", err)
+	}
 
 	// Clear ALL registries in the test manifest. Blank slate!
 	for _, rc := range mfest.Registries {


### PR DESCRIPTION
Much slower as no longer parallel execution, but more direct/simpler.