### PR TITLE
ServerContext: use a RemoteManifestFacility wrapper for cloning

### DIFF
--- a/lib/audit/BUILD.bazel
+++ b/lib/audit/BUILD.bazel
@@ -11,10 +11,9 @@ go_library(
     deps = [
         "//lib/dockerregistry:go_default_library",
         "//lib/logclient:go_default_library",
+        "//lib/remotemanifest:go_default_library",
         "//lib/report:go_default_library",
         "@com_google_cloud_go//errorreporting:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
         "@io_k8s_klog//:go_default_library",
     ],
 )

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -17,9 +17,8 @@ limitations under the License.
 package audit
 
 import (
-	"net/url"
-
 	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
 )
 
@@ -27,9 +26,7 @@ import (
 // up.
 type ServerContext struct {
 	ID                     string
-	RepoURL                *url.URL
-	RepoBranch             string
-	ThinManifestDirPath    string
+	RemoteManifestFacility remotemanifest.Facility
 	ErrorReportingFacility report.ReportingFacility
 	LoggingFacility        logclient.LoggingFacility
 }
@@ -48,7 +45,6 @@ type PubSubMessage struct {
 }
 
 const (
-	cloneDepth = 1
 	// LogName is the auditing log name to use. This is the name that comes up
 	// for "gcloud logging logs list".
 	LogName = "cip-audit-log"

--- a/lib/remotemanifest/BUILD.bazel
+++ b/lib/remotemanifest/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fake.go",
+        "git.go",
+        "types.go",
+    ],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/dockerregistry:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+    ],
+)

--- a/lib/remotemanifest/fake.go
+++ b/lib/remotemanifest/fake.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotemanifest
+
+import (
+	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+)
+
+// Fake is a fake remote manifest. It is fake in the sense that it
+// will never fetch anything from any remote.
+type Fake struct {
+	manifests []reg.Manifest
+}
+
+// Fetch just returns the manifests that were set in NewFakeRemoteManifest.
+func (remote *Fake) Fetch() ([]reg.Manifest, error) {
+	return remote.manifests, nil
+}
+
+// NewFake creates a new Fake.
+func NewFake(manifests []reg.Manifest) *Fake {
+	remote := Fake{}
+
+	remote.manifests = manifests
+
+	return &remote
+}

--- a/lib/remotemanifest/git.go
+++ b/lib/remotemanifest/git.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotemanifest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	gogit "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"k8s.io/klog"
+	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+)
+
+const (
+	gitCloneDepth = 1
+)
+
+// Git stores the Git-based information in order to fetch the Git contents (and
+// to parse them into promoter manifests).
+type Git struct {
+	repoURL             *url.URL
+	repoBranch          string
+	thinManifestDirPath string
+}
+
+// Fetch gets the remote Git contents and parses it into promoter manifests. It
+// could be the case that the repository is defined simply as a local path on
+// disk (in the case of e2e tests where we do not have a full-fledghed online
+// repository for the manifests we want to audit) --- in such cases, we have to
+// use the local path instead of freshly cloning a remote repo.
+func (remote *Git) Fetch() ([]reg.Manifest, error) {
+	// There is no remote; use the local path directly.
+	if len(remote.repoURL.String()) == 0 {
+		manifests, err := reg.ParseThinManifestsFromDir(
+			remote.thinManifestDirPath)
+		if err != nil {
+			return nil, err
+		}
+
+		return manifests, nil
+	}
+
+	var repoPath string
+	repoPath, err := cloneToTempDir(remote.repoURL, remote.repoBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests, err := reg.ParseThinManifestsFromDir(
+		filepath.Join(repoPath, remote.thinManifestDirPath))
+	if err != nil {
+		return nil, err
+	}
+
+	// Garbage-collect freshly-cloned repo (we don't need it any more).
+	err = os.RemoveAll(repoPath)
+	if err != nil {
+		// We don't really care too much about failures about removing the
+		// (temporary) repoPath directory, because we'll clone a fresh one
+		// anyway in the future. So don't return an error even if this fails.
+		klog.Errorf("Could not remove temporary Git repo %v: %v", repoPath, err)
+	}
+
+	return manifests, nil
+}
+
+func cloneToTempDir(
+	repoURL fmt.Stringer,
+	branch string,
+) (string, error) {
+	tdir, err := ioutil.TempDir("", "k8s.io-")
+	if err != nil {
+		return "", err
+	}
+
+	r, err := gogit.PlainClone(tdir, false, &gogit.CloneOptions{
+		URL:           repoURL.String(),
+		ReferenceName: (plumbing.ReferenceName)("refs/heads/" + branch),
+		Depth:         gitCloneDepth,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sha, err := getHeadSha(r)
+	if err == nil {
+		klog.Infof("cloned %v at revision %v", tdir, sha)
+	}
+
+	return tdir, nil
+}
+
+func getHeadSha(repo *gogit.Repository) (string, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return "", err
+	}
+
+	return head.Hash().String(), nil
+}
+
+// NewGit creates a new Git implementation for defining a remote set of promoter
+// manifest.
+func NewGit(
+	repoURLStr string,
+	repoBranch string,
+	thinManifestDirPath string,
+) (*Git, error) {
+
+	remote := Git{}
+
+	repoURL, err := url.Parse(repoURLStr)
+	if err != nil {
+		return nil, err
+	}
+
+	remote.repoURL = repoURL
+	remote.repoBranch = repoBranch
+	remote.thinManifestDirPath = thinManifestDirPath
+
+	return &remote, nil
+}

--- a/lib/remotemanifest/types.go
+++ b/lib/remotemanifest/types.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotemanifest
+
+import (
+	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+)
+
+// Facility requires a single method, called Fetch(), which corresponds to
+// fetching a set of promoter manifests.
+type Facility interface {
+	Fetch() ([]reg.Manifest, error)
+}


### PR DESCRIPTION
Instead of hardcoding the Git operations directly into the Auditor's
ServerContext, use a "RemoteManifestFacility" interface wrapper so that
we can use a Fake for unit tests.

/cc @justinsb