### PR TITLE
bazel: remove dead code

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,15 +24,8 @@ container_image(
         "/bin/bash",
         "-c",
     ],
-    layers = [":cip-util"],
-    env = {"PATH": "/cip:/cip/util:${PATH}"},
+    env = {"PATH": "/cip:${PATH}"},
     symlinks = {"/cip/cip": "/app/cip-docker-image.binary"},
-)
-
-container_layer(
-    name = "cip-util",
-    directory = "/cip/util",
-    files = ["util/multirun.sh"],
 )
 
 # Invoke with "bazel build //:cip-docker-loadable.tar". Then you can run "docker


### PR DESCRIPTION
The multirun.sh script is no longer used.

/assign @justinsb @ps882 