### PR TITLE
promobot-generate-manifest: Fix name of bazel target

### DIFF
--- a/cmd/promobot-generate-manifest/BUILD.bazel
+++ b/cmd/promobot-generate-manifest/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
 )
 
 go_binary(
-    name = "promobot-files",
+    name = "promobot-generate-manifest",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This lets us do `bazel build //cmd/promobot-generate-manifest`