### PR TITLE
cip: add service account activation logic

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
     deps = [
         "//lib/dockerregistry:go_default_library",
         "//lib/stream:go_default_library",
+        "//pkg/gcloud:go_default_library",
         "@io_k8s_klog//:go_default_library",
     ],
 )

--- a/cip.go
+++ b/cip.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
 )
 
 // GitDescribe is stamped by bazel.
@@ -67,6 +68,10 @@ func main() {
 		true,
 		"print what would have happened by running this tool;"+
 			" do not actually modify any registry")
+	keyFilesPtr := flag.String(
+		"key-files",
+		"",
+		"CSV of service account key files that must be activated for the promotion (<json-key-file-path>,...)")
 	// Add in help flag information, because Go's "flag" package automatically
 	// adds it, but for whatever reason does not show it as part of available
 	// options.
@@ -107,6 +112,13 @@ func main() {
 	if *versionPtr {
 		printVersion()
 		os.Exit(0)
+	}
+
+	// Activate service accounts.
+	if len(*keyFilesPtr) > 0 {
+		if err := gcloud.ActivateServiceAccounts(*keyFilesPtr); err != nil {
+			klog.Exitln(err)
+		}
 	}
 
 	var mfest reg.Manifest

--- a/pkg/gcloud/BUILD.bazel
+++ b/pkg/gcloud/BUILD.bazel
@@ -5,4 +5,7 @@ go_library(
     srcs = ["token.go"],
     importpath = "sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud",
     visibility = ["//visibility:public"],
+    deps = [
+        "@io_k8s_klog//:go_default_library",
+    ],
 )

--- a/test-e2e/BUILD.bazel
+++ b/test-e2e/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//lib/dockerregistry:go_default_library",
         "//lib/stream:go_default_library",
+        "//pkg/gcloud:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
         "@io_k8s_klog//:go_default_library",
     ],

--- a/test-e2e/e2e.go
+++ b/test-e2e/e2e.go
@@ -237,6 +237,9 @@ func runPromotion(repoRoot string, t E2ETest) error {
 		"--",
 		"-dry-run=false",
 		"-verbosity=3",
+		// There is no need to use -key-files=... because we already activated
+		// the 1 service account we need during e2e tests with our own -key-file
+		// flag.
 	}
 
 	argsFinal := []string{}

--- a/test-e2e/e2e.go
+++ b/test-e2e/e2e.go
@@ -15,6 +15,7 @@ import (
 
 	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
 )
 
 // GitDescribe is stamped by bazel.
@@ -65,8 +66,7 @@ func main() {
 	}
 
 	if len(*keyFilePtr) > 0 {
-		err = activateServiceAccount(*keyFilePtr)
-		if err != nil {
+		if err := gcloud.ActivateServiceAccount(*keyFilePtr); err != nil {
 			klog.Fatal("could not activate service account from .json", err)
 		}
 	}
@@ -113,23 +113,6 @@ func checkSnapshot(repo reg.RegistryName,
 	if err := checkEqual(got, expected); err != nil {
 		klog.Exitln(err)
 	}
-}
-
-func activateServiceAccount(keyFilePath string) error {
-	cmd := exec.Command("gcloud",
-		"auth",
-		"activate-service-account",
-		"--key-file="+keyFilePath)
-
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func testSetup(repoRoot string, t E2ETest) error {

--- a/tools/bazel_get_workspace_status
+++ b/tools/bazel_get_workspace_status
@@ -1,1 +1,0 @@
-../workspace_status.sh


### PR DESCRIPTION
This is in preparation for the deprecation of util/multirun.sh (which currently performs the account activation for us).

/assign @justinsb