### PR TITLE
add auditor testing entrypoint

### DIFF
--- a/test-e2e/cip-auditor/entrypoint-from-container.sh
+++ b/test-e2e/cip-auditor/entrypoint-from-container.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is meant to be used from inside the
+# gcr.io/k8s-testimages/kubekins-e2e image when running the promoter's e2e test
+# (e2e.go) as part of a Prow presubmit job. Because this script is so
+# bare-bones, we choose to just run it instead of creating a custom Docker image
+# that already has the setup logic in it. This way, we avoid having to
+# build/maintain a separate e2e environment image of our own.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+SCRIPT_ROOT=$(dirname "$(readlink -f "$0")")
+
+# Populate creds and turn on experimental docker features to support the "docker
+# manifest" subcommand.
+mkdir -p "${HOME}"/.docker
+cp -f "${SCRIPT_ROOT}/../../docker/config.json" "${HOME}/.docker"
+
+# TODO: Invoke the e2e test when it is ready.
+#make -C "${SCRIPT_ROOT}/../.." test-e2e-cip-auditor


### PR DESCRIPTION
For now, this test doesn't really do anything. It is here mainly to
allow for a Prow check to be written that will use this script as the
entrypoint.

Later when the actual auditor E2E test is ready, we can create a PR for
that (at which point in time the Prow check above will activate and run
the full test suite for us).

/cc @ps882 @thockin @justinsb 