### PR TITLE
workspace_status.sh: do not rely solely on Git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPO_ROOT:=$(shell git rev-parse --show-toplevel)
+REPO_ROOT:=$(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 BAZEL_BUILD_OPTS:=--workspace_status_command=$(REPO_ROOT)/workspace_status.sh \
 	--host_force_python=PY2 \
 	--stamp


### PR DESCRIPTION
In some environments (such as is cloudbuild.yaml which Prow uses), the
source code does not contain the .git folder and instead we are provided
with the _GIT_TAG variable. Use this variable instead of relying on
Git (which would otherwise result in a build failure).

This should fix https://github.com/kubernetes/kubernetes/issues/86880

/cc @dims @justinsb @thockin