### PR TITLE
disallow tag moves (immutable tags)

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -329,7 +329,12 @@ func main() {
 			tp)
 		return &sp
 	}
-	promotionEdges = sc.FilterPromotionEdges(promotionEdges, true)
+	promotionEdges, ok := sc.FilterPromotionEdges(promotionEdges, true)
+	// If any funny business was detected during a comparison of the manifests
+	// with the state of the registries, then exit immediately.
+	if !ok {
+		klog.Exitln(err)
+	}
 	err = sc.Promote(promotionEdges, mkProducer, nil)
 	if err != nil {
 		klog.Exitln(err)

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -148,8 +148,9 @@ const (
 	// overwrite (we are only adding tags).
 	Add TagOp = iota
 	// Move represents those tags that conflict with existing digests, and so
-	// must be move to re-point to the digest that we want to promote as defined
-	// in the manifest. It can be thought of a Delete followed by an Add.
+	// should be moved to re-point to the digest that we want to promote as
+	// defined in the manifest. It can be thought of a Delete followed by an
+	// Add.
 	Move = iota
 	// Delete represents those tags that are not in the manifest and should thus
 	// be removed and deleted. This is a kind of "demotion".


### PR DESCRIPTION
Because tags should always be immutable, moving tags are no longer
supported. We leave the code around detecting such events in tact, in
case we want to revert this behavior in the future.

Note that this means if the destination registries get into a bad state
because of a system independent of the promoter, the promoter can no
longer be used to rectify the situation.

Fixes #157 