### PR TITLE
use new staging repo name

### DIFF
--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1022,6 +1022,8 @@ func (sc *SyncContext) ReadRegistries(
 	sc.ExecRequests(populateRequests, processRequest)
 }
 
+// SplitByKnownRegistries splits a registry name into a RegistryName and
+// ImageName.
 func SplitByKnownRegistries(
 	r RegistryName,
 	rcs []RegistryContext) (RegistryName, ImageName, error) {

--- a/pkg/cmd/promotefiles.go
+++ b/pkg/cmd/promotefiles.go
@@ -52,6 +52,7 @@ func (o *PromoteFilesOptions) PopulateDefaults() {
 }
 
 // RunPromoteFiles executes a file promotion command
+// nolint[gocyclo]
 func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	manifest, err := readManifest(options.ManifestPath)
 	if err != nil {

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -53,6 +53,7 @@ type copyFileOp struct {
 }
 
 // Run implements SyncFileOp.Run
+// nolint[gocyclo]
 func (o *copyFileOp) Run(ctx context.Context) error {
 	// Download to our temp file
 	f, err := ioutil.TempFile("", "promoter")

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -102,6 +102,7 @@ func openFilestore(
 func (p *FilestorePromoter) computeNeededOperations(
 	source, dest map[string]*syncFileInfo,
 	destFilestore syncFilestore) ([]SyncFileOp, error) {
+	// nolint[prealloc]
 	var ops []SyncFileOp
 
 	for i := range p.Files {

--- a/pkg/filepromoter/manifest.go
+++ b/pkg/filepromoter/manifest.go
@@ -42,6 +42,7 @@ func (p *ManifestPromoter) BuildOperations(
 		return nil, err
 	}
 
+	// nolint[prealloc]
 	var operations []SyncFileOp
 
 	for i := range p.Manifest.Filestores {

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -28,7 +28,7 @@ image_tag="$git_desc"
 
 p_ STABLE_TEST_STAGING_IMG_REPOSITORY gcr.io/k8s-staging-cip-test
 p_ STABLE_IMG_REGISTRY gcr.io
-p_ STABLE_IMG_REPOSITORY cip-demo-staging
+p_ STABLE_IMG_REPOSITORY k8s-staging-artifact-promoter
 p_ STABLE_IMG_NAME cip
 p_ STABLE_GIT_COMMIT "${git_commit}"
 p_ STABLE_GIT_DESC "${git_desc}"


### PR DESCRIPTION
The new staging repo (gcr.io/k8s-staging-artifact-promoter) was created
with [1] and [2].

[1]: https://github.com/kubernetes/k8s.io/pull/335
[2]: https://github.com/kubernetes/k8s.io/pull/338