### PR TITLE
add gcloud fallback creds for go-containerregistry

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,8 +24,18 @@ container_image(
         "/bin/bash",
         "-c",
     ],
-    env = {"PATH": "/cip:${PATH}"},
+    env = {
+        "PATH": "/cip:${PATH}",
+        "HOME": "/",
+    },
+    layers = [":cip-docker-creds"],
     symlinks = {"/cip/cip": "/app/cip-docker-image.binary"},
+)
+
+container_layer(
+    name = "cip-docker-creds",
+    directory = "/.docker",
+    files = ["docker/config.json"],
 )
 
 # Invoke with "bazel build //:cip-docker-loadable.tar". Then you can run "docker

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,0 +1,11 @@
+{
+  "credHelpers": {
+    "gcr.io": "gcloud", 
+    "us.gcr.io": "gcloud", 
+    "eu.gcr.io": "gcloud", 
+    "asia.gcr.io": "gcloud", 
+    "staging-k8s.gcr.io": "gcloud", 
+    "marketplace.gcr.io": "gcloud"
+  }, 
+  "experimental": "enabled"
+}

--- a/test-e2e/e2e-entrypoint-from-container.sh
+++ b/test-e2e/e2e-entrypoint-from-container.sh
@@ -28,13 +28,10 @@ set -o xtrace
 
 SCRIPT_ROOT=$(dirname "$(readlink -f "$0")")
 
-# Turn on experimental Docker features. This enables the "docker manifest"
-# subcommand.
-mkdir -p $HOME/.docker
-echo '{"experimental":"enabled"}' > $HOME/.docker/config.json
-
-# Make Docker use gcloud as a credential helper when pushing to GCR.
-gcloud auth configure-docker --quiet
+# Populate creds and turn on experimental docker features to support the "docker
+# manifest" subcommand.
+mkdir -p "${HOME}"/.docker
+cp -f "${SCRIPT_ROOT}/../docker/config.json" "${HOME}/.docker"
 
 # Invoke the e2e test!
 make -C "${SCRIPT_ROOT}/.." test-e2e


### PR DESCRIPTION
This fixes  https://github.com/kubernetes/k8s.io/issues/426

This changes the e2e test entrypoint to also use the same creds that are
mounted into the cip container image for standalone invocations. This
way, the e2e test should catch any future auth issues.

/cc @thockin @dims @jonjohnsonjr 