### PR TITLE
fixups to auditing mechanism

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,5 +70,6 @@ issues:
     - dupl
     - errcheck
     - funlen
+    - gomnd
     - lll
     - staticcheck

--- a/cmd/promobot-files/main.go
+++ b/cmd/promobot-files/main.go
@@ -56,6 +56,7 @@ func main() {
 	ctx := context.Background()
 	if err := cmd.RunPromoteFiles(ctx, options); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		// nolint[gomnd]
 		os.Exit(1)
 	} else {
 		os.Exit(0)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go v0.46.3
 	cloud.google.com/go/logging v1.0.0
 	cloud.google.com/go/storage v1.1.2
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-containerregistry v0.0.0-20191023194145-7683b4ee5f61
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.11.0

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -58,6 +58,10 @@ type PubSubMessage struct {
 	Subscription string             `json:"subscription"`
 }
 
+const (
+	cloneDepth = 1
+)
+
 func initServerContext(
 	gcpProjectID, repoURLStr, branch, path string,
 ) (*ServerContext, error) {
@@ -156,7 +160,7 @@ func cloneToTempDir(
 	r, err := git.PlainClone(tdir, false, &git.CloneOptions{
 		URL:           repoURL.String(),
 		ReferenceName: (plumbing.ReferenceName)("refs/heads/" + branch),
-		Depth:         1,
+		Depth:         cloneDepth,
 	})
 	if err != nil {
 		return "", err

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -41,8 +41,6 @@ type ServerContext struct {
 	RepoURL              *url.URL
 	RepoBranch           string
 	ThinManifestDirPath  string
-	Repo                 *git.Repository
-	RepoPath             string
 	ErrorReportingClient *errorreporting.Client
 	LogClient            *logging.Client
 }
@@ -69,12 +67,6 @@ func initServerContext(
 		return nil, err
 	}
 
-	// This creates a full-blown clone to a temp dir.
-	r, repoPath, err := cloneToTempDir(repoURL, branch)
-	if err != nil {
-		return nil, err
-	}
-
 	erc := initErrorReportingClient(gcpProjectID)
 	logClient := initLogClient(gcpProjectID)
 
@@ -82,8 +74,6 @@ func initServerContext(
 		RepoURL:              repoURL,
 		RepoBranch:           branch,
 		ThinManifestDirPath:  path,
-		Repo:                 r,
-		RepoPath:             repoPath,
 		ErrorReportingClient: erc,
 		LogClient:            logClient,
 	}
@@ -134,7 +124,6 @@ func Auditor(gcpProjectID, repoURL, branch, path string) {
 	}
 
 	klog.Infoln(serverContext)
-	klog.Infoln(serverContext.Repo)
 
 	// nolint[errcheck]
 	defer serverContext.LogClient.Close()
@@ -158,10 +147,10 @@ func Auditor(gcpProjectID, repoURL, branch, path string) {
 func cloneToTempDir(
 	repoURL fmt.Stringer,
 	branch string,
-) (*git.Repository, string, error) {
+) (string, error) {
 	tdir, err := ioutil.TempDir("", "k8s.io-")
 	if err != nil {
-		return nil, "", err
+		return "", err
 	}
 
 	r, err := git.PlainClone(tdir, false, &git.CloneOptions{
@@ -170,54 +159,15 @@ func cloneToTempDir(
 		Depth:         1,
 	})
 	if err != nil {
-		return nil, "", err
+		return "", err
 	}
 
 	sha, err := getHeadSha(r)
 	if err == nil {
-		klog.Infof("updated %v to revision %v", tdir, sha)
+		klog.Infof("cloned %v at revision %v", tdir, sha)
 	}
 
-	return r, tdir, nil
-}
-
-// Check if the given path already has a git repository. If it does, just use
-// that. Otherwise, clone a repo to a new temporary path.
-func cloneOrPull(repoURL fmt.Stringer,
-	branch,
-	repoPath string,
-) (*git.Repository, string, error) {
-	r, err := git.PlainOpen(repoPath)
-	if err == nil {
-		// Pull
-		wt, err := r.Worktree()
-		if err != nil {
-			klog.Error("worktree error!! can't retrieve it!", err)
-			return r, repoPath, err
-		}
-
-		klog.Info("pulling")
-		err = wt.Pull(&git.PullOptions{RemoteName: "origin"})
-		switch err {
-		case git.NoErrAlreadyUpToDate:
-			fallthrough
-		case git.ErrNonFastForwardUpdate:
-			fallthrough
-		case nil:
-			klog.Info("pull OK")
-		default:
-			klog.Error(err)
-			return r, repoPath, err
-		}
-
-		sha, err := getHeadSha(r)
-		if err == nil {
-			klog.Infof("updated %v to revision %v", repoPath, sha)
-		}
-		return r, repoPath, nil
-	}
-
-	return cloneToTempDir(repoURL, branch)
+	return tdir, nil
 }
 
 func getHeadSha(repo *git.Repository) (string, error) {
@@ -308,8 +258,9 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 		panic(msg)
 	}
 
-	// (2) Re-pull the existing git repo (or clone it if it doesn't exist).
-	s.Repo, s.RepoPath, err = cloneOrPull(s.RepoURL, s.RepoBranch, s.RepoPath)
+	// (2) Clone fresh repo.
+	var repoPath string
+	repoPath, err = cloneToTempDir(s.RepoURL, s.RepoBranch)
 	if err != nil {
 		logError.Println(err)
 		// Return an HTTP error, so that this pubsub message may get retried
@@ -325,21 +276,29 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	logInfo.Printf("s.RepoURL: %v", s.RepoURL)
 	logInfo.Printf("s.RepoBranch: %v", s.RepoBranch)
 	logInfo.Printf("s.ThinManifestDirPath: %v", s.ThinManifestDirPath)
-	logInfo.Printf("s.Repo: %v", s.Repo)
-	logInfo.Printf("s.RepoPath: %v", s.RepoPath)
+	logInfo.Printf("s.RepoPath: %v", repoPath)
 
 	mfests, err := reg.ParseManifestsFromDir(
-		filepath.Join(s.RepoPath, s.ThinManifestDirPath),
+		filepath.Join(repoPath, s.ThinManifestDirPath),
 		reg.ParseThinManifestFromFile)
 	if err != nil {
 		logError.Println(err)
-		// Similar to the error from cloneOrPull(), respond with an HTTP error
+		// Similar to the error from cloneToTempDir(), respond with an HTTP error
 		// so that the Pub/Sub message may be retried. This gracefully handles
 		// the case where the Pub/Sub message is well-formed, but the promoter
 		// manifests are in a bad state (perhaps due to a faulty merge (e.g., a
 		// merge that forgot to remove conflict markers)).
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	// Garbage-collect freshly-cloned repo (we don't need it any more).
+	err = os.RemoveAll(repoPath)
+	if err != nil {
+		// We don't really care too much about failures about removing the
+		// (temporary) repoPath directory, because we'll clone a fresh one
+		// anyway in the future.
+		klog.Errorf("Could not remove temporary Git repo %v: %v", repoPath, err)
 	}
 
 	// (3) Compare GCR state change with the intent of the promoter manifests.

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -167,6 +167,7 @@ func cloneToTempDir(
 	r, err := git.PlainClone(tdir, false, &git.CloneOptions{
 		URL:           repoURL.String(),
 		ReferenceName: (plumbing.ReferenceName)("refs/heads/" + branch),
+		Depth:         1,
 	})
 	if err != nil {
 		return nil, "", err

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1020,6 +1020,7 @@ func GetTokenKeyDomainRepoPath(
 	s := string(registryName)
 	i := strings.IndexByte(s, '/')
 	key := ""
+	// nolint[gomnd]
 	if strings.Count(s, "/") < 2 {
 		key = s
 	} else {

--- a/lib/stream/http.go
+++ b/lib/stream/http.go
@@ -26,26 +26,21 @@ import (
 	"k8s.io/klog"
 )
 
-// Checks is from https://stackoverflow.com/a/40398093/437583.
-func Checks(fs ...func() error) {
-	for i := len(fs) - 1; i >= 0; i-- {
-		if err := fs[i](); err != nil {
-			fmt.Println("Received error:", err)
-		}
-	}
-}
-
 // HTTP is a wrapper around the net/http's Request type.
 type HTTP struct {
 	Req *http.Request
 	Res *http.Response
 }
 
+const (
+	requestTimeoutSeconds = 3
+)
+
 // Produce runs the external process and returns two io.Readers (to stdout and
 // stderr). In this case we equate the http.Respose "Body" with stdout.
 func (h *HTTP) Produce() (io.Reader, io.Reader, error) {
 	client := http.Client{
-		Timeout: time.Second * 3, // 3-second timeout
+		Timeout: time.Second * requestTimeoutSeconds,
 	}
 
 	var err error
@@ -58,7 +53,7 @@ func (h *HTTP) Produce() (io.Reader, io.Reader, error) {
 		return nil, nil, err
 	}
 
-	if h.Res.StatusCode == 200 {
+	if h.Res.StatusCode == http.StatusOK {
 		return h.Res.Body, nil, nil
 	}
 

--- a/lib/stream/types.go
+++ b/lib/stream/types.go
@@ -48,6 +48,8 @@ type ExternalRequest struct {
 }
 
 // BackoffDefault is the default Backoff behavior for network call retries.
+//
+// nolint[gomnd]
 var BackoffDefault = wait.Backoff{
 	Duration: time.Second,
 	Factor:   2,

--- a/pkg/api/files/validation.go
+++ b/pkg/api/files/validation.go
@@ -99,6 +99,7 @@ func validateFiles(files []File) error {
 			return fmt.Errorf("sha256 was not valid (not hex): %q", f.SHA256)
 		}
 
+		// nolint[gomnd]
 		if len(sha256) != 32 {
 			return fmt.Errorf("sha256 was not valid (bad length): %q", f.SHA256)
 		}

--- a/pkg/filepromoter/gcs.go
+++ b/pkg/filepromoter/gcs.go
@@ -87,6 +87,7 @@ func (s *gcsSyncFilestore) UploadFile(
 	w.SendCRC32C = true
 
 	// Much bigger chunk size for faster uploading
+	// nolint[gomnd]
 	w.ChunkSize = 128 * 1024 * 1024
 
 	if _, err := io.Copy(w, in); err != nil {

--- a/test-e2e/e2e.go
+++ b/test-e2e/e2e.go
@@ -231,6 +231,7 @@ func getBazelOption(repoRoot, o string) string {
 	for _, line := range strings.Split(strings.TrimSuffix(stdout, "\n"), "\n") {
 		if strings.Contains(line, o) {
 			words := strings.Split(line, " ")
+			// nolint[gomnd]
 			if len(words) == 2 {
 				return words[1]
 			}


### PR DESCRIPTION
1) shallow clone (depth=1)
2) always clone to tmp dir for each request (instead of pulling from an existing one if it exists)

/cc @thockin @justinsb @bartsmykla 