### PR TITLE
highlight tag move detection errors in the logs

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -350,7 +350,7 @@ func main() {
 	// If any funny business was detected during a comparison of the manifests
 	// with the state of the registries, then exit immediately.
 	if !ok {
-		klog.Exitln(err)
+		klog.Exitln("encountered errors during edge filtering")
 	}
 	err = sc.Promote(promotionEdges, mkProducer, nil)
 	if err != nil {

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -493,8 +493,11 @@ func (sc *SyncContext) getPromotionCandidates(
 					klog.Infof("edge %s: skipping because it was already promoted (case 2)\n", edge)
 					continue
 				} else {
-					klog.Errorf("edge %s: tag %s: tag move detected from %s to %s", edge, edge.DstImageTag.Tag, edge.Digest, *sc.getDigestForTag(edge.DstImageTag.Tag))
+					klog.Errorf("edge %s: tag %s: ERROR: tag move detected from %s to %s", edge, edge.DstImageTag.Tag, edge.Digest, *sc.getDigestForTag(edge.DstImageTag.Tag))
 					clean = false
+					// We continue instead of returning early, because we want
+					// to see and log as many errors as possible as we go
+					// through each promotion edge.
 					continue
 				}
 			} else {


### PR DESCRIPTION
This addresses the comment
https://github.com/kubernetes/k8s.io/pull/499#issuecomment-573267644
that the log output for tag moves is currently not really readable.

/cc @justinsb @dims @ps882 