### PR TITLE
Manifest validation

### DIFF
--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -218,17 +218,6 @@ func ValidateManifestsFromDir(mfests []Manifest) error {
 		return fmt.Errorf("no manifests to validate")
 	}
 
-	// Check that there are no overlapping manifests. Each manifest must be
-	// responsible for 1 unique source registry.
-	srcRegsSeen := make(map[RegistryName]string)
-	for _, mfest := range mfests {
-		if mfestFilepath, seen := srcRegsSeen[mfest.srcRegistry.Name]; seen {
-			// nolint[lll]
-			return fmt.Errorf("source registry '%s' defined in multiple manifests:\n- '%s'\n- '%s'\n", mfest.srcRegistry.Name, mfestFilepath, mfest.filepath)
-		}
-		srcRegsSeen[mfest.srcRegistry.Name] = mfest.filepath
-	}
-
 	// If two manifests are renaming images, then they should not share any
 	// rename information (should be mutually exclusive). We use a separate loop
 	// for clarity.

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -239,7 +239,8 @@ func ValidateManifestsFromDir(mfests []Manifest) error {
 
 // ToPromotionEdges converts a list of manifests to a set of edges we want to
 // try promoting.
-func ToPromotionEdges(mfests []Manifest) map[PromotionEdge]interface{} {
+func ToPromotionEdges(
+	mfests []Manifest) (map[PromotionEdge]interface{}, error) {
 	edges := make(map[PromotionEdge]interface{})
 	// nolint[lll]
 	for _, mfest := range mfests {
@@ -278,7 +279,8 @@ func ToPromotionEdges(mfests []Manifest) map[PromotionEdge]interface{} {
 			}
 		}
 	}
-	return edges
+
+	return checkOverlappingEdges(edges)
 }
 
 func mkPromotionEdge(
@@ -391,6 +393,90 @@ func (sc *SyncContext) getPromotionCandidates(
 	}
 
 	return toPromote
+}
+
+// checkOverlappingEdges checks to ensure that all the edges taken together as a
+// whole are consistent. It checks that there are no duplicate promotions
+// desired to the same destination vertex (same destination PQIN). If the
+// digests are the same for those edges, ignore because by definition the
+// digests are cryptographically guaranteed to be the same thing (it doesn't
+// matter if 2 different parties want the same exact image to become promoted to
+// the same destination --- in many ways this is actually a good thing because
+// it's a form of redundancy). However, return an error if the digests are
+// different, because most likely this is at best just human error and at worst
+// a malicious attack (someone trying to push an image to an endpoint they
+// shouldn't own, or possibly an attempt to rename a tag for an existin image to
+// be something else).
+//
+// nolint[gocyclo]
+func checkOverlappingEdges(
+	edges map[PromotionEdge]interface{}) (map[PromotionEdge]interface{}, error) {
+
+	// Build up a "promotionIntent". This will be checked below.
+	promotionIntent := make(map[string]map[Digest][]PromotionEdge)
+	for edge := range edges {
+		dstPQIN := ToPQIN(edge.DstRegistry.Name,
+			edge.DstImageTag.ImageName,
+			edge.DstImageTag.Tag)
+
+		digestToEdges, ok := promotionIntent[dstPQIN]
+		if ok {
+			// Store the edge.
+			digestToEdges[edge.Digest] = append(digestToEdges[edge.Digest], edge)
+			promotionIntent[dstPQIN] = digestToEdges
+		} else {
+			// Make this edge lay claim to this destination vertex.
+			edgeList := make([]PromotionEdge, 0)
+			edgeList = append(edgeList, edge)
+			digestToEdges := make(map[Digest][]PromotionEdge)
+			digestToEdges[edge.Digest] = edgeList
+			promotionIntent[dstPQIN] = digestToEdges
+		}
+	}
+
+	// Review the promotionIntent to ensure that there are no issues.
+	overlapError := false
+	emptyEdgeListError := false
+	checked := make(map[PromotionEdge]interface{})
+	for pqin, digestToEdges := range promotionIntent {
+		if len(digestToEdges) < 2 {
+			for _, edgeList := range digestToEdges {
+				switch len(edgeList) {
+				case 0:
+					klog.Errorf("no edges for %v", pqin)
+					emptyEdgeListError = true
+				case 1:
+					checked[edgeList[0]] = nil
+				default:
+					klog.Infof("redundant promotion: multiple edges want to promote the same digest to the same destination endpoint %v:", pqin)
+					for _, edge := range edgeList {
+						klog.Infof("%v", edge)
+					}
+					klog.Infof("using the first one: %v", edgeList[0])
+					checked[edgeList[0]] = nil
+				}
+			}
+		} else {
+			klog.Errorf("multiple edges want to promote *different* images (digests) to the same destination endpoint %v:", pqin)
+			for digest, edgeList := range digestToEdges {
+				klog.Errorf("  for digest %v:\n", digest)
+				for _, edge := range edgeList {
+					klog.Errorf("%v\n", edge)
+				}
+			}
+			overlapError = true
+		}
+	}
+
+	if overlapError {
+		return nil, fmt.Errorf("overlapping edges detected")
+	}
+
+	if emptyEdgeListError {
+		return nil, fmt.Errorf("empty edgeList(s) detected")
+	}
+
+	return checked, nil
 }
 
 // VertexProps determines the properties of each vertex (src and dst) in the
@@ -1455,13 +1541,11 @@ func mkPopulateRequestsForPromotionEdges(
 	}
 }
 
-// GetPromotionEdgesFromManifests generates all "edges" that we need to promote.
-func (sc *SyncContext) GetPromotionEdgesFromManifests(
-	mfests []Manifest,
+// FilterPromotionEdges generates all "edges" that we want to promote.
+func (sc *SyncContext) FilterPromotionEdges(
+	edges map[PromotionEdge]interface{},
 	readRepos bool,
 ) map[PromotionEdge]interface{} {
-
-	edges := ToPromotionEdges(mfests)
 
 	if readRepos {
 		regs := getRegistriesToRead(edges)

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest-by-rename/a/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest-by-rename/a/manifest.yaml
@@ -12,8 +12,4 @@ images:
 - name: foo-controller
   dmap:
     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
-renames:
-- - "gcr.io/foo-staging/foo-controller"
-  - "us.gcr.io/some-prod/foo/foo-controller"
-  - "eu.gcr.io/some-prod/foo/foo-controller"
-  - "asia.gcr.io/some-prod/foo/foo-controller"
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest-by-rename/b/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest-by-rename/b/manifest.yaml
@@ -1,0 +1,23 @@
+registries:
+- name: gcr.io/bar-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: bar-quux
+  dmap:
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": ["1.0"]
+renames:
+- - "gcr.io/bar-staging/bar-quux"
+  # These renames conflict with the destination name claimed by
+  # "a/manifest.yaml". It's OK if the images that are tagged are the same
+  # digest (redundant), but in this
+  # case the digests are also different.
+  - "us.gcr.io/some-prod/foo-controller"
+  - "eu.gcr.io/some-prod/foo-controller"
+  - "asia.gcr.io/some-prod/foo-controller"

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest/a/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest/a/manifest.yaml
@@ -11,9 +11,5 @@ registries:
 images:
 - name: foo-controller
   dmap:
-    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": ["1.0"]
-renames:
-- - "gcr.io/foo-staging/foo-controller"
-  - "us.gcr.io/some-prod/foo/foo-controller"
-  - "eu.gcr.io/some-prod/foo/foo-controller"
-  - "asia.gcr.io/some-prod/foo/foo-controller"
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest/b/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/invalid/overlapping-destination-vertices-different-digest/b/manifest.yaml
@@ -1,0 +1,16 @@
+registries:
+- name: gcr.io/foo-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: foo-controller
+  dmap:
+    # This sha conflicts with a's manifest that has "aaaa..." point to the "1.0" tag.
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": ["1.0"]
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest-by-rename/a/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest-by-rename/a/manifest.yaml
@@ -1,0 +1,15 @@
+registries:
+- name: gcr.io/foo-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: foo-controller
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest-by-rename/b/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest-by-rename/b/manifest.yaml
@@ -1,0 +1,21 @@
+registries:
+- name: gcr.io/bar-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: bar-quux
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
+renames:
+- - "gcr.io/bar-staging/bar-quux"
+  # These renames conflict with the destination name claimed by
+  # "a/manifest.yaml". It's OK though because the digests are the same (redundant).
+  - "us.gcr.io/some-prod/foo-controller"
+  - "eu.gcr.io/some-prod/foo-controller"
+  - "asia.gcr.io/some-prod/foo-controller"

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest/a/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest/a/manifest.yaml
@@ -1,0 +1,15 @@
+registries:
+- name: gcr.io/foo-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: foo-controller
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest/b/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-destination-vertices-same-digest/b/manifest.yaml
@@ -1,0 +1,15 @@
+registries:
+- name: gcr.io/bar-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: foo-controller
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-src-registries/a/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-src-registries/a/manifest.yaml
@@ -1,0 +1,15 @@
+registries:
+- name: gcr.io/foo-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: foo-controller
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["1.0"]
+renames: []

--- a/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-src-registries/b/manifest.yaml
+++ b/lib/dockerregistry/inventory_test/TestValidateManifestsFromDir/valid/overlapping-src-registries/b/manifest.yaml
@@ -1,0 +1,15 @@
+registries:
+- name: gcr.io/foo-staging
+  service-account: sa@robot.com
+  src: true
+- name: us.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: eu.gcr.io/some-prod
+  service-account: sa@robot.com
+- name: asia.gcr.io/some-prod
+  service-account: sa@robot.com
+images:
+- name: foo-controller
+  dmap:
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": ["1.1"]
+renames: []


### PR DESCRIPTION
This makes the -manifest-dir flag more flexible and robust. There are 2 things in this PR:

(1) allow multiple manifest files to reference the *same* source registry (e.g., legacy manifests to backfill subprojects from gcr.io/google-containers)
(2) make sure that as a whole, the manifests do not step on each other's toes; this means that we have to check whether the image destinations do *not* overlap if the digests are different. IOW, if different images are being promoted (this is essentially always the case for -manifest-dir flag), then make sure that they do not try to promote to the same destination name + tag combination. If the digests are the same, then it's actually OK because it's a form of "redundant" promotion (different source registries with the *same* image trying to promote to the *same* destination).

/assign @justinsb