### PR TITLE
convert LoggingFacility from a struct to an interface

### DIFF
--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -46,7 +46,7 @@ func initServerContext(
 	}
 
 	erc := initErrorReportingClient(gcpProjectID)
-	loggingFacility, err := logclient.NewGcpLoggingFacility(
+	loggingFacility, err := logclient.NewGcpLogClient(
 		gcpProjectID, LogName)
 	if err != nil {
 		return nil, err
@@ -233,9 +233,9 @@ func ParsePubSubMessage(r *http.Request) (*reg.GCRPubSubPayload, error) {
 // other.
 // nolint[funlen]
 func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
-	logInfo := s.LoggingFacility.LogInfo
-	logError := s.LoggingFacility.LogError
-	logAlert := s.LoggingFacility.LogAlert
+	logInfo := s.LoggingFacility.GetInfoLogger()
+	logError := s.LoggingFacility.GetErrorLogger()
+	logAlert := s.LoggingFacility.GetAlertLogger()
 
 	defer func() {
 		if msg := recover(); msg != nil {

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -31,7 +31,7 @@ type ServerContext struct {
 	RepoBranch           string
 	ThinManifestDirPath  string
 	ErrorReportingClient *errorreporting.Client
-	LoggingFacility      *logclient.LoggingFacility
+	LoggingFacility      logclient.LoggingFacility
 }
 
 // PubSubMessageInner is the inner struct that holds the actual Pub/Sub

--- a/lib/logclient/fake.go
+++ b/lib/logclient/fake.go
@@ -21,20 +21,40 @@ import (
 	"os"
 )
 
-// FakeLogClient is a fake log client. Its sole purpose is to implement a NOP
-// "Close()" method, for tests.
-type FakeLogClient struct{}
+// FakeLogClient is a fake log client.
+type FakeLogClient struct {
+	// Because this is fake, there is no actual logging client.
+	loggers [3]*log.Logger
+}
 
 // Close is a NOP (there is nothing to close).
-func (fakeLogClient *FakeLogClient) Close() error { return nil }
+func (c *FakeLogClient) Close() error { return nil }
 
-// NewFakeLoggingFacility returns a new LoggingFacility, but whose resources are
-// all local (stdout), with a FakeLogClient.
-func NewFakeLoggingFacility() *LoggingFacility {
+// GetInfoLogger exposes the internal Info logger.
+func (c *FakeLogClient) GetInfoLogger() *log.Logger {
+	return c.loggers[IndexLogInfo]
+}
 
-	logInfo := log.New(os.Stderr, "FAKE-INFO", log.LstdFlags)
-	logError := log.New(os.Stderr, "FAKE-ERROR", log.LstdFlags)
-	logAlert := log.New(os.Stderr, "FAKE-ALERT", log.LstdFlags)
+// GetErrorLogger exposes the internal Error logger.
+func (c *FakeLogClient) GetErrorLogger() *log.Logger {
+	return c.loggers[IndexLogError]
+}
 
-	return New(logInfo, logError, logAlert, &FakeLogClient{})
+// GetAlertLogger exposes the internal Alert logger.
+func (c *FakeLogClient) GetAlertLogger() *log.Logger {
+	return c.loggers[IndexLogAlert]
+}
+
+// NewFakeLogClient returns a new FakeLogClient.
+func NewFakeLogClient() *FakeLogClient {
+	c := FakeLogClient{}
+
+	c.loggers[IndexLogInfo] = log.
+		New(os.Stderr, "FAKE-INFO", log.LstdFlags)
+	c.loggers[IndexLogError] = log.
+		New(os.Stderr, "FAKE-ERROR", log.LstdFlags)
+	c.loggers[IndexLogAlert] = log.
+		New(os.Stderr, "FAKE-ALERT", log.LstdFlags)
+
+	return &c
 }

--- a/lib/logclient/gcp.go
+++ b/lib/logclient/gcp.go
@@ -18,37 +18,64 @@ package logclient
 
 import (
 	"context"
+	"log"
 
 	"cloud.google.com/go/logging"
 )
 
-// NewGcpLoggingFacility returns a new LoggingFacility that logs to GCP
-// resources. As such, it requires the GCP projectID as well as the logName to
-// log to.
-func NewGcpLoggingFacility(
-	projectID, logName string,
-) (*LoggingFacility, error) {
-
-	gcpLogClient, err := initGcpLogClient(projectID)
-	if err != nil {
-		return nil, err
-	}
-
-	logInfo := gcpLogClient.Logger(logName).StandardLogger(logging.Info)
-	logError := gcpLogClient.Logger(logName).StandardLogger(logging.Error)
-	logAlert := gcpLogClient.Logger(logName).StandardLogger(logging.Alert)
-
-	return New(logInfo, logError, logAlert, gcpLogClient), nil
+// GcpLogClient is a GCP log client.
+type GcpLogClient struct {
+	logClient *logging.Client
+	loggers   [3]*log.Logger
 }
 
-// initGcpLogClient creates a logging client that performs better logging than
-// the default behavior on GCP Stackdriver. For instance, logs sent with this
-// client are not split up over newlines, and also the severity levels are
-// actually understood by Stackdriver.
-func initGcpLogClient(projectID string) (*logging.Client, error) {
+// Close simply calls Close() to the underlying logging client (from which the
+// child loggers are derived).
+func (c *GcpLogClient) Close() error {
+	return c.logClient.Close()
+}
+
+// GetInfoLogger exposes the internal Info logger.
+func (c *GcpLogClient) GetInfoLogger() *log.Logger {
+	return c.loggers[IndexLogInfo]
+}
+
+// GetErrorLogger exposes the internal Error logger.
+func (c *GcpLogClient) GetErrorLogger() *log.Logger {
+	return c.loggers[IndexLogError]
+}
+
+// GetAlertLogger exposes the internal Alert logger.
+func (c *GcpLogClient) GetAlertLogger() *log.Logger {
+	return c.loggers[IndexLogAlert]
+}
+
+// NewGcpLogClient returns a new LoggingFacility that logs to GCP resources. As
+// such, it requires the GCP projectID as well as the logName to log to.
+func NewGcpLogClient(
+	projectID, logName string,
+) (*GcpLogClient, error) {
+
+	c := GcpLogClient{}
 
 	ctx := context.Background()
 
-	// Creates a client.
-	return logging.NewClient(ctx, projectID)
+	// This creates a logging client that performs better logging than the
+	// default behavior on GCP Stackdriver. For instance, logs sent with this
+	// client are not split up over newlines, and also the severity levels are
+	// actually understood by Stackdriver.
+	logClient, err := logging.NewClient(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	c.logClient = logClient
+
+	c.loggers[IndexLogInfo] = logClient.
+		Logger(logName).StandardLogger(logging.Info)
+	c.loggers[IndexLogError] = logClient.
+		Logger(logName).StandardLogger(logging.Error)
+	c.loggers[IndexLogAlert] = logClient.
+		Logger(logName).StandardLogger(logging.Alert)
+
+	return &c, nil
 }

--- a/lib/logclient/types.go
+++ b/lib/logclient/types.go
@@ -21,30 +21,23 @@ import (
 	"log"
 )
 
+// These constants refer to the logging levels.
+const (
+	IndexLogInfo = 0
+	IndexLogError
+	IndexLogAlert
+)
+
+// GetLoggers extracts 3 loggers, corresponding to the logging levels defined
+// above.
+type GetLoggers interface {
+	GetInfoLogger() *log.Logger
+	GetErrorLogger() *log.Logger
+	GetAlertLogger() *log.Logger
+}
+
 // LoggingFacility bundles 3 loggers together.
-type LoggingFacility struct {
-	LogInfo  *log.Logger
-	LogError *log.Logger
-	LogAlert *log.Logger
-
-	logClient io.Closer
-}
-
-// New returns a new LoggingFacility, based on the given loggers.
-func New(
-	logInfo, logError, logAlert *log.Logger,
-	logClient io.Closer,
-) *LoggingFacility {
-	return &LoggingFacility{
-		LogInfo:   logInfo,
-		LogError:  logError,
-		LogAlert:  logAlert,
-		logClient: logClient,
-	}
-}
-
-// Close implements the "Close" method for the LoggingFacility. This just calls
-// Close() on the "logClient".
-func (loggingFacility *LoggingFacility) Close() error {
-	return loggingFacility.logClient.Close()
+type LoggingFacility interface {
+	GetLoggers
+	io.Closer
 }


### PR DESCRIPTION
This makes it so that the fake/real implementations don't have to share
anything. Whereas before, the implementations had to call the New()
constructor to create a LoggingFacility struct type, with this change
they can each have their own struct which just satisfies the
LoggingFacility interface.

The change is subtle but leads to lighter shared code in
logclient/types.go.