### PR TITLE
WIP: add auditor e2e test for promoting an image to a subproject prefix

### DIFF
--- a/test-e2e/cip-auditor/fixture/fatManifest-subproject-different-prefix/images/foo/images.yaml
+++ b/test-e2e/cip-auditor/fixture/fatManifest-subproject-different-prefix/images/foo/images.yaml
@@ -1,0 +1,5 @@
+- name: foo
+  dmap:
+    # This is a fat manifest.
+    sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3:
+    - 1.0

--- a/test-e2e/cip-auditor/fixture/fatManifest-subproject-different-prefix/manifests/foo/promoter-manifest.yaml
+++ b/test-e2e/cip-auditor/fixture/fatManifest-subproject-different-prefix/manifests/foo/promoter-manifest.yaml
@@ -1,0 +1,6 @@
+registries:
+- name: gcr.io/k8s-gcr-audit-test-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com
+  src: true
+- name: us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com

--- a/test-e2e/cip-auditor/tests.yaml
+++ b/test-e2e/cip-auditor/tests.yaml
@@ -87,3 +87,40 @@
   - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:2740382935148a02bf425a893d14848dd6238e405935440ce5c13b771a33f2fd }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
   # Finally, the parent image itself should be verified.
   - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3 us.gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo:1.0}: agrees with manifest"
+# The main difference versus the plain "fatManifest" test is that the path
+# prefix "golden-foo" is NOT SHARED between the staging and prod repos here.
+- name: "fatManifest-subproject-different-prefix"
+  registries:
+  # Staging.
+  - name: gcr.io/k8s-gcr-audit-test-prod
+    service-account: k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com
+  # Prod.
+  - name: us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo
+    service-account: k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com
+  manifestDir: "/e2e-fixtures/fatManifest-subproject-different-prefix"
+  setupCip: []
+  setupExtra:
+  # Prepare the image to be stored in a more "subproject-y" location.
+  - - "gcloud"
+    - "--quiet"
+    - "container"
+    - "images"
+    - "add-tag"
+    - "gcr.io/k8s-gcr-audit-test-prod/golden-foo/foo@sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3"
+    - "gcr.io/k8s-gcr-audit-test-prod/foo:1.0"
+  mutations:
+  # Perform a mutation to promote to the subproject's prefix "subproject-foo" in prod.
+  - - "gcloud"
+    - "--quiet"
+    - "container"
+    - "images"
+    - "add-tag"
+    - "gcr.io/k8s-gcr-audit-test-prod/foo@sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3"
+    - "us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo/foo:1.0"
+  logMatch:
+  # There should be 2 child images that were copied over as a result of copying
+  # the fat manifest.
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo/foo@sha256:2af5205553239e0eb17c544bc1e90c2d6173012a191f0a44131aa2f9c44bb511 }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo/foo@sha256:2740382935148a02bf425a893d14848dd6238e405935440ce5c13b771a33f2fd }: agrees with manifest (parent digest sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3)"
+  # Finally, the parent image itself should be verified.
+  - "TRANSACTION VERIFIED: &{INSERT us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo/foo@sha256:a42e27f5d18d51c581efef2584ff9aebbfeffcb3145e81e52b1dccf62915e4a3 us.gcr.io/k8s-gcr-audit-test-prod/subproject-foo/foo:1.0}: agrees with manifest"


### PR DESCRIPTION
/hold

With #200 passing e2e tests, I am pushing this one up (*without* the fixes, but *with* the new e2e test) to see if I can reproduce what I've been seeing in production. Because why not?