### PR TITLE
ServerContext: use a ReportingFacility wrapper for errorreporting

### DIFF
--- a/lib/audit/BUILD.bazel
+++ b/lib/audit/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//lib/dockerregistry:go_default_library",
         "//lib/logclient:go_default_library",
+        "//lib/report:go_default_library",
         "@com_google_cloud_go//errorreporting:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -19,19 +19,19 @@ package audit
 import (
 	"net/url"
 
-	"cloud.google.com/go/errorreporting"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
 )
 
 // ServerContext holds all of the initialization data for the server to start
 // up.
 type ServerContext struct {
-	ID                   string
-	RepoURL              *url.URL
-	RepoBranch           string
-	ThinManifestDirPath  string
-	ErrorReportingClient *errorreporting.Client
-	LoggingFacility      logclient.LoggingFacility
+	ID                     string
+	RepoURL                *url.URL
+	RepoBranch             string
+	ThinManifestDirPath    string
+	ErrorReportingFacility report.ReportingFacility
+	LoggingFacility        logclient.LoggingFacility
 }
 
 // PubSubMessageInner is the inner struct that holds the actual Pub/Sub

--- a/lib/report/BUILD.bazel
+++ b/lib/report/BUILD.bazel
@@ -7,7 +7,10 @@ go_library(
         "gcp.go",
         "types.go",
     ],
-    importpath = "sigs.k8s.io/k8s-container-image-promoter/lib/logclient",
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/lib/report",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_cloud_go_logging//:go_default_library"],
+    deps = [
+        "@com_google_cloud_go//errorreporting:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+    ],
 )

--- a/lib/report/fake.go
+++ b/lib/report/fake.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"log"
+	"os"
+
+	"cloud.google.com/go/errorreporting"
+)
+
+// FakeReportingClient is a fake reporting client.
+type FakeReportingClient struct {
+	reporter *log.Logger
+}
+
+// Report simply prints the entry to STDERR. Nothing goes over the network!
+func (c *FakeReportingClient) Report(
+	e errorreporting.Entry,
+) {
+	c.reporter.Println(e)
+}
+
+// Close is a NOP (there is nothing to close).
+func (c *FakeReportingClient) Close() error { return nil }
+
+// NewFakeReportingClient creates a new FakeReportingClient that has the
+// reporter initialized to a basic logger to STDERR.
+func NewFakeReportingClient() *FakeReportingClient {
+	c := FakeReportingClient{}
+
+	c.reporter = log.New(os.Stderr, "FAKE-REPORT", log.LstdFlags)
+
+	return &c
+}

--- a/lib/report/gcp.go
+++ b/lib/report/gcp.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"context"
+
+	"cloud.google.com/go/errorreporting"
+	"k8s.io/klog"
+)
+
+// NewGcpErrorReportingClient returns a new Stackdriver Error Reporting client.
+func NewGcpErrorReportingClient(
+	projectID, serviceName string,
+) *errorreporting.Client {
+
+	ctx := context.Background()
+
+	erc, err := errorreporting.NewClient(ctx, projectID, errorreporting.Config{
+		ServiceName: serviceName,
+		OnError: func(err error) {
+			klog.Errorf("Could not log error: %v", err)
+		},
+	})
+	if err != nil {
+		klog.Fatalf("Failed to create errorreporting client: %v", err)
+	}
+
+	return erc
+}

--- a/lib/report/types.go
+++ b/lib/report/types.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"io"
+
+	"cloud.google.com/go/errorreporting"
+)
+
+// Reporter requires a single method, called Report(), which corresponds to
+// calling Stackdriver Error Reporting for the real implementation.
+type Reporter interface {
+	Report(errorreporting.Entry)
+}
+
+// ReportingFacility has a Reporter and Closer. Unlike LoggingFacility, there is
+// no need to have a struct type because the same thing is used to call Report()
+// and Close() on. This is because the real implementation calls both Report()
+// and Close() methods on the same errorreporting.Client type (and so, the fake
+// implementation follows suit and does the same). As such, there is no need to
+// have a wrapper struct around the two (separate) interfaces, and
+// ReportingFacility is just a plain interface.
+type ReportingFacility interface {
+	Reporter
+	io.Closer
+}


### PR DESCRIPTION
Instead of hardcoding the Stackdriver Error Reporting client directly
into the Auditor's ServerContext, use a "ReportingFacility" interface
wrapper so that we can use FakeReportingClient for unit tests.

/cc @justinsb 