### PR TITLE
Makefile: bazel: explicitly enable stamping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 REPO_ROOT:=$(shell git rev-parse --show-toplevel)
-BAZEL_BUILD_OPTS:=--workspace_status_command=$(REPO_ROOT)/workspace_status.sh --host_force_python=PY2
+BAZEL_BUILD_OPTS:=--workspace_status_command=$(REPO_ROOT)/workspace_status.sh \
+	--host_force_python=PY2 \
+	--stamp
 
 all: test build
 build:


### PR DESCRIPTION
At some point in time, it appears that the go_library rules stopped
stamping by default. This forces stamping to happen.

Stamping is important because this is how we encode version information
into the cip binary.

/assign @justinsb