### PR TITLE
WIP: Adding a JSON Summary for Promoter

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -53,6 +53,10 @@ func main() {
 	threadsPtr := flag.Int(
 		"threads",
 		10, "number of concurrent goroutines to use when talking to GCR")
+	jsonLogSummaryPtr := flag.Bool(
+		"json-log-summary",
+		false,
+		"only log a json summary of important errors")
 	parseOnlyPtr := flag.Bool(
 		"parse-only",
 		false,
@@ -334,6 +338,10 @@ func main() {
 		fmt.Print(snapshot)
 		os.Exit(0)
 	}
+
+	if *jsonLogSummaryPtr {
+		defer sc.LogJSONSummary()
+    }
 
 	// Check the pull request
 	if *dryRunPtr {

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -106,6 +106,17 @@ func MakeSyncContext(
 	return sc, nil
 }
 
+// LogJSONSummary logs the SyncContext's Logs as a prettified JSON.
+func (sc *SyncContext) LogJSONSummary() {
+	json, err := json.MarshalIndent(sc.Logs, "", "  ")
+	if err != nil {
+		klog.Infof("There was a problem generating the JSON summary: %v",
+			err)
+	} else {
+		klog.Info(string(json))
+	}
+}
+
 // ParseManifestFromFile parses a Manifest from a filepath.
 func ParseManifestFromFile(filePath string) (Manifest, error) {
 
@@ -1616,6 +1627,8 @@ func MkReadManifestListCmdReal(
 
 // ExecRequests uses the Worker Pool pattern, where MaxConcurrentRequests
 // determines the number of workers to spawn.
+//
+// nolint[funlen]
 func (sc *SyncContext) ExecRequests(
 	populateRequests PopulateRequests,
 	processRequest ProcessRequest) error {
@@ -1639,6 +1652,7 @@ func (sc *SyncContext) ExecRequests(
 				(*mutex).Lock()
 				err = fmt.Errorf("Encountered an error during the" +
 					" promotion step")
+				sc.Logs.Errors = append(sc.Logs.Errors, reqRes.Errors...)
 				(*mutex).Unlock()
 				klog.Errorf(
 					"Request %v: error(s) encountered: %v\n",

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -45,6 +45,11 @@ type Error struct {
 // is used for both -dry-run and testing.
 type CapturedRequests map[PromotionRequest]int
 
+// CollectedLogs holds all the Errors that are generated as the promoter runs.
+type CollectedLogs struct {
+	Errors Errors
+}
+
 // SyncContext is the main data structure for performing the promotion.
 type SyncContext struct {
 	Threads           int
@@ -57,6 +62,7 @@ type SyncContext struct {
 	Tokens            map[RootRepo]gcloud.Token
 	DigestMediaType   DigestMediaType
 	ParentDigest      ParentDigest
+	Logs              CollectedLogs
 }
 
 // PreCheck represents a check function to run against a pull request that


### PR DESCRIPTION
The Promoter will collect errors that are generated throughout the job and then log them as a prettified JSON when the job ends. 