### PR TITLE
auditor: separate validation failures from parse failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,7 @@ linters:
   - godox
   - gosec
   - stylecheck
+  - testpackage
   - whitespace
   - wsl
 

--- a/lib/audit/auditor_test.go
+++ b/lib/audit/auditor_test.go
@@ -20,12 +20,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"regexp"
-	"strings"
 	"testing"
 
 	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
@@ -70,7 +68,81 @@ func checkError(t *testing.T, err error, msg string) {
 	}
 }
 
-func TestParsePubSubMessage(t *testing.T) {
+func TestParsePubSubMessageBody(t *testing.T) {
+	toPsm := func(s string) PubSubMessage {
+		return PubSubMessage{
+			Message: PubSubMessageInner{
+				Data: []byte(s),
+				ID:   "1"},
+			Subscription: "2"}
+	}
+	var shouldBeValid = []struct {
+		name string
+		body string
+	}{
+		{
+			"nothing (missing keys, but is OK for just parsing from JSON)",
+			`{}`,
+		},
+		{
+			"regular insert, FQIN only",
+			`{"action": "INSERT", "digest": "gcr.io/foo/bar@sha256:000"}`,
+		},
+		{
+			"regular insert with both FQIN and PQIN",
+			`{"action": "INSERT", "digest": "gcr.io/foo/bar@sha256:000", "tag":"gcr.io/foo/bar:1.0"}`,
+		},
+		{
+			"deletion",
+			`{"action": "DELETE", "tag": "gcr.io/foo/bar:1.0"}`,
+		},
+	}
+
+	for _, test := range shouldBeValid {
+		psm := toPsm(test.body)
+		psmBytes, err := json.Marshal(psm)
+		if err != nil {
+			fmt.Println("could not Marshal psm")
+			t.Fail()
+		}
+
+		_, gotErr := ParsePubSubMessageBody(psmBytes)
+		errEqual := checkEqual(gotErr, nil)
+		checkError(t, errEqual, fmt.Sprintf("checkError: test: %q: shouldBeValid\n", test.name))
+	}
+
+	var shouldBeInvalid = []struct {
+		name        string
+		body        string
+		expectedErr error
+	}{
+		{
+			"malformed JSON",
+			`{`,
+			fmt.Errorf("json.Unmarshal (message data): unexpected end of JSON input"),
+		},
+		{
+			"incompatible type (int for string)",
+			`{"action": 1}`,
+			fmt.Errorf("json.Unmarshal (message data): json: cannot unmarshal number into Go struct field GCRPubSubPayload.action of type string"),
+		},
+	}
+
+	for _, test := range shouldBeInvalid {
+		psm := toPsm(test.body)
+		psmBytes, err := json.Marshal(psm)
+		if err != nil {
+			fmt.Println("could not Marshal psm")
+			t.Fail()
+		}
+
+		_, gotErr := ParsePubSubMessageBody(psmBytes)
+		errEqual := checkEqual(gotErr, test.expectedErr)
+		checkError(t, errEqual, fmt.Sprintf("checkError: test: %q: shouldBeInvalid\n", test.name))
+	}
+}
+
+func TestValidatePayload(t *testing.T) {
 	shouldBeValid := []reg.GCRPubSubPayload{
 		{
 			Action: "INSERT",
@@ -83,30 +155,8 @@ func TestParsePubSubMessage(t *testing.T) {
 		},
 	}
 
-	inputToHTTPReq := func(input reg.GCRPubSubPayload) *http.Request {
-		b, err := json.Marshal(&input)
-		if err != nil {
-			fmt.Println("11111111")
-			t.Fail()
-		}
-		psm := PubSubMessage{
-			Message: PubSubMessageInner{
-				Data: b,
-				ID:   "1"},
-			Subscription: "2"}
-
-		psmBytes, err := json.Marshal(psm)
-		if err != nil {
-			fmt.Println("22222222")
-			t.Fail()
-		}
-
-		return &http.Request{
-			Body: ioutil.NopCloser(strings.NewReader((string)(psmBytes)))}
-	}
-
 	for _, input := range shouldBeValid {
-		_, gotErr := ParsePubSubMessage(inputToHTTPReq(input))
+		gotErr := ValidatePayload(&input)
 		errEqual := checkEqual(gotErr, nil)
 		checkError(t, errEqual, "checkError: test: shouldBeValid\n")
 	}
@@ -140,7 +190,7 @@ func TestParsePubSubMessage(t *testing.T) {
 	}
 
 	for _, test := range shouldBeInValid {
-		_, gotErr := ParsePubSubMessage(inputToHTTPReq(test.input))
+		gotErr := ValidatePayload(&test.input)
 		errEqual := checkEqual(gotErr, test.expected)
 		checkError(t, errEqual, "checkError: test: shouldBeInValid\n")
 	}
@@ -394,10 +444,10 @@ func TestAudit(t *testing.T) {
 			readRepo1,
 			readManifestList1,
 			expectedPatterns{
-				report: []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
+				report: []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
 				info:   nil,
 				error:  nil,
-				alert:  []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
+				alert:  []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
 			},
 		},
 		{
@@ -411,10 +461,10 @@ func TestAudit(t *testing.T) {
 			readRepo1,
 			readManifestList1,
 			expectedPatterns{
-				report: []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
+				report: []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
 				info:   nil,
 				error:  nil,
-				alert:  []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
+				alert:  []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
 			},
 		},
 		{
@@ -428,10 +478,10 @@ func TestAudit(t *testing.T) {
 			readRepo1,
 			readManifestList1,
 			expectedPatterns{
-				report: []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/secret@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
+				report: []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/secret@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
 				info:   nil,
 				error:  nil,
-				alert:  []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/secret@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
+				alert:  []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "us.gcr.io/k8s-artifacts-prod/secret@sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", PQIN: "", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32", Tag: ""}: deletions are prohibited`},
 			},
 		},
 		{
@@ -445,10 +495,10 @@ func TestAudit(t *testing.T) {
 			readRepo1,
 			readManifestList1,
 			expectedPatterns{
-				report: []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/secret:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
+				report: []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/secret:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
 				info:   nil,
 				error:  nil,
-				alert:  []string{`TRANSACTION REJECTED: parse failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/secret:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
+				alert:  []string{`TRANSACTION REJECTED: validation failure: {Action: "DELETE", FQIN: "", PQIN: "us.gcr.io/k8s-artifacts-prod/secret:v0.0.8", Path: "us.gcr.io/k8s-artifacts-prod/secret", Digest: "", Tag: "v0.0.8"}: deletions are prohibited`},
 			},
 		},
 	}

--- a/lib/audit/auditor_test.go
+++ b/lib/audit/auditor_test.go
@@ -156,6 +156,7 @@ func TestValidatePayload(t *testing.T) {
 	}
 
 	for _, input := range shouldBeValid {
+		input := input
 		gotErr := ValidatePayload(&input)
 		errEqual := checkEqual(gotErr, nil)
 		checkError(t, errEqual, "checkError: test: shouldBeValid\n")

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1151,7 +1151,7 @@ func (sc *SyncContext) PopulateTokens() error {
 
 // GetTokenKeyDomainRepoPath splits a string by '/'. It's OK to do this because
 // the RegistryName is already parsed against a Regex. (Maybe we should store
-// the repo path separately when we do the initial parse...)
+// the repo path separately when we do the initial parse...).
 func GetTokenKeyDomainRepoPath(
 	registryName RegistryName) (string, string, string) {
 

--- a/pkg/api/files/validation.go
+++ b/pkg/api/files/validation.go
@@ -34,7 +34,7 @@ func (m *Manifest) Validate() error {
 	return nil
 }
 
-// validateFilestores validates the Filestores field of the manifest
+// validateFilestores validates the Filestores field of the manifest.
 func validateFilestores(filestores []Filestore) error {
 	if len(filestores) == 0 {
 		return fmt.Errorf("at least one filestore must be specified")
@@ -77,7 +77,7 @@ func validateFilestores(filestores []Filestore) error {
 	return nil
 }
 
-// validateFiles validates the Files field of the manifest
+// validateFiles validates the Files field of the manifest.
 func validateFiles(files []File) error {
 	if len(files) == 0 {
 		return fmt.Errorf("at least one file must be specified")

--- a/pkg/cmd/hash.go
+++ b/pkg/cmd/hash.go
@@ -33,7 +33,7 @@ type GenerateManifestOptions struct {
 	BaseDir string
 }
 
-// PopulateDefaults sets the default values for GenerateManifestOptions
+// PopulateDefaults sets the default values for GenerateManifestOptions.
 func (o *GenerateManifestOptions) PopulateDefaults() {
 	// There are no fields with non-empty default values
 	// (but we still want to follow the PopulateDefaults pattern)

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -115,7 +115,7 @@ func (o *copyFileOp) Run(ctx context.Context) error {
 	return nil
 }
 
-// String is the pretty-printer for an operation, as used by dry-run
+// String is the pretty-printer for an operation, as used by dry-run.
 func (o *copyFileOp) String() string {
 	return fmt.Sprintf(
 		"COPY %q to %q",

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -175,7 +175,7 @@ func joinFilepath(filestore *api.Filestore, relativePath string) string {
 }
 
 // BuildOperations builds the required operations to sync from the
-// Source Filestore to the Dest Filestore
+// Source Filestore to the Dest Filestore.
 func (p *FilestorePromoter) BuildOperations(
 	ctx context.Context) ([]SyncFileOp, error) {
 	sourceFilestore, err := openFilestore(ctx, p.Source, p.UseServiceAccount)

--- a/pkg/filepromoter/gcs.go
+++ b/pkg/filepromoter/gcs.go
@@ -38,7 +38,7 @@ type gcsSyncFilestore struct {
 	prefix    string
 }
 
-// OpenReader opens an io.ReadCloser for the specified file
+// OpenReader opens an io.ReadCloser for the specified file.
 func (s *gcsSyncFilestore) OpenReader(
 	ctx context.Context,
 	name string) (io.ReadCloser, error) {
@@ -46,7 +46,7 @@ func (s *gcsSyncFilestore) OpenReader(
 	return s.client.Bucket(s.bucket).Object(absolutePath).NewReader(ctx)
 }
 
-// UploadFile uploads a local file to the specified destination
+// UploadFile uploads a local file to the specified destination.
 func (s *gcsSyncFilestore) UploadFile(
 	ctx context.Context,
 	dest string,

--- a/pkg/filepromoter/token.go
+++ b/pkg/filepromoter/token.go
@@ -30,7 +30,7 @@ type gcloudTokenSource struct {
 	ServiceAccount string
 }
 
-// Token implements TokenSource.Token
+// Token implements TokenSource.Token.
 func (s *gcloudTokenSource) Token() (*oauth2.Token, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()


### PR DESCRIPTION
It's one thing to properly parse a JSON payload (to see it is
well-formed), and another thing to see if it makes sense on the
surface (validation).