### PR TITLE
Limit path traversal when parsing mfest from file

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -175,7 +175,7 @@ func main() {
 
 	doingPromotion := false
 	if *manifestPtr != "" {
-		mfest, err = reg.ParseManifestFromFile(*manifestPtr)
+		mfest, err = reg.ParseManifestFromFile(*manifestPtr, "")
 		if err != nil {
 			klog.Fatal(err)
 		}


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/151

imagesPath from thin manifests is now limited to only
--thin-manifest-dir directory

Signed-off-by: Bart Smykla <bartek@smykla.com>