### PR TITLE
fix child manifest handling

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -156,7 +156,17 @@ func main() {
 			uuid = guuid.New().String()
 			klog.Infof("Starting auditor in Regular Mode (%s)", uuid)
 		}
-		audit.Auditor(*auditGcpProjectID, *auditManifestRepoUrlPtr, *auditManifestRepoBranchPtr, *auditManifestPathPtr, uuid)
+
+		auditServerContext, err := audit.InitRealServerContext(
+			*auditGcpProjectID,
+			*auditManifestRepoUrlPtr,
+			*auditManifestRepoBranchPtr,
+			*auditManifestPathPtr,
+			uuid)
+		if err != nil {
+			klog.Exitln(err)
+		}
+		auditServerContext.RunAuditor()
 	}
 
 	// Activate service accounts.

--- a/lib/audit/BUILD.bazel
+++ b/lib/audit/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//lib/logclient:go_default_library",
         "//lib/remotemanifest:go_default_library",
         "//lib/report:go_default_library",
+        "//lib/stream:go_default_library",
         "@com_google_cloud_go//errorreporting:go_default_library",
         "@io_k8s_klog//:go_default_library",
     ],
@@ -22,5 +23,10 @@ go_test(
     name = "go_default_test",
     srcs = ["auditor_test.go"],
     embed = [":go_default_library"],
-    deps = ["//lib/dockerregistry:go_default_library"],
+    deps = [
+        "//lib/dockerregistry:go_default_library",
+        "//lib/logclient:go_default_library",
+        "//lib/remotemanifest:go_default_library",
+        "//lib/report:go_default_library",
+    ],
 )

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -190,9 +190,10 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	logInfo.Printf("(%s) gcrPayload: %v", s.ID, gcrPayload)
 	logInfo.Printf("(%s) RemoteManifestFacility: %v", s.ID, s.RemoteManifestFacility)
 
-	// (3) Compare GCR state change with the intent of the promoter manifests.
+	// (3) Compare GCR state change with the intent of the promoter manifests
+	// (exact digest match on a tagged or tagless image).
 	for _, manifest := range manifests {
-		if manifest.Contains(*gcrPayload) {
+		if manifest.Contains(*gcrPayload)&(reg.FlagDigestMatched|reg.FlagTagMatched) != 0 {
 			msg := fmt.Sprintf(
 				"(%s) TRANSACTION VERIFIED: %v: agrees with manifest\n", s.ID, gcrPayload)
 			logInfo.Println(msg)

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -253,7 +253,6 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 		true,
 		s.GcrReadingFacility.ReadRepo)
 	sc.ReadGCRManifestLists(s.GcrReadingFacility.ReadManifestList)
-	klog.Infof("sc.ParentDigest is: %v", sc.ParentDigest)
 	var childDigest reg.Digest
 	childImageParts := strings.Split(gcrPayload.Digest, "@")
 	if len(childImageParts) != 2 {

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -261,8 +261,8 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	sc.ReadRegistries(
 		[]reg.RegistryContext{srcRegistry},
 		true,
-		reg.MkReadRepositoryCmdReal)
-	sc.ReadGCRManifestLists(reg.MkReadManifestListCmdReal)
+		s.GcrReadingFacility.ReadRepo)
+	sc.ReadGCRManifestLists(s.GcrReadingFacility.ReadManifestList)
 	klog.Infof("sc.ParentDigest is: %v", sc.ParentDigest)
 	var childDigest reg.Digest
 	childImageParts := strings.Split(gcrPayload.Digest, "@")

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -128,11 +128,17 @@ func ParsePubSubMessage(r *http.Request) (*reg.GCRPubSubPayload, error) {
 		return nil, fmt.Errorf(
 			"%v: deletions are prohibited", gcrPayload)
 	case "INSERT":
-		return &gcrPayload, nil
+		break
 	default:
 		return nil, fmt.Errorf(
 			"gcrPayload: unknown action %q", gcrPayload.Action)
 	}
+
+	if err := gcrPayload.PopulateExtraFields(); err != nil {
+		return nil, err
+	}
+
+	return &gcrPayload, nil
 }
 
 // Audit receives and processes a Pub/Sub push message. It has 3 parts: (1)

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -111,9 +111,9 @@ func ParsePubSubMessage(r *http.Request) (*reg.GCRPubSubPayload, error) {
 		return nil, fmt.Errorf("json.Unmarshal: %v", err)
 	}
 
-	if len(gcrPayload.Digest) == 0 && len(gcrPayload.Tag) == 0 {
+	if len(gcrPayload.FQIN) == 0 && len(gcrPayload.PQIN) == 0 {
 		return nil, fmt.Errorf(
-			"gcrPayload: neither Digest nor Tag was specified")
+			"gcrPayload: neither 'digest' nor 'tag' was specified")
 	}
 
 	switch gcrPayload.Action {
@@ -254,9 +254,9 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 		s.GcrReadingFacility.ReadRepo)
 	sc.ReadGCRManifestLists(s.GcrReadingFacility.ReadManifestList)
 	var childDigest reg.Digest
-	childImageParts := strings.Split(gcrPayload.Digest, "@")
+	childImageParts := strings.Split(gcrPayload.FQIN, "@")
 	if len(childImageParts) != 2 {
-		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: could not split child digest information: %v", s.ID, gcrPayload.Digest)
+		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: could not split child digest information: %v", s.ID, gcrPayload.FQIN)
 		_, _ = w.Write([]byte(msg))
 		panic(msg)
 	}
@@ -304,5 +304,5 @@ func GetMatchingSourceRegistry(
 	return reg.RegistryContext{},
 		fmt.Errorf(
 			"could not find matching source registry for %v",
-			gcrPayload.Digest)
+			gcrPayload.FQIN)
 }

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -203,8 +203,8 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	// (exact digest match on a tagged or tagless image).
 	for _, manifest := range manifests {
 		m := gcrPayload.Match(manifest)
-		if m&(reg.FlagDigestMatched|reg.FlagTagMatched) != 0 &&
-			m&(reg.FlagTagMismatch) == 0 {
+		if (m.DigestMatch || m.TagMatch) &&
+			!m.TagMismatch {
 			msg := fmt.Sprintf(
 				"(%s) TRANSACTION VERIFIED: %v: agrees with manifest\n", s.ID, gcrPayload)
 			logInfo.Println(msg)
@@ -297,10 +297,10 @@ func GetMatchingSourceRegistry(
 ) (reg.RegistryContext, error) {
 
 	for _, manifest := range manifests {
-		if gcrPayload.Match(manifest) == 0 {
+		if !gcrPayload.Match(manifest).PathMatch {
 			continue
 		}
-		// Now that there is a match (at least a FlagPathMatch), just fish out
+		// Now that there is a match (at least a PathMatch), just fish out
 		// the source registry in the manifest.
 		for _, rc := range manifest.Registries {
 			if rc.Src {

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -94,6 +94,8 @@ func (s *ServerContext) RunAuditor() {
 }
 
 // ParsePubSubMessage parses an HTTP request body into a reg.GCRPubSubPayload.
+//
+// nolint[gocyclo]
 func ParsePubSubMessage(r *http.Request) (*reg.GCRPubSubPayload, error) {
 	var psm PubSubMessage
 	var gcrPayload reg.GCRPubSubPayload

--- a/lib/audit/auditor_test.go
+++ b/lib/audit/auditor_test.go
@@ -38,8 +38,9 @@ import (
 func checkMatch(haystack []byte, re *regexp.Regexp) error {
 	if !re.Match(haystack) {
 		return fmt.Errorf(
-			`!!! COULD NOT FIND MATCH FOR %q`,
-			re.String())
+			"===BEGIN-MESSAGE===\nCOULD NOT FIND MATCH FOR %q IN\n%s\n===END-MESSAGE===",
+			re.String(),
+			haystack)
 	}
 	return nil
 }

--- a/lib/audit/auditor_test.go
+++ b/lib/audit/auditor_test.go
@@ -17,15 +17,22 @@ limitations under the License.
 package audit
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
 	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
 )
 
 func checkEqual(got, expected interface{}) error {
@@ -127,4 +134,287 @@ func TestParsePubSubMessage(t *testing.T) {
 		errEqual := checkEqual(gotErr, test.expected)
 		checkError(t, errEqual, "checkError: test: shouldBeInValid\n")
 	}
+}
+
+func TestAudit(t *testing.T) {
+	// Regression test case for
+	// https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/191.
+	manifests := []reg.Manifest{
+		{
+			Registries: []reg.RegistryContext{
+				{
+					Name: "gcr.io/k8s-staging-kas-network-proxy",
+					Src:  true,
+				},
+				{
+					Name:           "us.gcr.io/k8s-artifacts-prod/kas-network-proxy",
+					ServiceAccount: "foobar@google-containers.iam.gserviceaccount.com",
+				},
+			},
+
+			Images: []reg.Image{
+				{
+					ImageName: "proxy-agent",
+					Dmap: reg.DigestTags{
+						"sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32": {"v0.0.8"},
+					},
+				},
+			},
+		},
+	}
+
+	var shouldBeValid = []struct {
+		name             string
+		payload          reg.GCRPubSubPayload
+		readRepo         map[string]string
+		readManifestList map[string]string
+		expectedPattern  string
+	}{
+		{
+			"basic child manifest (tagless child image, digest not in promoter manifest, but parent image is in promoter manifest)",
+			reg.GCRPubSubPayload{
+				Action: "INSERT",
+				Digest: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:8735603bbd7153b8bfc8d2460481282bb44e2e830e5b237738e5c3e2a58c8f45",
+				Tag:    "",
+			},
+			map[string]string{
+				"gcr.io/k8s-staging-kas-network-proxy": `{
+  "child": [
+    "proxy-agent"
+  ],
+  "manifest": {},
+  "name": "k8s-staging-kas-network-proxy",
+  "tags": []
+}`,
+				"gcr.io/k8s-staging-kas-network-proxy/proxy-agent": `{
+  "child": [],
+  "manifest": {
+    "sha256:43273b274ee48f7fd7fc09bc82e7e75ddc596ca219fd9b522b1701bebec6ceff": {
+      "imageSizeBytes": "6843680",
+      "layerId": "",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tag": [],
+      "timeCreatedMs": "1583451840426",
+      "timeUploadedMs": "1583475320110"
+    },
+    "sha256:7bcbdf4cb26400ac576b33718000f0b630290dcf6380be3f60e33e5ba0461d31": {
+      "imageSizeBytes": "7367874",
+      "layerId": "",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tag": [],
+      "timeCreatedMs": "1583451717939",
+      "timeUploadedMs": "1583475314214"
+    },
+    "sha256:8735603bbd7153b8bfc8d2460481282bb44e2e830e5b237738e5c3e2a58c8f45": {
+      "imageSizeBytes": "7396163",
+      "layerId": "",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tag": [],
+      "timeCreatedMs": "1583451882087",
+      "timeUploadedMs": "1583475321761"
+    },
+    "sha256:99bade313218f3e6e63fdeb87bcddbf3a134aaa9e45e633be5ee5e60ddaac667": {
+      "imageSizeBytes": "6888230",
+      "layerId": "",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tag": [],
+      "timeCreatedMs": "1583451799250",
+      "timeUploadedMs": "1583475318193"
+    },
+    "sha256:c1ccf44d6b6fe49fc8506f7571f4a988ad69eb00c7747cd2b307b5e5b125a1f1": {
+      "imageSizeBytes": "6888983",
+      "layerId": "",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tag": [],
+      "timeCreatedMs": "1583451758583",
+      "timeUploadedMs": "1583475316361"
+    },
+    "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32": {
+      "imageSizeBytes": "0",
+      "layerId": "",
+      "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+      "tag": [
+        "v0.0.8"
+      ],
+      "timeCreatedMs": "0",
+      "timeUploadedMs": "1583475321879"
+    }
+  },
+  "name": "k8s-staging-kas-network-proxy/proxy-agent",
+  "tags": [
+    "v0.0.8"
+  ]
+}`,
+			},
+			map[string]string{
+				// This is the response for reading the manifest for the parent
+				// image by digest.
+				"gcr.io/k8s-staging-kas-network-proxy/proxy-agent@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32": `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:7bcbdf4cb26400ac576b33718000f0b630290dcf6380be3f60e33e5ba0461d31",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:c1ccf44d6b6fe49fc8506f7571f4a988ad69eb00c7747cd2b307b5e5b125a1f1",
+         "platform": {
+            "architecture": "arm",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:99bade313218f3e6e63fdeb87bcddbf3a134aaa9e45e633be5ee5e60ddaac667",
+         "platform": {
+            "architecture": "arm64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:43273b274ee48f7fd7fc09bc82e7e75ddc596ca219fd9b522b1701bebec6ceff",
+         "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:8735603bbd7153b8bfc8d2460481282bb44e2e830e5b237738e5c3e2a58c8f45",
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         }
+      }
+   ]
+}`,
+			},
+			`TRANSACTION VERIFIED`,
+		},
+	}
+
+	for _, test := range shouldBeValid {
+
+		// Create a new ResponseRecorder to record the response from Audit().
+		w := httptest.NewRecorder()
+
+		// Create a new Request to pass to the handler, which incorporates the
+		// GCRPubSubPayload.
+		payload, err := json.Marshal(test.payload)
+		checkError(t, err, "checkError: test: shouldBeValid (payload)\n")
+
+		psm := PubSubMessage{
+			Message: PubSubMessageInner{
+				Data: payload,
+				ID:   "1"},
+			Subscription: "2"}
+		b, err := json.Marshal(psm)
+		checkError(t, err, "checkError: test: shouldBeValid (psm)\n")
+
+		r, err := http.NewRequest("POST", "/", bytes.NewBuffer(b))
+		checkError(t, err, "checkError: test: shouldBeValid (NewRequest)\n")
+
+		// test is used to pin the "test" variable from the outer "range" scope
+		// (see scopelint) into the fakeReadRepo (in a sense it ensures that
+		// fakeReadRepo closes over "test" in the outer scope, as a closure
+		// should).
+		test := test
+		fakeReadRepo := func(sc *reg.SyncContext, rc reg.RegistryContext) stream.Producer {
+			var sr stream.Fake
+
+			_, domain, repoPath := reg.GetTokenKeyDomainRepoPath(rc.Name)
+			key := fmt.Sprintf("%s/%s", domain, repoPath)
+			fakeHTTPBody, ok := test.readRepo[key]
+			if !ok {
+				checkError(
+					t,
+					fmt.Errorf("could not read fakeHTTPBody"),
+					fmt.Sprintf("Test: %v\n", test.name))
+			}
+			sr.Bytes = []byte(fakeHTTPBody)
+			return &sr
+		}
+
+		fakeReadManifestList := func(sc *reg.SyncContext, gmlc reg.GCRManifestListContext) stream.Producer {
+			var sr stream.Fake
+
+			_, domain, repoPath := reg.GetTokenKeyDomainRepoPath(gmlc.RegistryContext.Name)
+			key := fmt.Sprintf("%s/%s/%s@%s",
+				domain,
+				repoPath,
+				gmlc.ImageName,
+				gmlc.Digest)
+			fakeHTTPBody, ok := test.readManifestList[key]
+			if !ok {
+				checkError(
+					t,
+					fmt.Errorf("could not read fakeHTTPBody"),
+					fmt.Sprintf("Test: %v\n", test.name))
+			}
+			sr.Bytes = []byte(fakeHTTPBody)
+			return &sr
+		}
+
+		reportingFacility := report.NewFakeReportingClient()
+		loggingFacility := logclient.NewFakeLogClient()
+
+		s := initFakeServerContext(
+			manifests,
+			reportingFacility,
+			loggingFacility,
+			fakeReadRepo,
+			fakeReadManifestList)
+
+		// Handle the request.
+		s.Audit(w, r)
+
+		// Check what happened!
+		if status := w.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
+
+		infoBuffer := loggingFacility.GetInfoBuffer()
+
+		re := regexp.MustCompile(test.expectedPattern)
+		if !re.Match(infoBuffer.Bytes()) {
+			t.Errorf("transaction was not verified")
+		}
+	}
+}
+
+func initFakeServerContext(
+	manifests []reg.Manifest,
+	reportingFacility report.ReportingFacility,
+	loggingFacility logclient.LoggingFacility,
+	fakeReadRepo func(*reg.SyncContext, reg.RegistryContext) stream.Producer,
+	fakeReadManifestList func(*reg.SyncContext, reg.GCRManifestListContext) stream.Producer,
+) ServerContext {
+
+	remoteManifestFacility := remotemanifest.NewFake(manifests)
+
+	serverContext := ServerContext{
+		ID:                     "cafec0ffee",
+		RemoteManifestFacility: remoteManifestFacility,
+		ErrorReportingFacility: reportingFacility,
+		LoggingFacility:        loggingFacility,
+		GcrReadingFacility: GcrReadingFacility{
+			ReadRepo:         fakeReadRepo,
+			ReadManifestList: fakeReadManifestList,
+		},
+	}
+
+	return serverContext
 }

--- a/lib/audit/auditor_test.go
+++ b/lib/audit/auditor_test.go
@@ -74,12 +74,12 @@ func TestParsePubSubMessage(t *testing.T) {
 	shouldBeValid := []reg.GCRPubSubPayload{
 		{
 			Action: "INSERT",
-			Digest: "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			FQIN:   "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 		},
 		{
 			Action: "INSERT",
-			Digest: "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-			Tag:    "gcr.io/foo/bar:1.0",
+			FQIN:   "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			PQIN:   "gcr.io/foo/bar:1.0",
 		},
 	}
 
@@ -118,23 +118,23 @@ func TestParsePubSubMessage(t *testing.T) {
 		{
 			reg.GCRPubSubPayload{
 				Action: "INSERT"},
-			fmt.Errorf("gcrPayload: neither Digest nor Tag was specified"),
+			fmt.Errorf("gcrPayload: neither 'digest' nor 'tag' was specified"),
 		},
 		{
 			reg.GCRPubSubPayload{
-				Digest: "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+				FQIN: "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
 			fmt.Errorf("gcrPayload: Action not specified"),
 		},
 		{
 			reg.GCRPubSubPayload{
 				Action: "DELETE",
-				Digest: "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
-			fmt.Errorf("{DELETE gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000 }: deletions are prohibited"),
+				FQIN:   "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			fmt.Errorf("{DELETE gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000    }: deletions are prohibited"),
 		},
 		{
 			reg.GCRPubSubPayload{
 				Action: "WOOF",
-				Digest: "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+				FQIN:   "gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
 			fmt.Errorf("gcrPayload: unknown action \"WOOF\""),
 		},
 	}
@@ -192,8 +192,8 @@ func TestAudit(t *testing.T) {
 			"basic child manifest (tagless child image, digest not in promoter manifest, but parent image is in promoter manifest)",
 			reg.GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:8735603bbd7153b8bfc8d2460481282bb44e2e830e5b237738e5c3e2a58c8f45",
-				Tag:    "",
+				FQIN:   "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:8735603bbd7153b8bfc8d2460481282bb44e2e830e5b237738e5c3e2a58c8f45",
+				PQIN:   "",
 			},
 			map[string]string{
 				"gcr.io/k8s-staging-kas-network-proxy": `{

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -17,10 +17,21 @@ limitations under the License.
 package audit
 
 import (
+	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
+	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
 )
+
+// GcrReadingFacility holds functions used to create streams for reading the
+// repository and manifest list.
+//
+// nolint[lll]
+type GcrReadingFacility struct {
+	ReadRepo         func(*reg.SyncContext, reg.RegistryContext) stream.Producer
+	ReadManifestList func(*reg.SyncContext, reg.GCRManifestListContext) stream.Producer
+}
 
 // ServerContext holds all of the initialization data for the server to start
 // up.
@@ -29,6 +40,7 @@ type ServerContext struct {
 	RemoteManifestFacility remotemanifest.Facility
 	ErrorReportingFacility report.ReportingFacility
 	LoggingFacility        logclient.LoggingFacility
+	GcrReadingFacility     GcrReadingFacility
 }
 
 // PubSubMessageInner is the inner struct that holds the actual Pub/Sub

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2643,3 +2643,33 @@ func (payload GCRPubSubPayload) matchImage(
 	}
 	return r
 }
+
+// PopulateExtraFields takes the existing fields in GCRPubSubPayload and uses
+// them to populate the un-exported (hidden) fields. This is because the payload
+// bundles up digests, tags, etc into a single string. Instead of dealing with
+// them later on, we just break them up into the pieces we would like to use.
+func (payload *GCRPubSubPayload) PopulateExtraFields() error {
+	// Populate digest, if found.
+	if len(payload.FQIN) > 0 {
+		parsed := strings.Split(payload.FQIN, "@")
+		// nolint[gomnd]
+		if len(parsed) != 2 {
+			return fmt.Errorf("invalid FQIN: %v", payload.FQIN)
+		}
+		payload.digest = Digest(parsed[1])
+		payload.path = parsed[0]
+	}
+
+	// Populate tag, if found.
+	if len(payload.PQIN) > 0 {
+		parsed := strings.Split(payload.PQIN, ":")
+		// nolint[gomnd]
+		if len(parsed) != 2 {
+			return fmt.Errorf("invalid PQIN: %v", payload.PQIN)
+		}
+		payload.tag = Tag(parsed[1])
+		payload.path = parsed[0]
+	}
+
+	return nil
+}

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2220,11 +2220,7 @@ func MkRequestCapturer(captured *CapturedRequests) ProcessRequest {
 		for req := range reqs {
 			pr := req.RequestParams.(PromotionRequest)
 			mutex.Lock()
-			if _, ok := (*captured)[pr]; ok {
-				(*captured)[pr]++
-			} else {
-				(*captured)[pr] = 1
-			}
+			(*captured)[pr]++
 			mutex.Unlock()
 			wg.Add(-1)
 		}

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2579,7 +2579,7 @@ func (payload GCRPubSubPayload) matchImages(
 	}
 	// Speed up the search by skipping over registry names whose leading
 	// characters do not match.
-	if !strings.HasPrefix(payload.Digest, (string)(rc.Name)) {
+	if !strings.HasPrefix(payload.FQIN, (string)(rc.Name)) {
 		return r
 	}
 
@@ -2601,20 +2601,19 @@ func (payload GCRPubSubPayload) matchImage(
 
 	var r GcrPayloadMatch
 
-	if !strings.Contains(payload.Digest, (string)(image.ImageName)) {
+	if !strings.Contains(payload.FQIN, (string)(image.ImageName)) {
 		return r
 	}
 	r |= FlagPathMatched
 	for digest, tags := range image.Dmap {
 		fqin := ToFQIN(rc.Name, image.ImageName, digest)
-		// The payload.Digest field actually holds the FQIN.
-		if payload.Digest != fqin {
+		if payload.FQIN != fqin {
 			continue
 		}
 		r |= FlagDigestMatched
 
 		// Now perform an additional check on the Tag, if that field is
-		// available. I.e., if payload.Tag is non-empty, a
+		// available. I.e., if payload.PQIN is non-empty, a
 		// particular PQIN change occurred in GCR. Such a change
 		// MUST match both the digest and tag combination as set out
 		// in the manifest.
@@ -2622,13 +2621,12 @@ func (payload GCRPubSubPayload) matchImage(
 		// Matching solely on the tag (but not digest) or vice versa
 		// goes AGAINST the intent of the promoter manifest and is
 		// cause for alarm!
-		if len(payload.Tag) == 0 {
+		if len(payload.PQIN) == 0 {
 			continue
 		}
 		for _, tag := range tags {
 			pqin := ToPQIN(rc.Name, image.ImageName, tag)
-			// The payload.Tag field actually holds the PQIN.
-			if payload.Tag == pqin {
+			if payload.PQIN == pqin {
 				r |= FlagTagMatched
 			}
 		}

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2527,8 +2527,11 @@ func GetDeleteCmd(
 		cmd)
 }
 
-// GcrPayloadMatch holds flags for matching a GCRPubSubPayload against a
+// GcrPayloadMatch holds bitwise flags for matching a GCRPubSubPayload against a
 // promoter manifest.
+//
+// For an example of how bitwise flags work, see
+// https://yourbasic.org/golang/bitmask-flag-set-clear/.
 type GcrPayloadMatch uint
 
 const (

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2565,11 +2565,7 @@ func TestGarbageCollection(t *testing.T) {
 		for req := range reqs {
 			pr := req.RequestParams.(PromotionRequest)
 			mutex.Lock()
-			if _, ok := captured[pr]; ok {
-				captured[pr]++
-			} else {
-				captured[pr] = 1
-			}
+			captured[pr]++
 			mutex.Unlock()
 			wg.Add(-1)
 		}
@@ -2705,11 +2701,7 @@ func TestGarbageCollectionMulti(t *testing.T) {
 		for req := range reqs {
 			pr := req.RequestParams.(PromotionRequest)
 			mutex.Lock()
-			if _, ok := captured[pr]; ok {
-				captured[pr]++
-			} else {
-				captured[pr] = 1
-			}
+			captured[pr]++
 			mutex.Unlock()
 			wg.Add(-1)
 		}

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2902,7 +2902,7 @@ func TestParseContainerParts(t *testing.T) {
 	}
 }
 
-func TestContains(t *testing.T) {
+func TestMatch(t *testing.T) {
 	inputMfest := Manifest{
 		Registries: []RegistryContext{
 			{
@@ -2988,7 +2988,7 @@ func TestContains(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		contains := test.mfest.Contains(test.gcrPayload)
+		contains := test.gcrPayload.Match(test.mfest)
 		errEqual := checkEqual(contains, test.expectedContains)
 		checkError(t, errEqual, fmt.Sprintf("checkError: test %q: shouldBeValid\n", test.name))
 	}

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2935,7 +2935,7 @@ func TestContains(t *testing.T) {
 		name             string
 		mfest            Manifest
 		gcrPayload       GCRPubSubPayload
-		expectedContains bool
+		expectedContains GcrPayloadMatch
 	}{
 		{
 			"INSERT message contains both Digest and Tag",
@@ -2945,7 +2945,7 @@ func TestContains(t *testing.T) {
 				Digest: "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
 			},
-			true,
+			FlagPathMatched | FlagDigestMatched | FlagTagMatched,
 		},
 		{
 			"INSERT message only contains Digest",
@@ -2954,36 +2954,36 @@ func TestContains(t *testing.T) {
 				Action: "INSERT",
 				Digest: "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			true,
+			FlagPathMatched | FlagDigestMatched,
 		},
 		{
-			"INSERT's digest is not in Manifest (digest only)",
+			"INSERT's digest is not in Manifest (digest only, but path matched)",
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
 				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
 			},
-			false,
+			FlagPathMatched,
 		},
 		{
-			"INSERT's digest is not in Manifest (tag specified)",
-			inputMfest,
-			GCRPubSubPayload{
-				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
-				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
-			},
-			false,
-		},
-		{
-			"INSERT's digest is not in Manifest (tag specified)",
+			"INSERT's digest is not in Manifest (tag specified, but path matched)",
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
 				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
 				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
 			},
-			false,
+			FlagPathMatched,
+		},
+		{
+			"INSERT's digest is not in Manifest (tag specified, but path matched)",
+			inputMfest,
+			GCRPubSubPayload{
+				Action: "INSERT",
+				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
+				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
+			},
+			FlagPathMatched,
 		},
 	}
 

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2932,10 +2932,10 @@ func TestMatch(t *testing.T) {
 		},
 		filepath: "a/promoter-manifest.yaml"}
 	var tests = []struct {
-		name             string
-		mfest            Manifest
-		gcrPayload       GCRPubSubPayload
-		expectedContains GcrPayloadMatch
+		name          string
+		mfest         Manifest
+		gcrPayload    GCRPubSubPayload
+		expectedMatch GcrPayloadMatch
 	}{
 		{
 			"INSERT message contains both Digest and Tag",
@@ -2957,7 +2957,7 @@ func TestMatch(t *testing.T) {
 			FlagPathMatched | FlagDigestMatched,
 		},
 		{
-			"INSERT's digest is not in Manifest (digest only, but path matched)",
+			"INSERT's digest is not in Manifest (digest mismatch, but path matched)",
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
@@ -2966,7 +2966,7 @@ func TestMatch(t *testing.T) {
 			FlagPathMatched,
 		},
 		{
-			"INSERT's digest is not in Manifest (tag specified, but path matched)",
+			"INSERT's digest is not in Manifest (neither digest nor tag match, but path matched)",
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
@@ -2976,20 +2976,20 @@ func TestMatch(t *testing.T) {
 			FlagPathMatched,
 		},
 		{
-			"INSERT's digest is not in Manifest (tag specified, but path matched)",
+			"INSERT's digest is not in Manifest (tag specified, but tag mismatch)",
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
-				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
+				Digest: "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Tag:    "us.gcr.io/some-prod/foo-controller:white-powder",
 			},
-			FlagPathMatched,
+			FlagPathMatched | FlagDigestMatched | FlagTagMismatch,
 		},
 	}
 
 	for _, test := range tests {
-		contains := test.gcrPayload.Match(test.mfest)
-		errEqual := checkEqual(contains, test.expectedContains)
+		got := test.gcrPayload.Match(test.mfest)
+		errEqual := checkEqual(got, test.expectedMatch)
 		checkError(t, errEqual, fmt.Sprintf("checkError: test %q: shouldBeValid\n", test.name))
 	}
 }

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2937,7 +2937,11 @@ func TestMatch(t *testing.T) {
 				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				PQIN:   "us.gcr.io/some-prod/foo-controller:1.0",
 			},
-			FlagPathMatched | FlagDigestMatched | FlagTagMatched,
+			GcrPayloadMatch{
+				PathMatch:   true,
+				DigestMatch: true,
+				TagMatch:    true,
+			},
 		},
 		{
 			"INSERT message only contains Digest",
@@ -2946,7 +2950,10 @@ func TestMatch(t *testing.T) {
 				Action: "INSERT",
 				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			FlagPathMatched | FlagDigestMatched,
+			GcrPayloadMatch{
+				PathMatch:   true,
+				DigestMatch: true,
+			},
 		},
 		{
 			"INSERT's digest is not in Manifest (digest mismatch, but path matched)",
@@ -2955,7 +2962,9 @@ func TestMatch(t *testing.T) {
 				Action: "INSERT",
 				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:000",
 			},
-			FlagPathMatched,
+			GcrPayloadMatch{
+				PathMatch: true,
+			},
 		},
 		{
 			"INSERT's digest is not in Manifest (neither digest nor tag match, but path matched)",
@@ -2965,7 +2974,9 @@ func TestMatch(t *testing.T) {
 				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:000",
 				PQIN:   "us.gcr.io/some-prod/foo-controller:1.0",
 			},
-			FlagPathMatched,
+			GcrPayloadMatch{
+				PathMatch: true,
+			},
 		},
 		{
 			"INSERT's digest is not in Manifest (tag specified, but tag mismatch)",
@@ -2975,7 +2986,11 @@ func TestMatch(t *testing.T) {
 				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				PQIN:   "us.gcr.io/some-prod/foo-controller:white-powder",
 			},
-			FlagPathMatched | FlagDigestMatched | FlagTagMismatch,
+			GcrPayloadMatch{
+				PathMatch:   true,
+				DigestMatch: true,
+				TagMismatch: true,
+			},
 		},
 	}
 

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2988,6 +2988,7 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test.gcrPayload.PopulateExtraFields()
 		got := test.gcrPayload.Match(test.mfest)
 		errEqual := checkEqual(got, test.expectedMatch)
 		checkError(t, errEqual, fmt.Sprintf("checkError: test %q: shouldBeValid\n", test.name))

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2942,8 +2942,8 @@ func TestMatch(t *testing.T) {
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
+				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				PQIN:   "us.gcr.io/some-prod/foo-controller:1.0",
 			},
 			FlagPathMatched | FlagDigestMatched | FlagTagMatched,
 		},
@@ -2952,7 +2952,7 @@ func TestMatch(t *testing.T) {
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 			FlagPathMatched | FlagDigestMatched,
 		},
@@ -2961,7 +2961,7 @@ func TestMatch(t *testing.T) {
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
+				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:000",
 			},
 			FlagPathMatched,
 		},
@@ -2970,8 +2970,8 @@ func TestMatch(t *testing.T) {
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:000",
-				Tag:    "us.gcr.io/some-prod/foo-controller:1.0",
+				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:000",
+				PQIN:   "us.gcr.io/some-prod/foo-controller:1.0",
 			},
 			FlagPathMatched,
 		},
@@ -2980,8 +2980,8 @@ func TestMatch(t *testing.T) {
 			inputMfest,
 			GCRPubSubPayload{
 				Action: "INSERT",
-				Digest: "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				Tag:    "us.gcr.io/some-prod/foo-controller:white-powder",
+				FQIN:   "us.gcr.io/some-prod/foo-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				PQIN:   "us.gcr.io/some-prod/foo-controller:white-powder",
 			},
 			FlagPathMatched | FlagDigestMatched | FlagTagMismatch,
 		},

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -366,11 +366,21 @@ type digest struct {
 // nolint[lll]
 type GCRPubSubPayload struct {
 	Action string `json:"action"`
-	// Digest is always a FQIN. E.g.,
-	// "gcr.io/linusa/small@sha256:35f442d8d56cc7a2d4000f3417d71f44a730b900f3df440c09a9c40c42c40f86".
-	Digest string `json:"digest,omitempty"`
-	// Tag is always a PQIN. E.g., "gcr.io/linusa/small:a".
-	Tag string `json:"tag,omitempty"`
+	// The payload field is "digest", but really it is a FQIN like
+	//  "gcr.io/linusa/small@sha256:35f442d8d56cc7a2d4000f3417d71f44a730b900f3df440c09a9c40c42c40f86".
+	FQIN string `json:"digest,omitempty"`
+	// Similarly, the field "tag is always a PQIN. E.g.,
+	// "gcr.io/linusa/small:a".
+	PQIN string `json:"tag,omitempty"`
+
+	// Everything leading up to either the tag or digest. E.g., given
+	// "us.gcr.io/k8s-artifacts-prod/foo/bar:1.0", this would be
+	// "us.gcr.io/k8s-artifacts-prod/foo/bar".
+	path string
+	// Image digest, if any.
+	digest Digest
+	// Tag, if any.
+	tag Tag
 }
 
 // Various conversion functions.

--- a/lib/logclient/fake.go
+++ b/lib/logclient/fake.go
@@ -17,14 +17,15 @@ limitations under the License.
 package logclient
 
 import (
+	"bytes"
 	"log"
-	"os"
 )
 
 // FakeLogClient is a fake log client.
 type FakeLogClient struct {
 	// Because this is fake, there is no actual logging client.
 	loggers [3]*log.Logger
+	buffers [3]bytes.Buffer
 }
 
 // Close is a NOP (there is nothing to close).
@@ -45,16 +46,31 @@ func (c *FakeLogClient) GetAlertLogger() *log.Logger {
 	return c.loggers[IndexLogAlert]
 }
 
+// GetInfoBuffer exposes the internal Info logger's buffer.
+func (c *FakeLogClient) GetInfoBuffer() bytes.Buffer {
+	return c.buffers[IndexLogInfo]
+}
+
+// GetErrorBuffer exposes the internal Error logger's buffer.
+func (c *FakeLogClient) GetErrorBuffer() bytes.Buffer {
+	return c.buffers[IndexLogError]
+}
+
+// GetAlertBuffer exposes the internal Alert logger's buffer.
+func (c *FakeLogClient) GetAlertBuffer() bytes.Buffer {
+	return c.buffers[IndexLogAlert]
+}
+
 // NewFakeLogClient returns a new FakeLogClient.
 func NewFakeLogClient() *FakeLogClient {
 	c := FakeLogClient{}
 
 	c.loggers[IndexLogInfo] = log.
-		New(os.Stderr, "FAKE-INFO", log.LstdFlags)
+		New(&c.buffers[IndexLogInfo], "FAKE-INFO", log.LstdFlags)
 	c.loggers[IndexLogError] = log.
-		New(os.Stderr, "FAKE-ERROR", log.LstdFlags)
+		New(&c.buffers[IndexLogError], "FAKE-ERROR", log.LstdFlags)
 	c.loggers[IndexLogAlert] = log.
-		New(os.Stderr, "FAKE-ALERT", log.LstdFlags)
+		New(&c.buffers[IndexLogAlert], "FAKE-ALERT", log.LstdFlags)
 
 	return &c
 }

--- a/lib/logclient/types.go
+++ b/lib/logclient/types.go
@@ -23,7 +23,7 @@ import (
 
 // These constants refer to the logging levels.
 const (
-	IndexLogInfo = 0
+	IndexLogInfo = iota
 	IndexLogError
 	IndexLogAlert
 )

--- a/lib/report/fake.go
+++ b/lib/report/fake.go
@@ -17,15 +17,21 @@ limitations under the License.
 package report
 
 import (
+	"bytes"
 	"log"
-	"os"
 
 	"cloud.google.com/go/errorreporting"
 )
 
 // FakeReportingClient is a fake reporting client.
 type FakeReportingClient struct {
-	reporter *log.Logger
+	reporter     *log.Logger
+	reportBuffer bytes.Buffer
+}
+
+// GetReportBuffer retrieves the reportBuffer.
+func (c *FakeReportingClient) GetReportBuffer() bytes.Buffer {
+	return c.reportBuffer
 }
 
 // Report simply prints the entry to STDERR. Nothing goes over the network!
@@ -42,8 +48,7 @@ func (c *FakeReportingClient) Close() error { return nil }
 // reporter initialized to a basic logger to STDERR.
 func NewFakeReportingClient() *FakeReportingClient {
 	c := FakeReportingClient{}
-
-	c.reporter = log.New(os.Stderr, "FAKE-REPORT", log.LstdFlags)
+	c.reporter = log.New(&c.reportBuffer, "FAKE-REPORT", log.LstdFlags)
 
 	return &c
 }

--- a/test-e2e/cip-auditor/tests.yaml
+++ b/test-e2e/cip-auditor/tests.yaml
@@ -46,8 +46,8 @@
     - "gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166"
     - "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:2.0"
   logMatch:
-  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166 us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:1.0}: agrees with manifest"
-  - "TRANSACTION REJECTED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166 us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:2.0}: could not validate"
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166 us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:1.0 us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166 1.0}: agrees with manifest"
+  - "TRANSACTION REJECTED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166 us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:2.0 us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar sha256:408d6837313f95f081d5d02cc2691344c5781d43e98653f4af6cf9c1b8d26166 2.0}: could not validate"
 - name: "fatManifest"
   registries:
   # Staging.
@@ -83,7 +83,7 @@
   logMatch:
   # There should be 2 child images that were copied over as a result of copying
   # the fat manifest.
-  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:2af5205553239e0eb17c544bc1e90c2d6173012a191f0a44131aa2f9c44bb511 }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
-  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:2740382935148a02bf425a893d14848dd6238e405935440ce5c13b771a33f2fd }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:2af5205553239e0eb17c544bc1e90c2d6173012a191f0a44131aa2f9c44bb511  us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo sha256:2af5205553239e0eb17c544bc1e90c2d6173012a191f0a44131aa2f9c44bb511 }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:2740382935148a02bf425a893d14848dd6238e405935440ce5c13b771a33f2fd  us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo sha256:2740382935148a02bf425a893d14848dd6238e405935440ce5c13b771a33f2fd }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
   # Finally, the parent image itself should be verified.
-  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3 us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo:1.0}: agrees with manifest"
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3 us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo:1.0 us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3 1.0}: agrees with manifest"


### PR DESCRIPTION
This should fix https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/191

The problem was that the parsing around child manifests was not done correctly. I have added a unit test to cover this case.

Putting this up now for feedback. I still have to (1) add more unit tests for Audit() and (2) add an e2e test for the bug in #191. But I would like to do those in separate PRs as this PR is already pretty big.

/cc @justinsb @thockin @dims @bartsmykla 