### PR TITLE
increased timeout of golangci-lint and added verbosity flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ image-load-cip-auditor-e2e:
 image-push-cip-auditor-e2e:
 	bazel run //test-e2e/cip-auditor:push-cip-auditor-test
 lint:
-	GO111MODULE=on golangci-lint --timeout=2s run
+	GO111MODULE=on golangci-lint run \
+		-v \
+		--timeout=5m 
 lint-ci: download
 	make lint
 test: build


### PR DESCRIPTION
Despite adding the --timeout flag to the make lint target, the pull-cip-lint job is still failing due to timeouts. Increased the timeout of the linter from 2 seconds to 5 minutes, and added a verbosity flag in order to see why failures might be occurring.