### PR TITLE
added --timeout option to make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ image-load-cip-auditor-e2e:
 image-push-cip-auditor-e2e:
 	bazel run //test-e2e/cip-auditor:push-cip-auditor-test
 lint:
-	GO111MODULE=on golangci-lint run
+	GO111MODULE=on golangci-lint --timeout=2s run
 lint-ci: download
 	make lint
 test: build


### PR DESCRIPTION
The pull-cip-lint job sometimes fails on pull requests due to timeout issues. In order to fix this, the "--timeout" flag has been added to ensure that the job runs for long enough to finish. Fixing issue #225.
