### PR TITLE
e2e: pass --stamp flag to bazel

### DIFF
--- a/test-e2e/e2e.go
+++ b/test-e2e/e2e.go
@@ -233,6 +233,7 @@ func runPromotion(repoRoot string, t E2ETest) error {
 	args := []string{
 		"run",
 		"--workspace_status_command=" + repoRoot + "/workspace_status.sh",
+		"--stamp",
 		":cip",
 		"--",
 		"-dry-run=false",


### PR DESCRIPTION
This is because we want to make e2e tests show the version information
for the promoter when it runs the cip binary.

/assign @justinsb