### PR TITLE
WIP: Adding Image size check

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -123,10 +123,10 @@ func main() {
 		"audit-gcp-project-id",
 		os.Getenv("CIP_AUDIT_GCP_PROJECT_ID"),
 		"GCP project ID (name); used for labeling error reporting logs to GCP")
-	maxImageSizePtr := flag.Float64(
+	maxImageSizePtr := flag.Int(
 		"max-image-size",
-		2,
-		"The maximum image size in GB allowed for promotion (defaults to 2GB)")
+		2048,
+		"The maximum image size (MB) allowed for promotion. Default is 2048MB")
 	flag.Parse()
 
 	if len(os.Args) == 1 {

--- a/cip.go
+++ b/cip.go
@@ -341,7 +341,12 @@ func main() {
 
 	// Check the pull request
 	if *dryRunPtr {
-		err = sc.RunChecks(promotionEdges, []reg.PreCheck{})
+		err = sc.RunChecks(promotionEdges, []reg.PreCheck{
+			reg.MKRealImageSizeCheck(
+				*maxImageSizePtr,
+				sc.DigestImageSize,
+			),
+		})
 		if err != nil {
 			klog.Exitln(err)
 		}

--- a/cip.go
+++ b/cip.go
@@ -126,7 +126,7 @@ func main() {
 	maxImageSizePtr := flag.Int(
 		"max-image-size",
 		2048,
-		"The maximum image size (MB) allowed for promotion. Default is 2048MB")
+		"The maximum image size (MiB) allowed for promotion. Default is 2048MiB")
 	flag.Parse()
 
 	if len(os.Args) == 1 {

--- a/cip.go
+++ b/cip.go
@@ -126,7 +126,10 @@ func main() {
 	maxImageSizePtr := flag.Int(
 		"max-image-size",
 		2048,
-		"The maximum image size (MiB) allowed for promotion. Default is 2048MiB")
+		"The maximum image size (MiB) allowed for promotion and must be a positive value (othwerise set to the default value of 2048 MiB)")
+	if *maxImageSizePtr <= 0 {
+		*maxImageSizePtr = 2048
+	}
 	flag.Parse()
 
 	if len(os.Args) == 1 {
@@ -341,9 +344,10 @@ func main() {
 
 	// Check the pull request
 	if *dryRunPtr {
-		err = sc.RunChecks(promotionEdges, []reg.PreCheck{
+		err = sc.RunChecks([]reg.PreCheck{
 			reg.MKRealImageSizeCheck(
 				*maxImageSizePtr,
+				promotionEdges,
 				sc.DigestImageSize,
 			),
 		})

--- a/cip.go
+++ b/cip.go
@@ -123,6 +123,10 @@ func main() {
 		"audit-gcp-project-id",
 		os.Getenv("CIP_AUDIT_GCP_PROJECT_ID"),
 		"GCP project ID (name); used for labeling error reporting logs to GCP")
+	maxImageSizePtr := flag.Float64(
+		"max-image-size",
+		2,
+		"The maximum image size in GB allowed for promotion (defaults to 2GB)")
 	flag.Parse()
 
 	if len(os.Args) == 1 {

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1973,6 +1973,13 @@ func (sc *SyncContext) RunChecks(
 	return nil
 }
 
+func (check *ImageSizeCheck) Run(
+	edges map[PromotionEdge]interface{},
+) error {
+	var err error
+	return err
+}
+
 // FilterPromotionEdges generates all "edges" that we want to promote.
 func (sc *SyncContext) FilterPromotionEdges(
 	edges map[PromotionEdge]interface{},

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1996,7 +1996,7 @@ func (check *ImageSizeCheck) Run(
 	}
 	if len(oversizedImages) > 0 {
 		return fmt.Errorf("The following images were over the max file size"+
-			" of %dMB: %v",
+			" of %dMiB: %v",
 			check.MaxImageSize,
 			strings.Join(oversizedImages, ", "))
 	}

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2049,6 +2049,23 @@ func TestRunChecks(t *testing.T) {
 	}
 }
 
+func TestImageSizeCheck(t *testing.T) {
+	var tests = []struct {
+		name      string
+		check     reg.ImageSizeCheck
+		manifests []reg.Manifest
+		expected  error
+	}{}
+
+	for _, test := range tests {
+		edges, _ := reg.ToPromotionEdges(test.manifests)
+		got := test.check.Run(edges)
+		err := checkEqual(got, test.expected)
+		checkError(t, err,
+			fmt.Sprintf("checkError: test: %v (Error Tracking)\n", test.name))
+	}
+}
+
 // TestPromotion is the most important test as it simulates the main job of the
 // promoter.
 func TestPromotion(t *testing.T) {

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -56,6 +56,7 @@ type SyncContext struct {
 	SrcRegistry       *RegistryContext
 	Tokens            map[RootRepo]gcloud.Token
 	DigestMediaType   DigestMediaType
+	DigestImageSize   DigestImageSize
 	ParentDigest      ParentDigest
 }
 
@@ -68,8 +69,11 @@ type PreCheck interface {
 	Run(edges map[PromotionEdge]interface{}) error
 }
 
+// MaxFileSize implements the PreCheck interface and checks against images that
+// are larger than a size threshold (controlled by the max-image-size flag).
 type ImageSizeCheck struct {
-	MaxFileSize int
+	MaxImageSize    float64
+	DigestImageSize DigestImageSize
 }
 
 // PromotionEdge represents a promotion "link" of an image repository between 2
@@ -305,6 +309,9 @@ type ImageName string
 
 // DigestMediaType holds media information about a Digest.
 type DigestMediaType map[Digest]cr.MediaType
+
+// DigestImageSize holds information about the size of an image in bytes.
+type DigestImageSize map[Digest]int
 
 // ParentDigest holds a map of the digests of children to parent digests. It is
 // a reverse mapping of ManifestLists, which point to all the child manifests.

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -73,7 +73,7 @@ type PreCheck interface {
 // images that are larger than a size threshold (controlled by the
 // max-image-size flag).
 type ImageSizeCheck struct {
-	MaxImageSize    float64
+	MaxImageSize    int
 	DigestImageSize DigestImageSize
 }
 

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -68,6 +68,10 @@ type PreCheck interface {
 	Run(edges map[PromotionEdge]interface{}) error
 }
 
+type ImageSizeCheck struct {
+	MaxFileSize int
+}
+
 // PromotionEdge represents a promotion "link" of an image repository between 2
 // registries.
 type PromotionEdge struct {

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -63,10 +63,10 @@ type SyncContext struct {
 // PreCheck represents a check function to run against a pull request that
 // modifies the promoter manifests before oking promotion of the changes.
 //
-// Run runs the defined check on a set of PromotionEdges and returns an error
-// if the check fails, returns nil otherwise.
+// Run runs the defined check and returns an error if the check fails, returns
+// nil otherwise.
 type PreCheck interface {
-	Run(edges map[PromotionEdge]interface{}) error
+	Run() error
 }
 
 // ImageSizeCheck implements the PreCheck interface and checks against
@@ -75,6 +75,7 @@ type PreCheck interface {
 type ImageSizeCheck struct {
 	MaxImageSize    int
 	DigestImageSize DigestImageSize
+	PullEdges       map[PromotionEdge]interface{}
 }
 
 // PromotionEdge represents a promotion "link" of an image repository between 2

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -69,8 +69,9 @@ type PreCheck interface {
 	Run(edges map[PromotionEdge]interface{}) error
 }
 
-// MaxFileSize implements the PreCheck interface and checks against images that
-// are larger than a size threshold (controlled by the max-image-size flag).
+// ImageSizeCheck implements the PreCheck interface and checks against
+// images that are larger than a size threshold (controlled by the
+// max-image-size flag).
 type ImageSizeCheck struct {
 	MaxImageSize    float64
 	DigestImageSize DigestImageSize


### PR DESCRIPTION
We need to add an image size check to make sure that the promoter isn't promoting unnecessarily large images, since larger images can pose a security risk and are generally bad practice.