### PR TITLE
do not promote images that could not be read properly

### DIFF
--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -53,6 +53,7 @@ type SyncContext struct {
 	DryRun              bool
 	UseServiceAccount   bool
 	Inv                 MasterInventory
+	InvIgnore           []ImageName
 	RegistryContexts    []RegistryContext
 	SrcRegistry         *RegistryContext
 	Tokens              map[RootRepo]Token


### PR DESCRIPTION
If an image from *any* repository cannot be read, ignore it by removing
it from the Manifest as well as our snapshot of the src registry.

We could later on add more robustness by only ignoring images on a
registry-by-registry basis (e.g., promote "foo" to destA if destA had no
read issues, but do not try to promote "foo" to destB if destB had read
issues).

This is a follow-up to #75 

/hold
/cc @justinsb 