### PR TITLE
SplitByKnownRegistries: ensure clean split

### DIFF
--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -864,6 +864,8 @@ func TestSplitByKnownRegistries(t *testing.T) {
 		// See
 		// https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/188.
 		`us.gcr.io/k8s-artifacts-prod/kube-state-metrics`,
+		`us.gcr.io/k8s-artifacts-prod/metrics-server`,
+		`us.gcr.io/k8s-artifacts-prod`,
 	}
 	knownRegistryContexts := make([]RegistryContext, 0)
 	for _, knownRegistryName := range knownRegistryNames {
@@ -884,6 +886,13 @@ func TestSplitByKnownRegistries(t *testing.T) {
 			`us.gcr.io/k8s-artifacts-prod/kube-state-metrics`,
 			`us.gcr.io/k8s-artifacts-prod`,
 			`kube-state-metrics`,
+			nil,
+		},
+		{
+			`unclean split (known repo cuts into middle of image name)`,
+			`us.gcr.io/k8s-artifacts-prod/metrics-server-amd64`,
+			`us.gcr.io/k8s-artifacts-prod`,
+			`metrics-server-amd64`,
 			nil,
 		},
 	}


### PR DESCRIPTION
We allowed cutting into the middle of an image. This resulted in repo
reads being mis-written into the wrong key, when populating the
SyncContext.Inv, in ReadRegistries. For example, the digests for

    us.gcr.io/k8s-artifacts-prod/metrics-server-amd64

were incorrectly assigned to the

    us.gcr.io/k8s-artifacts-prod/metrics-server

repo, under the image name "-amd64". This resulted in the promoter
thinking that there were no digests under
us.gcr.io/k8s-artifacts-prod/metrics-server-amd64 at all, resulting in
continued promotions to there. This has been fixed.

Also, this adds a unit test to ensure we don't suffer from a regression.

I noticed this behavior earlier today when the ci-k8sio-cip job kept promoting the same set of a handful of images over and over again (on each subsequent run). I've reproduced the behavior and added a test to fix.