### PR TITLE
add -flattened-snapshot flag

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -93,6 +93,10 @@ func main() {
 		"minimal-snapshot",
 		false,
 		"(only works with -snapshot) discard tagless images from -snapshot output if they are referenced by a manifest list")
+	flattenedSnapshotPtr := flag.Bool(
+		"flattened-snapshot",
+		false,
+		"(only works with -snapshot) instead of printing YAML, print all images by their full digest reference, sorted lexicographically")
 	snapshotSvcAccPtr := flag.String(
 		"snapshot-service-account",
 		"",
@@ -292,7 +296,12 @@ func main() {
 			}
 		}
 
-		snapshot := rii.ToYAML()
+		var snapshot string
+		if *flattenedSnapshotPtr {
+			snapshot = rii.ToFlattened()
+		} else {
+			snapshot = rii.ToYAML()
+		}
 		fmt.Print(snapshot)
 		os.Exit(0)
 	}

--- a/cip.go
+++ b/cip.go
@@ -298,7 +298,7 @@ func main() {
 
 		var snapshot string
 		if *flattenedSnapshotPtr {
-			snapshot = rii.ToFlattened()
+			snapshot = rii.ToCSV()
 		} else {
 			snapshot = rii.ToYAML()
 		}

--- a/cip.go
+++ b/cip.go
@@ -42,7 +42,7 @@ func main() {
 	klog.InitFlags(nil)
 
 	manifestPtr := flag.String(
-		"manifest", "", "the manifest file to load (REQUIRED)")
+		"manifest", "", "the manifest file to load")
 	manifestDirPtr := flag.String(
 		"manifest-dir",
 		"",
@@ -92,7 +92,7 @@ func main() {
 	minimalSnapshotPtr := flag.Bool(
 		"minimal-snapshot",
 		false,
-		"(only works with -snapshot) discard tagless images from -snapshot output if they are referenced by a manifest list")
+		"(only works with -snapshot/-manifest-based-snapshot-of) discard tagless images from snapshot output if they are referenced by a manifest list")
 	flattenedSnapshotPtr := flag.Bool(
 		"flattened-snapshot",
 		false,

--- a/cip.go
+++ b/cip.go
@@ -93,10 +93,10 @@ func main() {
 		"minimal-snapshot",
 		false,
 		"(only works with -snapshot/-manifest-based-snapshot-of) discard tagless images from snapshot output if they are referenced by a manifest list")
-	flattenedSnapshotPtr := flag.Bool(
-		"flattened-snapshot",
-		false,
-		"(only works with -snapshot) instead of printing YAML, print all images by their full digest reference, sorted lexicographically")
+	outputFormatPtr := flag.String(
+		"output-format",
+		"YAML",
+		"(only works with -snapshot/-manifest-based-snapshot-of) choose output format of the snapshot (default: YAML; allowed values: 'YAML' or 'CSV')")
 	snapshotSvcAccPtr := flag.String(
 		"snapshot-service-account",
 		"",
@@ -297,9 +297,13 @@ func main() {
 		}
 
 		var snapshot string
-		if *flattenedSnapshotPtr {
+		switch *outputFormatPtr {
+		case "CSV":
 			snapshot = rii.ToCSV()
-		} else {
+		case "YAML":
+			snapshot = rii.ToYAML()
+		default:
+			klog.Errorf("invalid value %s for -output-format; defaulting to YAML", *outputFormatPtr)
 			snapshot = rii.ToYAML()
 		}
 		fmt.Print(snapshot)

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1608,8 +1608,8 @@ func ToPQIN(registryName RegistryName, imageName ImageName, tag Tag) string {
 }
 
 // ToSorted converts a RegInvImage type to a sorted structure.
-func (rii *RegInvImage) ToSorted() []ImageSortable {
-	images := make([]ImageSortable, 0)
+func (rii *RegInvImage) ToSorted() []ImageWithDigestSlice {
+	images := make([]ImageWithDigestSlice, 0)
 
 	for name, dmap := range *rii {
 		var digests []digest
@@ -1630,7 +1630,7 @@ func (rii *RegInvImage) ToSorted() []ImageSortable {
 			return digests[i].hash < digests[j].hash
 		})
 
-		images = append(images, ImageSortable{
+		images = append(images, ImageWithDigestSlice{
 			name:    string(name),
 			digests: digests,
 		})

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1668,7 +1668,7 @@ func (rii *RegInvImage) ToYAML() string {
 	return b.String()
 }
 
-// ToFlattened is like ToYAML, but instead of printing things in an indented
+// ToCSV is like ToYAML, but instead of printing things in an indented
 // format, it prints one image on each line as a CSV. If there is a tag pointing
 // to the image, then it is printed next to the image on the same line.
 //
@@ -1678,7 +1678,7 @@ func (rii *RegInvImage) ToYAML() string {
 // a@sha256:0000000000000000000000000000000000000000000000000000000000000000,a:1.0
 // a@sha256:0000000000000000000000000000000000000000000000000000000000000000,a:latest
 // b@sha256:1111111111111111111111111111111111111111111111111111111111111111,-
-func (rii *RegInvImage) ToFlattened() string {
+func (rii *RegInvImage) ToCSV() string {
 	images := rii.ToSorted()
 
 	var b strings.Builder

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1607,21 +1607,9 @@ func ToPQIN(registryName RegistryName, imageName ImageName, tag Tag) string {
 	return string(registryName) + "/" + string(imageName) + ":" + string(tag)
 }
 
-// ToYAML displays a RegInvImage as YAML, but with the map items sorted
-// alphabetically.
-func (rii *RegInvImage) ToYAML() string {
-	// Temporary structs that have slices, not maps.
-	type digest struct {
-		hash string
-		tags []string
-	}
-
-	type image struct {
-		name    string
-		digests []digest
-	}
-
-	images := make([]image, 0)
+// ToSorted converts a RegInvImage type to a sorted structure.
+func (rii *RegInvImage) ToSorted() []ImageSortable {
+	images := make([]ImageSortable, 0)
 
 	for name, dmap := range *rii {
 		var digests []digest
@@ -1642,7 +1630,7 @@ func (rii *RegInvImage) ToYAML() string {
 			return digests[i].hash < digests[j].hash
 		})
 
-		images = append(images, image{
+		images = append(images, ImageSortable{
 			name:    string(name),
 			digests: digests,
 		})
@@ -1651,6 +1639,14 @@ func (rii *RegInvImage) ToYAML() string {
 	sort.Slice(images, func(i, j int) bool {
 		return images[i].name < images[j].name
 	})
+
+	return images
+}
+
+// ToYAML displays a RegInvImage as YAML, but with the map items sorted
+// alphabetically.
+func (rii *RegInvImage) ToYAML() string {
+	images := rii.ToSorted()
 
 	var b strings.Builder
 	for _, image := range images {

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -349,9 +349,9 @@ type PromotionContext func(
 	Tag,
 	TagOp) stream.Producer
 
-// ImageSortable uses a slice of digests instead of a map, allowing its contents
-// to be sorted.
-type ImageSortable struct {
+// ImageWithDigestSlice uses a slice of digests instead of a map, allowing its
+// contents to be sorted.
+type ImageWithDigestSlice struct {
 	name    string
 	digests []digest
 }

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -349,6 +349,18 @@ type PromotionContext func(
 	Tag,
 	TagOp) stream.Producer
 
+// ImageSortable uses a slice of digests instead of a map, allowing its contents
+// to be sorted.
+type ImageSortable struct {
+	name    string
+	digests []digest
+}
+
+type digest struct {
+	hash string
+	tags []string
+}
+
 // Various conversion functions.
 
 // ToRegInvImageDigest converts a Manifest to a RegInvImageDigest.


### PR DESCRIPTION
This makes the `-snapshot` output more `diff`-friendly because we have the complete image information on each line of text.

E.g. this is the output against us.gcr.io/k8s-artifacts-prod:

```
artifact-promoter/cip@sha256:799f81d9a855717eab7198310655d1b55919320b120f0f015c3bb43c4e90316d,artifact-promoter/cip:20190821-v2.2.1-2-gc29e4fc
capi-kubeadm/cluster-api-kubeadm-controller@sha256:c3ee2e114b6bf81d0cf0686bc80ba3281d70782ffd56b2ae8ef281aec319530b,capi-kubeadm/cluster-api-kubeadm-controller:v0.1.0
capi-kubeadm/cluster-api-kubeadm-controller-amd64@sha256:51e5a17ac02cf8f2f9ce0bd0892da6fc52fa15d0a9d4ffd6a623d0e20d2eaacb,capi-kubeadm/cluster-api-kubeadm-controller-amd64:v0.1.0
capi-kubeadm/cluster-api-kubeadm-controller-arm@sha256:3f53bf8a424f1d70ee58c1b94930ce892c9bad7874cd1a2d8ab4598a60545005,capi-kubeadm/cluster-api-kubeadm-controller-arm:v0.1.0
capi-kubeadm/cluster-api-kubeadm-controller-arm64@sha256:b3745c214ea8ca87339b58e898bcaaedeffc05015d22c5febdf50017a96626e8,capi-kubeadm/cluster-api-kubeadm-controller-arm64:v0.1.0
capi-kubeadm/cluster-api-kubeadm-controller-ppc64le@sha256:801beba208ba51f1b8c5be64bb6c5c99e87449eef3544d4e082ac4e2044a148e,capi-kubeadm/cluster-api-kubeadm-controller-ppc64le:v0.1.0
capi-kubeadm/cluster-api-kubeadm-controller-s390x@sha256:90d53f71722e6b3a1410747c261fc9a23fc6c4a5d02f67852cdec602dc43ced0,capi-kubeadm/cluster-api-kubeadm-controller-s390x:v0.1.0
cluster-api-aws/cluster-api-aws-controller@sha256:7397e3ef7dfa72b102197eaa6bd20ca8b572ccbc31a30f3d262188376e95836a,cluster-api-aws/cluster-api-aws-controller:v0.3.6
cluster-api-aws/cluster-api-aws-controller@sha256:76cf7f26e0abfb5bd862670606a93593f4ac9c51a2ba1c281cc7d709869a2cc1,cluster-api-aws/cluster-api-aws-controller:v0.4.0
cluster-api-aws/cluster-api-aws-controller@sha256:b04cd8882f99aec51ef714a60bd16b7d1f6bae3e4f955bee834744c35b6fb21f,cluster-api-aws/cluster-api-aws-controller:v0.3.8
cluster-api-aws/cluster-api-aws-controller@sha256:e167eec012a77eb6f1741bcb7c6b9514ffdd5ac154137cba86c14f40db979913,cluster-api-aws/cluster-api-aws-controller:v0.3.7
cluster-api-aws/cluster-api-aws-controller-amd64@sha256:0bd88bcba94f800715fca33ffc4bde430646a7c797237313cbccdcdef9f80f2d,cluster-api-aws/cluster-api-aws-controller-amd64:v0.4.0
cluster-api-aws/cluster-api-aws-controller-arm@sha256:19016ec3ce30985a128494909993aef9109a5bdd749874e9b3be20bd65056fee,cluster-api-aws/cluster-api-aws-controller-arm:v0.4.0
cluster-api-aws/cluster-api-aws-controller-arm64@sha256:5c434128d7e28d96d25f11a096e6b9d666d52c5bb683662ba708d22792a0f154,cluster-api-aws/cluster-api-aws-controller-arm64:v0.4.0
cluster-api-aws/cluster-api-aws-controller-ppc64le@sha256:e0af472014f7639b6362e1649717a63e621faf91a5be1ed89f1055689111214c,cluster-api-aws/cluster-api-aws-controller-ppc64le:v0.4.0
cluster-api-aws/cluster-api-aws-controller-s390x@sha256:0ad4f92011b2fa5de88a6e6a2d8b97f38371246021c974760e5fc54b9b7069e5,cluster-api-aws/cluster-api-aws-controller-s390x:v0.4.0
cluster-api/cluster-api-controller@sha256:04e5bbda841ff8c34afd5fc598b9f3f8fd6b82cca49129ba4de7af316e40f87e,cluster-api/cluster-api-controller:v0.2.0
cluster-api/cluster-api-controller@sha256:5867b7735a9d85ea13ed5ab0fce90ae0945c753a119e6bd02f7ceeebec2dd608,cluster-api/cluster-api-controller:v0.1.9
cluster-api/cluster-api-controller@sha256:663829ece3a14201b71ec1e211c3d33f99ecdf0ea8081f7486806442a61d925d,cluster-api/cluster-api-controller:v0.1.7
cluster-api/cluster-api-controller@sha256:663829ece3a14201b71ec1e211c3d33f99ecdf0ea8081f7486806442a61d925d,cluster-api/cluster-api-controller:v0.1.8
cluster-api/cluster-api-controller@sha256:9057a2875d6620521ddea456f31655b8480f07f6a31a50c15b111c1ae09af487,cluster-api/cluster-api-controller:v0.1.5
cluster-api/cluster-api-controller@sha256:9057a2875d6620521ddea456f31655b8480f07f6a31a50c15b111c1ae09af487,cluster-api/cluster-api-controller:v0.1.6
cluster-api/cluster-api-controller@sha256:9652a07cc57081be625d50ab68d4226c7db0e2289384dc1a7061b6a7375f0f05,cluster-api/cluster-api-controller:v0.1.10
cluster-api/cluster-api-controller@sha256:a2049bd4253224693abb248ad446c633a2028e1af5b0628491af5ef7877a0166,cluster-api/cluster-api-controller:v0.2.1
cluster-api/cluster-api-controller@sha256:d5ca573e5fb723a52b267df51e00c811fe97f4d797fb8ad6f8680f13f3282008,cluster-api/cluster-api-controller:v0.2.2
cluster-api/cluster-api-controller-amd64@sha256:ea0e994082f56bf7713d36002abfbffbad43b2c257b89842b3e3694c987d3a07,cluster-api/cluster-api-controller-amd64:v0.2.0
cluster-api/cluster-api-controller-arm@sha256:ddac971ea0e62e0bc969263c57d10bcdaace99918ff5b304b0531ad115459a1f,cluster-api/cluster-api-controller-arm:v0.2.0
cluster-api/cluster-api-controller-arm64@sha256:86e2ae014190d8ab6f511ba8ed9c60658e906f4a2e6eab7adbb65debd91f51b7,cluster-api/cluster-api-controller-arm64:v0.2.0
cluster-api/cluster-api-controller-ppc64le@sha256:d7ec2c3a3c353e5dccff16e5ca9253415d3e3b5398a7beb3f95bf54f1e270fb8,cluster-api/cluster-api-controller-ppc64le:v0.2.0
cluster-api/cluster-api-controller-s390x@sha256:47e89f01c17f66513adddac0b48e035ab937469f3b93df7ab704d725d1e611c1,cluster-api/cluster-api-controller-s390x:v0.2.0
cluster-api/plantuml@sha256:befa605d8640516f9fbada5c1969638c5cb60fb042f598a432cbd22345570bc5,cluster-api/plantuml:1.2019.6
```

/assign @justinsb