### PR TITLE
Fix auditor

### DIFF
--- a/lib/audit/BUILD.bazel
+++ b/lib/audit/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["auditor.go"],
+    srcs = [
+        "auditor.go",
+        "types.go",
+    ],
     importpath = "sigs.k8s.io/k8s-container-image-promoter/lib/audit",
     visibility = ["//visibility:public"],
     deps = [

--- a/lib/audit/BUILD.bazel
+++ b/lib/audit/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lib/dockerregistry:go_default_library",
+        "//lib/logclient:go_default_library",
         "@com_google_cloud_go//errorreporting:go_default_library",
-        "@com_google_cloud_go_logging//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
         "@io_k8s_klog//:go_default_library",

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -36,37 +36,6 @@ import (
 	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
 )
 
-// ServerContext holds all of the initialization data for the server to start
-// up.
-type ServerContext struct {
-	ID                   string
-	RepoURL              *url.URL
-	RepoBranch           string
-	ThinManifestDirPath  string
-	ErrorReportingClient *errorreporting.Client
-	LogClient            *logging.Client
-}
-
-// PubSubMessageInner is the inner struct that holds the actual Pub/Sub
-// information.
-type PubSubMessageInner struct {
-	Data []byte `json:"data,omitempty"`
-	ID   string `json:"id"`
-}
-
-// PubSubMessage is the payload of a Pub/Sub event.
-type PubSubMessage struct {
-	Message      PubSubMessageInner `json:"message"`
-	Subscription string             `json:"subscription"`
-}
-
-const (
-	cloneDepth = 1
-	// LogName is the auditing log name to use. This is the name that comes up
-	// for "gcloud logging logs list".
-	LogName = "cip-audit-log"
-)
-
 func initServerContext(
 	gcpProjectID, repoURLStr, branch, path, uuid string,
 ) (*ServerContext, error) {

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"net/url"
+
+	"cloud.google.com/go/errorreporting"
+	"cloud.google.com/go/logging"
+)
+
+// ServerContext holds all of the initialization data for the server to start
+// up.
+type ServerContext struct {
+	ID                  string
+	RepoURL             *url.URL
+	RepoBranch          string
+	ThinManifestDirPath string
+	// TODO: Change ErrorReportingClient and LogClient into interfaces. Then use
+	// dependency injection to make unit tests for the Audit() function.
+	ErrorReportingClient *errorreporting.Client
+	LogClient            *logging.Client
+}
+
+// PubSubMessageInner is the inner struct that holds the actual Pub/Sub
+// information.
+type PubSubMessageInner struct {
+	Data []byte `json:"data,omitempty"`
+	ID   string `json:"id"`
+}
+
+// PubSubMessage is the payload of a Pub/Sub event.
+type PubSubMessage struct {
+	Message      PubSubMessageInner `json:"message"`
+	Subscription string             `json:"subscription"`
+}
+
+const (
+	cloneDepth = 1
+	// LogName is the auditing log name to use. This is the name that comes up
+	// for "gcloud logging logs list".
+	LogName = "cip-audit-log"
+)

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -20,20 +20,18 @@ import (
 	"net/url"
 
 	"cloud.google.com/go/errorreporting"
-	"cloud.google.com/go/logging"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
 )
 
 // ServerContext holds all of the initialization data for the server to start
 // up.
 type ServerContext struct {
-	ID                  string
-	RepoURL             *url.URL
-	RepoBranch          string
-	ThinManifestDirPath string
-	// TODO: Change ErrorReportingClient and LogClient into interfaces. Then use
-	// dependency injection to make unit tests for the Audit() function.
+	ID                   string
+	RepoURL              *url.URL
+	RepoBranch           string
+	ThinManifestDirPath  string
 	ErrorReportingClient *errorreporting.Client
-	LogClient            *logging.Client
+	LoggingFacility      *logclient.LoggingFacility
 }
 
 // PubSubMessageInner is the inner struct that holds the actual Pub/Sub

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -302,7 +302,7 @@ func ValidateThinManifestDirectoryStructure(
 		return err
 	}
 
-	fmt.Printf("*looking at %q\n", dir)
+	klog.Infof("*looking at %q", dir)
 	for _, file := range files {
 		p, err := os.Stat(filepath.Join(manifestDir, file.Name()))
 		if err != nil {

--- a/lib/logclient/BUILD.bazel
+++ b/lib/logclient/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fake.go",
+        "gcp.go",
+        "types.go",
+    ],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/lib/logclient",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_cloud_go_logging//:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+    ],
+)

--- a/lib/logclient/fake.go
+++ b/lib/logclient/fake.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logclient
+
+import (
+	"log"
+	"os"
+)
+
+// FakeLogClient is a fake log client. Its sole purpose is to implement a NOP
+// "Close()" method, for tests.
+type FakeLogClient struct{}
+
+// Close is a NOP (there is nothing to close).
+func (fakeLogClient *FakeLogClient) Close() error { return nil }
+
+// NewFakeLoggingFacility returns a new LoggingFacility, but whose resources are
+// all local (stdout), with a FakeLogClient.
+func NewFakeLoggingFacility() *LoggingFacility {
+
+	logInfo := log.New(os.Stdout, "FAKE-INFO", log.LstdFlags)
+	logError := log.New(os.Stdout, "FAKE-ERROR", log.LstdFlags)
+	logAlert := log.New(os.Stdout, "FAKE-ALERT", log.LstdFlags)
+
+	return New(logInfo, logError, logAlert, &FakeLogClient{})
+}

--- a/lib/logclient/gcp.go
+++ b/lib/logclient/gcp.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logclient
+
+import (
+	"context"
+
+	"cloud.google.com/go/logging"
+	"k8s.io/klog"
+)
+
+// NewGcpLoggingFacility returns a new LoggingFacility that logs to GCP
+// resources. As such, it requires the GCP projectID as well as the logName to
+// log to.
+func NewGcpLoggingFacility(projectID, logName string) *LoggingFacility {
+	gcpLogClient := initGcpLogClient(projectID)
+
+	logInfo := gcpLogClient.Logger(logName).StandardLogger(logging.Info)
+	logError := gcpLogClient.Logger(logName).StandardLogger(logging.Error)
+	logAlert := gcpLogClient.Logger(logName).StandardLogger(logging.Alert)
+
+	return New(logInfo, logError, logAlert, gcpLogClient)
+}
+
+// initGcpLogClient creates a logging client that performs better logging than
+// the default behavior on GCP Stackdriver. For instance, logs sent with this
+// client are not split up over newlines, and also the severity levels are
+// actually understood by Stackdriver.
+func initGcpLogClient(projectID string) *logging.Client {
+
+	ctx := context.Background()
+
+	// Creates a client.
+	client, err := logging.NewClient(ctx, projectID)
+	if err != nil {
+		klog.Fatalf("Failed to create client: %v", err)
+	}
+
+	return client
+}

--- a/lib/logclient/types.go
+++ b/lib/logclient/types.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logclient
+
+import (
+	"io"
+	"log"
+)
+
+// LoggingFacility bundles 3 loggers together.
+type LoggingFacility struct {
+	LogInfo  *log.Logger
+	LogError *log.Logger
+	LogAlert *log.Logger
+
+	logClient io.Closer
+}
+
+// New returns a new LoggingFacility, based on the given loggers.
+func New(
+	logInfo, logError, logAlert *log.Logger,
+	logClient io.Closer,
+) *LoggingFacility {
+	return &LoggingFacility{
+		LogInfo:   logInfo,
+		LogError:  logError,
+		LogAlert:  logAlert,
+		logClient: logClient,
+	}
+}
+
+// Close implements the "Close" method for the LoggingFacility. This just calls
+// Close() on the "logClient".
+func (loggingFacility *LoggingFacility) Close() error {
+	return loggingFacility.logClient.Close()
+}


### PR DESCRIPTION
This is first part of a couple more PRs to fix #191. I need to do this so that I can add unit tests for the `Audit()` function. After this PR I need to do a similar change (introduction of a wrapper type) for the `errorreporting.Client` stuff we still have in `Audit()`.
