### PR TITLE
Added a PreCheck Interface for adding future checks against pull requests

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -345,6 +345,14 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Check the pull request
+	if *dryRunPtr {
+		err = sc.RunChecks(promotionEdges, []reg.PreCheck{})
+		if err != nil {
+			klog.Exitln(err)
+		}
+	}
+
 	// Promote.
 	mkProducer := func(
 		srcRegistry reg.RegistryName,

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1952,6 +1952,28 @@ func MKPopulateRequestsForPromotionEdges(
 	}
 }
 
+// RunChecks runs defined PreChecks in order to check the promotion.
+func (sc *SyncContext) RunChecks(
+	edges map[PromotionEdge]interface{},
+	preChecks []PreCheck,
+) error {
+
+	var errors []error
+	for _, preCheck := range preChecks {
+		err := preCheck.Run(edges)
+		if err != nil {
+			klog.Error(err)
+			errors = append(errors, err)
+		}
+	}
+
+	if errors != nil {
+		return fmt.Errorf("%v error(s) encountered during the prechecks",
+			len(errors))
+	}
+	return nil
+}
+
 // FilterPromotionEdges generates all "edges" that we want to promote.
 func (sc *SyncContext) FilterPromotionEdges(
 	edges map[PromotionEdge]interface{},

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -60,6 +60,15 @@ type SyncContext struct {
 	ParentDigest      ParentDigest
 }
 
+// PreCheck represents a check function to run against a pull request that
+// modifies the promoter manifests before oking promotion of the changes.
+//
+// Run runs the defined check on a set of PromotionEdges and returns an error
+// if the check fails, returns nil otherwise.
+type PreCheck interface {
+	Run(edges map[PromotionEdge]interface{}) error
+}
+
 // PromotionEdge represents a promotion "link" of an image repository between 2
 // registries.
 type PromotionEdge struct {


### PR DESCRIPTION
The PullCheck interface will make it easier for engineers in the future to add checks for the promoter against pull requests that attempt to modify manifests. 