### PR TITLE
lint: download go dependencies

### DIFF
--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -599,6 +599,8 @@ func validateRequiredComponents(m Manifest) error {
 }
 
 // PrettyValue creates a prettified string representation of MasterInventory.
+//
+// nolint[gocyclo]
 func (mi *MasterInventory) PrettyValue() string {
 	var b strings.Builder
 	regNames := []RegistryName{}

--- a/lint.sh
+++ b/lint.sh
@@ -17,6 +17,17 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
+
+# If running in prow, set up the dependencies and default checkout folder.
+if [[ -n "${PROW_JOB_ID:-}" ]]; then
+    mkdir /home/prow/go/src/sigs.k8s.io
+    ln -s "${PWD}" /home/prow/go/src/sigs.k8s.io/k8s-container-image-promoter
+    cd /home/prow/go/src/sigs.k8s.io/k8s-container-image-promoter
+    export GO111MODULE=on
+    go version
+    go mod download
+fi
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
 


### PR DESCRIPTION
In a CI setting, none of the go dependencies will be there on disk, so
we have to populate it first.