### PR TITLE
Add ImageSizeCheck to the promoter

### DIFF
--- a/cip.go
+++ b/cip.go
@@ -127,6 +127,13 @@ func main() {
 		"audit-gcp-project-id",
 		os.Getenv("CIP_AUDIT_GCP_PROJECT_ID"),
 		"GCP project ID (name); used for labeling error reporting logs to GCP")
+	maxImageSizePtr := flag.Int(
+		"max-image-size",
+		2048,
+		"The maximum image size (MiB) allowed for promotion and must be a positive value (othwerise set to the default value of 2048 MiB)")
+	if *maxImageSizePtr <= 0 {
+		*maxImageSizePtr = 2048
+	}
 	flag.Parse()
 
 	if len(os.Args) == 1 {
@@ -341,7 +348,7 @@ func main() {
 
 	if *jsonLogSummaryPtr {
 		defer sc.LogJSONSummary()
-    }
+	}
 
 	// Check the pull request
 	if *dryRunPtr {

--- a/lib/dockerregistry/checks.go
+++ b/lib/dockerregistry/checks.go
@@ -27,6 +27,18 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
+// MBToBytes converts a value from MiB to Bytes.
+func MBToBytes(value int) int {
+	const mbToBytesShift = 20
+	return value << mbToBytesShift
+}
+
+// BytesToMB converts a value from Bytes to MiB.
+func BytesToMB(value int) int {
+	const bytesToMBShift = 20
+	return value >> bytesToMBShift
+}
+
 func getGitShaFromEnv(envVar string) (plumbing.Hash, error) {
 	potenitalSHA := os.Getenv(envVar)
 	const gitShaLength = 40
@@ -154,5 +166,82 @@ func (check *ImageRemovalCheck) Compare(
 		return fmt.Errorf("The following images were removed in this pull "+
 			"request: %v", strings.Join(removedImages, ", "))
 	}
+	return nil
+}
+
+// Error is a function of ImageSizeError and implements the error interface.
+func (err ImageSizeError) Error() string {
+	errStr := ""
+	if len(err.OversizedImages) > 0 {
+		errStr += fmt.Sprintf("The following images were over the max file "+
+			"size of %dMiB:\n%v\n", err.MaxImageSize,
+			err.joinImageSizesToString(err.OversizedImages))
+	}
+	if len(err.InvalidImages) > 0 {
+		errStr += fmt.Sprintf("The following images had an invalid file size "+
+			"of 0 bytes or less:\n%v\n",
+			err.joinImageSizesToString(err.InvalidImages))
+	}
+	return errStr
+}
+
+func (err ImageSizeError) joinImageSizesToString(
+	imageSizes map[string]int,
+) string {
+	imageSizesStr := ""
+	imageNames := make([]string, 0)
+	for k := range imageSizes {
+		imageNames = append(imageNames, k)
+	}
+	sort.Strings(imageNames)
+	for i, imageName := range imageNames {
+		imageSizesStr += imageName + " (" +
+			fmt.Sprint(BytesToMB(imageSizes[imageName])) + " MiB)"
+		if i < len(imageNames)-1 {
+			imageSizesStr += "\n"
+		}
+	}
+	return imageSizesStr
+}
+
+// MKRealImageSizeCheck returns an instance of ImageSizeCheck which
+// checks that all images to be promoted are under a max size.
+func MKRealImageSizeCheck(
+	maxImageSize int,
+	edges map[PromotionEdge]interface{},
+	digestImageSize DigestImageSize,
+) *ImageSizeCheck {
+	return &ImageSizeCheck{
+		maxImageSize,
+		digestImageSize,
+		edges,
+	}
+}
+
+// Run is a function of ImageSizeCheck and checks that all
+// images to be promoted are under the max file size.
+func (check *ImageSizeCheck) Run() error {
+	maxImageSizeByte := MBToBytes(check.MaxImageSize)
+	oversizedImages := make(map[string]int)
+	invalidImages := make(map[string]int)
+	for edge := range check.PullEdges {
+		imageSize := check.DigestImageSize[edge.Digest]
+		imageName := string(edge.DstImageTag.ImageName)
+		if imageSize > maxImageSizeByte {
+			oversizedImages[imageName] = imageSize
+		}
+		if imageSize <= 0 {
+			invalidImages[imageName] = imageSize
+		}
+	}
+
+	if len(oversizedImages) > 0 || len(invalidImages) > 0 {
+		return ImageSizeError{
+			check.MaxImageSize,
+			oversizedImages,
+			invalidImages,
+		}
+	}
+
 	return nil
 }

--- a/lib/dockerregistry/checks.go
+++ b/lib/dockerregistry/checks.go
@@ -20,20 +20,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
-
-// ImageRemovalCheck implements the PreCheck interface and checks against
-// pull requests that attempt to remove any images from the promoter manifests.
-type ImageRemovalCheck struct {
-	GitRepoPath    string
-	MasterSHA      plumbing.Hash
-	PullRequestSHA plumbing.Hash
-	PullEdges      map[PromotionEdge]interface{}
-}
 
 func getGitShaFromEnv(envVar string) (plumbing.Hash, error) {
 	potenitalSHA := os.Getenv(envVar)

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -68,6 +68,7 @@ func MakeSyncContext(
 		Tokens:            make(map[RootRepo]gcloud.Token),
 		RegistryContexts:  make([]RegistryContext, 0),
 		DigestMediaType:   make(DigestMediaType),
+		DigestImageSize:   make(DigestImageSize),
 		ParentDigest:      make(ParentDigest)}
 
 	registriesSeen := make(map[RegistryContext]interface{})
@@ -1287,6 +1288,9 @@ func (sc *SyncContext) ReadRegistries(
 					fmt.Printf("digest %s: %s\n", digest, err)
 				}
 				sc.DigestMediaType[Digest(digest)] = mediaType
+
+				// Store ImageSize
+				sc.DigestImageSize[Digest(digest)] = int(mfestInfo.Size)
 				mutex.Unlock()
 			}
 

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -1222,7 +1222,8 @@ func TestReadRegistries(t *testing.T) {
 		sc := reg.SyncContext{
 			RegistryContexts: rcs,
 			Inv:              map[reg.RegistryName]reg.RegInvImage{fakeRegName: nil},
-			DigestMediaType:  make(reg.DigestMediaType)}
+			DigestMediaType:  make(reg.DigestMediaType),
+			DigestImageSize:  make(reg.DigestImageSize)}
 		// test is used to pin the "test" variable from the outer "range"
 		// scope (see scopelint).
 		test := test
@@ -1308,7 +1309,8 @@ func TestReadGManifestLists(t *testing.T) {
 						"sha256:0000000000000000000000000000000000000000000000000000000000000000": {"1.0"}}}},
 			DigestMediaType: reg.DigestMediaType{
 				"sha256:0000000000000000000000000000000000000000000000000000000000000000": cr.DockerManifestList},
-			ParentDigest: make(reg.ParentDigest)}
+			DigestImageSize: make(reg.DigestImageSize),
+			ParentDigest:    make(reg.ParentDigest)}
 		// test is used to pin the "test" variable from the outer "range"
 		// scope (see scopelint).
 		test := test

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -21,6 +21,7 @@ import (
 
 	cr "github.com/google/go-containerregistry/pkg/v1/types"
 
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
 	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
 )
@@ -72,6 +73,15 @@ type SyncContext struct {
 // nil otherwise.
 type PreCheck interface {
 	Run() error
+}
+
+// ImageRemovalCheck implements the PreCheck interface and checks against
+// pull requests that attempt to remove any images from the promoter manifests.
+type ImageRemovalCheck struct {
+	GitRepoPath    string
+	MasterSHA      plumbing.Hash
+	PullRequestSHA plumbing.Hash
+	PullEdges      map[PromotionEdge]interface{}
 }
 
 // PromotionEdge represents a promotion "link" of an image repository between 2

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -42,6 +42,14 @@ type Error struct {
 	Error   error
 }
 
+// ImageSizeError contains ImageSizeCheck information on images that are either
+// over the promoter's max image size or have an invalid size of 0 or less.
+type ImageSizeError struct {
+	MaxImageSize    int
+	OversizedImages map[string]int
+	InvalidImages   map[string]int
+}
+
 // CapturedRequests holds a map of all PromotionRequests that were generated. It
 // is used for both -dry-run and testing.
 type CapturedRequests map[PromotionRequest]int
@@ -62,6 +70,7 @@ type SyncContext struct {
 	SrcRegistry       *RegistryContext
 	Tokens            map[RootRepo]gcloud.Token
 	DigestMediaType   DigestMediaType
+	DigestImageSize   DigestImageSize
 	ParentDigest      ParentDigest
 	Logs              CollectedLogs
 }
@@ -73,6 +82,15 @@ type SyncContext struct {
 // nil otherwise.
 type PreCheck interface {
 	Run() error
+}
+
+// ImageSizeCheck implements the PreCheck interface and checks against
+// images that are larger than a size threshold (controlled by the
+// max-image-size flag).
+type ImageSizeCheck struct {
+	MaxImageSize    int
+	DigestImageSize DigestImageSize
+	PullEdges       map[PromotionEdge]interface{}
 }
 
 // ImageRemovalCheck implements the PreCheck interface and checks against
@@ -317,6 +335,9 @@ type ImageName string
 
 // DigestMediaType holds media information about a Digest.
 type DigestMediaType map[Digest]cr.MediaType
+
+// DigestImageSize holds information about the size of an image in bytes.
+type DigestImageSize map[Digest]int
 
 // ParentDigest holds a map of the digests of children to parent digests. It is
 // a reverse mapping of ManifestLists, which point to all the child manifests.


### PR DESCRIPTION
We need to add an image size check to make sure that the promoter isn't promoting unnecessarily large images, since larger images can pose a security risk and are generally bad practice. Moved from PR #227.