### PR TITLE
auditor e2e test: remove CIP_E2E_KEY_FILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-ci: download
 test-e2e-cip:
 	bazel run $(BAZEL_BUILD_OPTS) //test-e2e/cip:e2e -- -tests=$(REPO_ROOT)/test-e2e/cip/tests.yaml -repo-root=$(REPO_ROOT) -key-file=$(CIP_E2E_KEY_FILE)
 test-e2e-cip-auditor:
-	bazel run $(BAZEL_BUILD_OPTS) //test-e2e/cip-auditor:cip-auditor-e2e -- -tests=$(REPO_ROOT)/test-e2e/cip-auditor/tests.yaml -repo-root=$(REPO_ROOT) -key-file=$(CIP_E2E_KEY_FILE)
+	bazel run $(BAZEL_BUILD_OPTS) //test-e2e/cip-auditor:cip-auditor-e2e -- -tests=$(REPO_ROOT)/test-e2e/cip-auditor/tests.yaml -repo-root=$(REPO_ROOT)
 download:
 	GO111MODULE=on go mod download
 update:


### PR DESCRIPTION
The following PRs (in flight) make this need to reference the Google
Service Account obsolete. (KSA = Kubernetes SA, GSA = Google SA).

https://github.com/kubernetes/test-infra/pull/15984 (adds the KSA)
https://github.com/kubernetes/test-infra/pull/15924 (adds the job using the KSA)

/cc @justinsb @dims