### PR TITLE
Add manifest edit command

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,3 @@
 common --workspace_status_command=$PWD/workspace_status.sh
-common --host_force_python=PY2 
+common --host_force_python=PY2
 common --stamp

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -111,3 +111,11 @@ docker_push(
     name = "push-cip",
     bundle = "cip-docker-loadable",
 )
+
+# Support local installation of "cip" binary.
+load("@com_github_google_rules_install//installer:def.bzl", "installer")
+
+installer(
+    name = "install-cip",
+    data = [":cip"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -119,3 +119,8 @@ installer(
     name = "install-cip",
     data = [":cip"],
 )
+
+installer(
+    name = "install-cip-mm",
+    data = ["//cmd/cip-mm"],
+)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 		//test-e2e/cip-auditor:cip-auditor-e2e \
 		//cmd/promobot-files:promobot-files
 install:
-	bazel run $(BAZEL_BUILD_OPTS) //:install-cip -c opt -- $(shell go env GOPATH)/bin
+	bazel run //:install-cip -c opt -- $(shell go env GOPATH)/bin
 image:
 	bazel build //:cip-docker-loadable.tar
 image-load: image

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ build:
 	bazel build //:cip \
 		//test-e2e/cip:e2e \
 		//test-e2e/cip-auditor:cip-auditor-e2e \
+		//cmd/cip-mm:cip-mm \
 		//cmd/promobot-files:promobot-files
 install:
 	bazel run //:install-cip -c opt -- $(shell go env GOPATH)/bin
+	bazel run //:install-cip-mm -c opt -- $(shell go env GOPATH)/bin
 image:
 	bazel build //:cip-docker-loadable.tar
 image-load: image

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ build:
 		//test-e2e/cip:e2e \
 		//test-e2e/cip-auditor:cip-auditor-e2e \
 		//cmd/promobot-files:promobot-files
+install:
+	bazel run $(BAZEL_BUILD_OPTS) //:install-cip -c opt -- $(shell go env GOPATH)/bin
 image:
 	bazel build //:cip-docker-loadable.tar
 image-load: image

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -80,6 +80,24 @@ container_pull(
 #    digest = "sha256:6e6b1e2fd53cb94c4dc2af8381ef50bf4c7ac49bc5c728efda4ab15b41d0b510",
 #)
 
+# Rules for installing binaries into the local filesystem.
+#
+# Replace with http_archive() (official rules install instructions) after
+# https://github.com/google/bazel_rules_install/pull/27 is merged.
+git_repository(
+    name = "com_github_google_rules_install",
+    commit = "84406bab66bbb5061621d3b4b782c453e22c160a",
+    remote = "https://github.com/listx/bazel_rules_install",
+)
+
+load("@com_github_google_rules_install//:deps.bzl", "install_rules_dependencies")
+
+install_rules_dependencies()
+
+load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
+
+install_rules_setup()
+
 container_pull(
     name = "distroless-base",
     registry = "gcr.io",

--- a/cip.go
+++ b/cip.go
@@ -336,10 +336,10 @@ func main() {
 		case "CSV":
 			snapshot = rii.ToCSV()
 		case "YAML":
-			snapshot = rii.ToYAML()
+			snapshot = rii.ToYAML(reg.YamlMarshalingOpts{})
 		default:
 			klog.Errorf("invalid value %s for -output-format; defaulting to YAML", *outputFormatPtr)
-			snapshot = rii.ToYAML()
+			snapshot = rii.ToYAML(reg.YamlMarshalingOpts{})
 		}
 		fmt.Print(snapshot)
 		os.Exit(0)

--- a/cmd/cip-mm/BUILD.bazel
+++ b/cmd/cip-mm/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/cmd/cip-mm",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//lib/dockerregistry:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cip-mm",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/cip-mm/BUILD.bazel
+++ b/cmd/cip-mm/BUILD.bazel
@@ -8,8 +8,6 @@ go_library(
     deps = [
         "//lib/dockerregistry:go_default_library",
         "@io_k8s_klog//:go_default_library",
-        "@io_k8s_sigs_yaml//:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/cmd/cip-mm/README.md
+++ b/cmd/cip-mm/README.md
@@ -1,5 +1,40 @@
 # cip-mm
 
-This tool *m*odifies promoter *m*anifests. For now it dumps some filtered
-subset of a staging GCR and merge those contents back into a given promoter
+This tool **m**odifies promoter **m**anifests. For now it dumps some filtered
+subset of a staging GCR and merges those contents back into a given promoter
 manifest.
+
+## Examples
+
+- Add all images with a matching digest from staging repo
+  `gcr.io/k8s-staging-artifact-promoter` to a manifest, using the name and tags
+  already existing in the staging repo:
+
+```
+cip-mm \
+  --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
+  --staging_repo=gcr.io/k8s-staging-artifact-promoter \
+  --filter_digest=sha256:7594278deaf6eeaa35caedec81796d103e3c83a26d7beab091a5d25a9ba6aa16
+```
+
+- Add a single image named "foo" and tagged "1.0" from staging repo
+  `gcr.io/k8s-staging-artifact-promoter` to a manifest:
+
+```
+cip-mm \
+  --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
+  --staging_repo=gcr.io/k8s-staging-artifact-promoter \
+  --filter_image=cip \
+  --filter_tag=1.0
+```
+
+- Add all images tagged `1.0` from staging repo
+  `gcr.io/k8s-staging-artifact-promoter` to a manifest:
+
+```
+cip-mm \
+  --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
+  --staging_repo=gcr.io/k8s-staging-artifact-promoter \
+  --filter_image=cip \
+  --filter_tag=1.0
+```

--- a/cmd/cip-mm/README.md
+++ b/cmd/cip-mm/README.md
@@ -1,0 +1,5 @@
+# cip-mm
+
+This tool *m*odifies promoter *m*anifests. For now it dumps some filtered
+subset of a staging GCR and merge those contents back into a given promoter
+manifest.

--- a/cmd/cip-mm/main.go
+++ b/cmd/cip-mm/main.go
@@ -87,10 +87,5 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	err := reg.GrowManifest(ctx, opt)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return reg.GrowManifest(ctx, opt)
 }

--- a/cmd/cip-mm/main.go
+++ b/cmd/cip-mm/main.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
+	"k8s.io/klog"
+	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	"sigs.k8s.io/yaml"
+)
+
+func main() {
+	ctx := context.Background()
+
+	if err := run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		// nolint[gomnd]
+		os.Exit(1)
+	}
+}
+
+// nolint[lll]
+func run(ctx context.Context) error {
+	klog.InitFlags(nil)
+
+	baseDir := ""
+	flag.StringVar(
+		&baseDir,
+		"base_dir",
+		baseDir,
+		"the manifest directory to look at and modify")
+	subprojectDir := ""
+	flag.StringVar(
+		&subprojectDir,
+		"subproject_dir",
+		subprojectDir,
+		"the directory <name> under <BASE_DIR>/images/<name>, which we want to modify")
+
+	flag.Parse()
+
+	if baseDir == "" {
+		return xerrors.New("must specify --base_dir")
+	}
+
+	var opt reg.GrowManifestOptions
+	opt.PopulateDefaults()
+
+	s, err := filepath.Abs(baseDir)
+	if err != nil {
+		return xerrors.Errorf("cannot resolve %q to absolute path: %w", baseDir, err)
+	}
+	opt.BaseDir = s
+
+	manifest, err := reg.GrowManifest(ctx, opt)
+	if err != nil {
+		return err
+	}
+
+	manifestYAML, err := yaml.Marshal(manifest)
+	if err != nil {
+		return xerrors.Errorf("error serializing manifest: %w", err)
+	}
+
+	if _, err := os.Stdout.Write(manifestYAML); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/dockerregistry/BUILD.bazel
+++ b/lib/dockerregistry/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@in_gopkg_yaml_v2//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_klog//:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/lib/dockerregistry/BUILD.bazel
+++ b/lib/dockerregistry/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "grow_manifest.go",
         "inventory.go",
         "set.go",
         "types.go",

--- a/lib/dockerregistry/BUILD.bazel
+++ b/lib/dockerregistry/BUILD.bazel
@@ -28,7 +28,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["inventory_test.go"],
+    srcs = [
+        "grow_manifest_test.go",
+        "inventory_test.go",
+    ],
     # Include test fixtures.
     data = glob(["inventory_test/**/*"]),
     embed = [":go_default_library"],

--- a/lib/dockerregistry/grow_manifest.go
+++ b/lib/dockerregistry/grow_manifest.go
@@ -18,65 +18,295 @@ package inventory
 
 import (
 	"context"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
 	"k8s.io/klog"
+)
+
+const (
+	// This is a banned tag. It is not allowed to be manipulated with this tool.
+	latestTag = "latest"
 )
 
 // GrowManifestOptions holds the  parameters for modifying manifests.
 type GrowManifestOptions struct {
 	// BaseDir is the directory containing the thin promoter manifests.
 	BaseDir string
-	// StagingSubproject is the staging subproject name to filter by.
-	SubprojectDir string
-	// ImageName is the image name to filter by.
-	ImageName ImageName
-	// StagingDigest is the image digest in staging to use.
-	StagingDigest Digest
-	// StagingTag is the image tag in staging to use.
-	StagingTag Tag
+	// StagingRepo is the staging subproject repo to read from. If no filters
+	// are provided, all images are attempted to be promoted as-is without any
+	// modifications.
+	StagingRepo RegistryName
+	// FilterImage is the image (name) to filter by. Optional.
+	FilterImage ImageName
+	// FilterDigest is the image digest to filter by. Optional.
+	FilterDigest Digest
+	// FilterTag is the image tag to filter by. Optional.
+	FilterTag Tag
 }
 
-// PopulateDefaults sets the default values for GrowManifestOptions.
-func (o *GrowManifestOptions) PopulateDefaults() {
-	// There are no fields with non-empty default values
-	// (but we still want to follow the PopulateDefaults pattern)
+// Populate sets the values for GrowManifestOptions.
+func (o *GrowManifestOptions) Populate(
+	baseDir,
+	stagingRepo,
+	filterImage,
+	filterDigest,
+	filterTag string,
+) error {
+	baseDirAbsPath, err := filepath.Abs(baseDir)
+	if err != nil {
+		return xerrors.Errorf(
+			"cannot resolve %q to absolute path: %w", baseDir, err)
+	}
+
+	o.BaseDir = baseDirAbsPath
+	o.StagingRepo = RegistryName(stagingRepo)
+	o.FilterImage = ImageName(filterImage)
+	o.FilterDigest = Digest(filterDigest)
+	o.FilterTag = Tag(filterTag)
+
+	return nil
+}
+
+// Validate validates the options.
+func (o *GrowManifestOptions) Validate() error {
+	if len(o.BaseDir) == 0 {
+		return xerrors.New("must specify --base_dir")
+	}
+
+	if len(o.StagingRepo) == 0 {
+		return xerrors.New("must specify --staging_repo")
+	}
+
+	if o.FilterTag == latestTag {
+		return xerrors.Errorf(
+			"--filter_tag cannot be %q (anti-pattern)", latestTag)
+	}
+	return nil
 }
 
 // GrowManifest modifies a manifest by adding images into it.
 func GrowManifest(
 	ctx context.Context,
 	o GrowManifestOptions,
-) (Manifest, error) {
+) error {
 
 	var err error
+	var riiCombined RegInvImage
+
+	// (1) Scan the BaseDir and find the promoter manifest to modify.
+	manifest, err := FindManifest(o)
+	if err != nil {
+		return err
+	}
+
+	// (2) Scan the StagingRepo, and whittle the read results down with some
+	// filters (Filter* fields in GrowManifestOptions).
+	riiFiltered, err := ReadStagingRepo(o)
+	if err != nil {
+		return err
+	}
+
+	// (3) Inject (2)'s output into (1)'s manifest's images to create a larger
+	// RegInvImage.
+	riiCombined = Union(manifest.ToRegInvImage(), riiFiltered)
+
+	// (4) Write back RegInvImage as Manifest ([]Image field}) back onto disk.
+	err = WriteImages(manifest, riiCombined)
+
+	return err
+}
+
+// WriteImages writes images as YAML out to the expected path of the given
+// (thin) manifest.
+func WriteImages(manifest Manifest, rii RegInvImage) error {
+	// Chop off trailing "promoter-manifest.yaml".
+	p := path.Dir(manifest.Filepath)
+	// Get staging repo directory name as it is laid out in the thin manifest
+	// dir.
+	stagingRepoName := path.Base(p)
+	// Construct path to the images.yaml.
+	imagesPath := path.Join(p, "..", "..",
+		"images", stagingRepoName, "images.yaml")
+	klog.Infoln("RENDER", imagesPath)
+
+	// Write the file.
+	err := ioutil.WriteFile(imagesPath, []byte(rii.ToYAML()), 0644)
+	return err
+}
+
+// FindManifest finds the manifest to modify.
+func FindManifest(o GrowManifestOptions) (Manifest, error) {
+	var err error
 	var manifests []Manifest
-	m := Manifest{}
-	// (1) Using the SubprojectDir, scan the correct manifest and get the source
-	// registry. This is the registry to read with filters.
-	//
-	// INPUT: staging GCR + filters
-	// OUTPUT: RegInvImage of images to promote
-
-	// (2) Scan the BaseDir to identify the manifest folders to modify.
-	//
-	// INPUT: On-disk manifest
-	// OUTPU: Manifest data structure (with RegInvImage)
-
-	// (3) Inject (1)'s output into (2)'s output to create a larger RegInvImage.
-	//
-	// INPUT: RegInvImage (to promote) + RegInvImage (found on-disk)
-	// OUTPUT: RegInvImage (sum total)
-
 	manifests, err = ParseThinManifestsFromDir(o.BaseDir)
 	if err != nil {
-		klog.Exitln(err)
+		return Manifest{}, err
 	}
 
 	klog.Infof("%d manifests parsed", len(manifests))
+	for _, manifest := range manifests {
+		if manifest.SrcRegistry.Name == o.StagingRepo {
+			return manifest, nil
+		}
+	}
+	return Manifest{},
+		xerrors.Errorf("could not find Manifest for %q", o.StagingRepo)
+}
 
-	// (4) Write back RegInvImage as Manifest ([]Image field}) back onto disk.
-	//
-	// INPUT: RegInvImage (sum total) (or maybe as a Manifest?)
-	// OUTPUT: Overwrite existing file with YAML.
+// ReadStagingRepo reads the StagingRepo, and apply whatever filters are
+// available to the resulting RegInvImage. This RegInvImage is what we want to
+// inject into the "images.yaml" of a thin manifest.
+func ReadStagingRepo(o GrowManifestOptions) (RegInvImage, error) {
 
-	return m, nil
+	stagingRepoRC := RegistryContext{
+		Name: o.StagingRepo,
+	}
+
+	var rii RegInvImage
+
+	manifests := []Manifest{
+		{
+			Registries: []RegistryContext{
+				stagingRepoRC,
+			},
+			Images: []Image{},
+		},
+	}
+
+	sc, err := MakeSyncContext(
+		manifests,
+		2,
+		10,
+		true,
+		false)
+	if err != nil {
+		return RegInvImage{}, err
+	}
+	sc.ReadRegistries(
+		[]RegistryContext{stagingRepoRC},
+		// Read all registries recursively, because we want to produce a
+		// complete snapshot.
+		true,
+		MkReadRepositoryCmdReal)
+
+	rii = sc.Inv[manifests[0].Registries[0].Name]
+
+	// Now perform some filtering, if any.
+	if len(o.FilterImage) > 0 {
+		rii = FilterByImage(rii, o.FilterImage)
+	}
+
+	if len(o.FilterTag) > 0 {
+		rii = FilterByTag(rii, string(o.FilterTag))
+	}
+
+	if len(o.FilterDigest) > 0 {
+		rii = FilterByDigest(rii, o.FilterDigest)
+	}
+
+	// Remove any other tags that should still be filtered.
+	excludeTags := map[Tag]bool{latestTag: true}
+	rii = ExcludeTags(rii, excludeTags)
+
+	if len(rii) == 0 {
+		// nolint[lll]
+		return RegInvImage{}, xerrors.New(
+			"no images survived filtering; double-check your --filter_* flag(s) for typos")
+	}
+
+	return rii, nil
+}
+
+// FilterByImage removes all images in RegInvImage that do not match the
+// filterImage.
+func FilterByImage(rii RegInvImage, filterImage ImageName) RegInvImage {
+	filtered := make(RegInvImage)
+	for imageName, digestTags := range rii {
+		if imageName == filterImage {
+			filtered[imageName] = digestTags
+		}
+	}
+	return filtered
+}
+
+// FilterByDigest removes all images in RegInvImage that do not match the
+// filterDigest.
+func FilterByDigest(rii RegInvImage, filterDigest Digest) RegInvImage {
+	filtered := make(RegInvImage)
+	for imageName, digestTags := range rii {
+		for digest, tags := range digestTags {
+			if digest == filterDigest {
+				if filtered[imageName] == nil {
+					filtered[imageName] = make(DigestTags)
+				}
+				filtered[imageName][digest] = tags
+			}
+		}
+	}
+	return filtered
+}
+
+// ExcludeTags removes tags in rii that match excludedTags.
+func ExcludeTags(rii RegInvImage, excludedTags map[Tag]bool) RegInvImage {
+	filtered := make(RegInvImage)
+	for imageName, digestTags := range rii {
+		for digest, tags := range digestTags {
+			for _, tag := range tags {
+				if _, excludeMe := excludedTags[tag]; excludeMe {
+					continue
+				}
+				if filtered[imageName] == nil {
+					filtered[imageName] = make(DigestTags)
+				}
+				filtered[imageName][digest] = append(
+					filtered[imageName][digest],
+					tag)
+			}
+		}
+	}
+	return filtered
+}
+
+// Union inject b's contents into a. However, it does so in a special way.
+func Union(a, b RegInvImage) RegInvImage {
+	for imageName, digestTags := range b {
+		// If a does not have this image at all, then it's a simple
+		// injection.
+		if a[imageName] == nil {
+			a[imageName] = digestTags
+			continue
+		}
+		for digest, tags := range digestTags {
+			// If a has the image but not this digest, inject just this digest
+			// and all associated tags.
+			if a[imageName][digest] == nil {
+				a[imageName][digest] = tags
+				continue
+			}
+			// If c has the digest already, try to inject those tags in b that
+			// are not already in a.
+			tagSlice := TagSlice{}
+			for tag := range tags.Union(a[imageName][digest]) {
+				if tag == "latest" {
+					continue
+				}
+				tagSlice = append(tagSlice, tag)
+			}
+			a[imageName][digest] = tagSlice
+		}
+	}
+
+	return a
+}
+
+// ToRegInvImage converts a Manifest into a RegInvImage.
+func (manifest *Manifest) ToRegInvImage() RegInvImage {
+	rii := make(RegInvImage)
+	for _, image := range manifest.Images {
+		rii[image.ImageName] = image.Dmap
+	}
+	return rii
 }

--- a/lib/dockerregistry/grow_manifest.go
+++ b/lib/dockerregistry/grow_manifest.go
@@ -206,6 +206,11 @@ func ReadStagingRepo(
 // rii.
 func ApplyFilters(o GrowManifestOptions, rii RegInvImage) (RegInvImage, error) {
 
+	// If nothing to filter, short-circuit.
+	if len(rii) == 0 {
+		return rii, nil
+	}
+
 	// Now perform some filtering, if any.
 	if len(o.FilterImage) > 0 {
 		rii = FilterByImage(rii, o.FilterImage)

--- a/lib/dockerregistry/grow_manifest.go
+++ b/lib/dockerregistry/grow_manifest.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"context"
+	"k8s.io/klog"
+)
+
+// GrowManifestOptions holds the  parameters for modifying manifests.
+type GrowManifestOptions struct {
+	// BaseDir is the directory containing the thin promoter manifests.
+	BaseDir string
+	// StagingSubproject is the staging subproject name to filter by.
+	SubprojectDir string
+	// ImageName is the image name to filter by.
+	ImageName ImageName
+	// StagingDigest is the image digest in staging to use.
+	StagingDigest Digest
+	// StagingTag is the image tag in staging to use.
+	StagingTag Tag
+}
+
+// PopulateDefaults sets the default values for GrowManifestOptions.
+func (o *GrowManifestOptions) PopulateDefaults() {
+	// There are no fields with non-empty default values
+	// (but we still want to follow the PopulateDefaults pattern)
+}
+
+// GrowManifest modifies a manifest by adding images into it.
+func GrowManifest(
+	ctx context.Context,
+	o GrowManifestOptions,
+) (Manifest, error) {
+
+	var err error
+	var manifests []Manifest
+	m := Manifest{}
+	// (1) Using the SubprojectDir, scan the correct manifest and get the source
+	// registry. This is the registry to read with filters.
+	//
+	// INPUT: staging GCR + filters
+	// OUTPUT: RegInvImage of images to promote
+
+	// (2) Scan the BaseDir to identify the manifest folders to modify.
+	//
+	// INPUT: On-disk manifest
+	// OUTPU: Manifest data structure (with RegInvImage)
+
+	// (3) Inject (1)'s output into (2)'s output to create a larger RegInvImage.
+	//
+	// INPUT: RegInvImage (to promote) + RegInvImage (found on-disk)
+	// OUTPUT: RegInvImage (sum total)
+
+	manifests, err = ParseThinManifestsFromDir(o.BaseDir)
+	if err != nil {
+		klog.Exitln(err)
+	}
+
+	klog.Infof("%d manifests parsed", len(manifests))
+
+	// (4) Write back RegInvImage as Manifest ([]Image field}) back onto disk.
+	//
+	// INPUT: RegInvImage (sum total) (or maybe as a Manifest?)
+	// OUTPUT: Overwrite existing file with YAML.
+
+	return m, nil
+}

--- a/lib/dockerregistry/grow_manifest.go
+++ b/lib/dockerregistry/grow_manifest.go
@@ -133,7 +133,8 @@ func WriteImages(manifest Manifest, rii RegInvImage) error {
 	klog.Infoln("RENDER", imagesPath)
 
 	// Write the file.
-	err := ioutil.WriteFile(imagesPath, []byte(rii.ToYAML()), 0644)
+	err := ioutil.WriteFile(
+		imagesPath, []byte(rii.ToYAML(YamlMarshalingOpts{})), 0644)
 	return err
 }
 

--- a/lib/dockerregistry/grow_manifest_test.go
+++ b/lib/dockerregistry/grow_manifest_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+)
+
+func TestFindManifest(t *testing.T) {
+	pwd := bazelTestPath("TestFindManifest")
+	srcRC := reg.RegistryContext{
+		Name:           "gcr.io/foo-staging",
+		ServiceAccount: "sa@robot.com",
+		Src:            true,
+	}
+	var tests = []struct {
+		// name is folder name
+		name             string
+		input            reg.GrowManifestOptions
+		expectedManifest reg.Manifest
+		expectedErr      error
+	}{
+		{
+			"empty",
+			reg.GrowManifestOptions{
+				BaseDir:     filepath.Join(pwd, "empty"),
+				StagingRepo: "gcr.io/foo",
+			},
+			reg.Manifest{},
+			&os.PathError{
+				Op:   "stat",
+				Path: filepath.Join(pwd, "empty/images"),
+				Err:  fmt.Errorf("no such file or directory"),
+			},
+		},
+		{
+			"singleton",
+			reg.GrowManifestOptions{
+				BaseDir:     filepath.Join(pwd, "singleton"),
+				StagingRepo: "gcr.io/foo-staging",
+			},
+			reg.Manifest{
+				Registries: []reg.RegistryContext{
+					srcRC,
+					{
+						Name:           "us.gcr.io/some-prod",
+						ServiceAccount: "sa@robot.com",
+					},
+					{
+						Name:           "eu.gcr.io/some-prod",
+						ServiceAccount: "sa@robot.com",
+					},
+					{
+						Name:           "asia.gcr.io/some-prod",
+						ServiceAccount: "sa@robot.com",
+					},
+				},
+				Images: []reg.Image{
+					{ImageName: "foo-controller",
+						Dmap: reg.DigestTags{
+							"sha256:c3d310f4741b3642497da8826e0986db5e02afc9777a2b8e668c8e41034128c1": {"1.0"},
+						},
+					},
+				},
+				Filepath: filepath.Join(pwd, "singleton/manifests/a/promoter-manifest.yaml"),
+			},
+			nil,
+		},
+		{
+			"singleton (unrecognized staging repo)",
+			reg.GrowManifestOptions{
+				BaseDir:     filepath.Join(pwd, "singleton"),
+				StagingRepo: "gcr.io/nonsense-staging",
+			},
+			reg.Manifest{},
+			fmt.Errorf("could not find Manifest for %q", "gcr.io/nonsense-staging"),
+		},
+	}
+
+	for _, test := range tests {
+		gotManifest, gotErr := reg.FindManifest(test.input)
+
+		// Clean up gotManifest for purposes of comparing against expected
+		// results. Namely, clear out the SrcRegistry pointer because this will
+		// always be different.
+		gotManifest.SrcRegistry = nil
+
+		eqErr := checkEqual(gotManifest, test.expectedManifest)
+		checkError(
+			t,
+			eqErr,
+			fmt.Sprintf("Test: %q (unexpected manifest)\n", test.name))
+
+		var gotErrStr string
+		var expectedErrStr string
+		if gotErr != nil {
+			gotErrStr = gotErr.Error()
+		}
+		if test.expectedErr != nil {
+			expectedErrStr = test.expectedErr.Error()
+		}
+
+		eqErr = checkEqual(gotErrStr, expectedErrStr)
+		checkError(
+			t,
+			eqErr,
+			fmt.Sprintf("Test: %q (unexpected error)\n", test.name))
+	}
+}

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2845,6 +2845,7 @@ func TestSnapshot(t *testing.T) {
 			"Basic",
 			reg.RegInvImage{
 				"foo": {
+					"sha256:111": {"one"},
 					"sha256:fff": {"0.9", "0.5"},
 					"sha256:abc": {"0.3", "0.2"},
 				},
@@ -2853,24 +2854,18 @@ func TestSnapshot(t *testing.T) {
 			},
 			`- name: bar
   dmap:
-    sha256:000:
-    - 0.5
-    - 0.8
-    - 0.9
+    "sha256:000": ["0.5", "0.8", "0.9"]
 - name: foo
   dmap:
-    sha256:abc:
-    - 0.2
-    - 0.3
-    sha256:fff:
-    - 0.5
-    - 0.9
+    "sha256:111": ["one"]
+    "sha256:abc": ["0.2", "0.3"]
+    "sha256:fff": ["0.5", "0.9"]
 `,
 		},
 	}
 
 	for _, test := range tests {
-		gotYAML := test.input.ToYAML()
+		gotYAML := test.input.ToYAML(reg.YamlMarshalingOpts{})
 		err := checkEqual(gotYAML, test.expected)
 		checkError(t, err, fmt.Sprintf("checkError: test: %v\n", test.name))
 	}

--- a/lib/dockerregistry/inventory_test/TestFindManifest/empty
+++ b/lib/dockerregistry/inventory_test/TestFindManifest/empty
@@ -1,0 +1,1 @@
+../TestParseThinManifestsFromDir/empty

--- a/lib/dockerregistry/inventory_test/TestFindManifest/singleton
+++ b/lib/dockerregistry/inventory_test/TestFindManifest/singleton
@@ -1,0 +1,1 @@
+../TestParseThinManifestsFromDir/singleton

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -383,6 +383,34 @@ type GCRPubSubPayload struct {
 	Tag Tag
 }
 
+// YamlMarshalingOpts holds options for tweaking the YAML output.
+type YamlMarshalingOpts struct {
+	// Render multiple tags on separate lines. I.e.,
+	// prefer
+	//
+	//    sha256:abc...:
+	//    - one
+	//    - two
+	//
+	// over
+	//
+	//    sha256:abc...: ["one", "two"]
+	//
+	// If there is only 1 tag, it will be on one line in brackets (e.g.,
+	// '["one"]').
+	SplitTagsOverMultipleLines bool
+
+	// Do not quote the digest. I.e., prefer
+	//
+	//    sha256:...:
+	//
+	// over
+	//
+	//    "sha256:...":
+	//
+	BareDigest bool
+}
+
 // Various conversion functions.
 
 // ToRegInvImageDigest converts a Manifest to a RegInvImageDigest.


### PR DESCRIPTION
Allows editing manifests programmatically. Addresses #190 

This builds on #208 and #209; any changes to those PRs will necessitate a force-push here. Putting this up for now to encourage discussion.

Meanwhile, I'll add some unit tests.

/cc @justaugustus 