### PR TITLE
workspace_status: use Mac-friendly arguments to 'date'

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -21,7 +21,7 @@ p_() {
 
 git_commit="$(git rev-parse HEAD)"
 git_desc="$(git describe --always --dirty --long)"
-timestamp_utc_rfc3339=$(date --utc --rfc-3339=seconds)
+timestamp_utc_rfc3339=$(date -u +"%Y-%m-%d %H:%M:%S%z")
 timestamp_utc_date_dashes="${timestamp_utc_rfc3339% *}"
 timestamp_utc_date_no_dashes="${timestamp_utc_date_dashes//-/}"
 image_tag="$git_desc"


### PR DESCRIPTION
The old invocation only worked with the GNU coreutils version of 'date'.
This one works with both and gives the same results.

This should fix #121 