### PR TITLE
Removed unused 'verbosity' flag from the promoter

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -41,6 +41,7 @@ var TimestampUtcRfc3339 string
 
 // nolint[gocyclo]
 func main() {
+	// klog uses the "v" flag in order to set the verbosity level
 	klog.InitFlags(nil)
 
 	manifestPtr := flag.String(
@@ -52,14 +53,6 @@ func main() {
 	threadsPtr := flag.Int(
 		"threads",
 		10, "number of concurrent goroutines to use when talking to GCR")
-	verbosityPtr := flag.Int(
-		"verbosity",
-		2,
-		"verbosity level for logging;"+
-			" 0 = fatal only,"+
-			" 1 = fatal + errors,"+
-			" 2 = fatal + errors + warnings,"+
-			" 3 = fatal + errors + warnings + informational (everything)")
 	parseOnlyPtr := flag.Bool(
 		"parse-only",
 		false,
@@ -224,7 +217,6 @@ func main() {
 		}
 		sc, err = reg.MakeSyncContext(
 			mfests,
-			*verbosityPtr,
 			*threadsPtr,
 			*dryRunPtr,
 			useServiceAccount)
@@ -240,7 +232,6 @@ func main() {
 
 		sc, err = reg.MakeSyncContext(
 			mfests,
-			*verbosityPtr,
 			*threadsPtr,
 			*dryRunPtr,
 			useServiceAccount)
@@ -306,7 +297,6 @@ func main() {
 		} else {
 			sc, err = reg.MakeSyncContext(
 				mfests,
-				*verbosityPtr,
 				*threadsPtr,
 				*dryRunPtr,
 				useServiceAccount)

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -255,8 +255,6 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	// reg.ReadGCRManifestLists.
 	sc, err := reg.MakeSyncContext(
 		manifests,
-		// verbosity
-		2,
 		// threads
 		10,
 		// dry run (although not necessary as we'll only be doing image reads,

--- a/lib/dockerregistry/grow_manifest.go
+++ b/lib/dockerregistry/grow_manifest.go
@@ -185,7 +185,6 @@ func ReadStagingRepo(
 
 	sc, err := MakeSyncContext(
 		manifests,
-		2,
 		10,
 		true,
 		false)

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -56,11 +56,10 @@ func GetSrcRegistry(rcs []RegistryContext) (*RegistryContext, error) {
 // MakeSyncContext creates a SyncContext.
 func MakeSyncContext(
 	mfests []Manifest,
-	verbosity, threads int,
+	threads int,
 	dryRun, useSvcAcc bool) (SyncContext, error) {
 
 	sc := SyncContext{
-		Verbosity:         verbosity,
 		Threads:           threads,
 		DryRun:            dryRun,
 		UseServiceAccount: useSvcAcc,

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -47,7 +47,6 @@ type CapturedRequests map[PromotionRequest]int
 
 // SyncContext is the main data structure for performing the promotion.
 type SyncContext struct {
-	Verbosity         int
 	Threads           int
 	DryRun            bool
 	UseServiceAccount bool

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -418,7 +418,6 @@ func (t *E2ETest) clearRepositories() error {
 		[]reg.Manifest{
 			{Registries: t.Registries},
 		},
-		2,
 		10,
 		false,
 		true)

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -248,7 +248,7 @@ func runPromotion(repoRoot string, t E2ETest) error {
 		":cip",
 		"--",
 		"-dry-run=false",
-		"-verbosity=3",
+		"-v=3",
 		"-use-service-account",
 		// There is no need to use -key-files=... because we already activated
 		// the 1 service account we need during e2e tests with our own -key-file
@@ -341,7 +341,6 @@ func (t *E2ETest) clearRepositories() error {
 		[]reg.Manifest{
 			{Registries: t.Registries},
 		},
-		2,
 		10,
 		false,
 		true)


### PR DESCRIPTION
Removed unused 'verbosity' flag from the promoter and any use of verbosity in SyncContext type since they weren't being used. Verbosity levels from now on will be set using klog's expected "v" flag since we already use klog to handle all logging. This will also allow for future use of the "klog.V(int)" syntax to determine whether something should be logged. 