### PR TITLE
moved WaitGroup drain to after request results processed

### DIFF
--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2564,7 +2564,6 @@ func TestExecRequests(t *testing.T) {
 		for req := range reqs {
 			reqRes := reg.RequestResult{Context: req}
 			requestResults <- reqRes
-			wg.Add(-1)
 		}
 	}
 
@@ -2582,7 +2581,6 @@ func TestExecRequests(t *testing.T) {
 				Error:   fmt.Errorf("This request results in an error")})
 			reqRes.Errors = errors
 			requestResults <- reqRes
-			wg.Add(-1)
 		}
 	}
 


### PR DESCRIPTION
In order to fix the current bug in ExecRequests (Issue #237), we can simply move the WaitGroup draining logic to after the request results are processed. So from now on, the WaitGroup is drained at the end of the ProcessRequest function if and only if the request results channel is not being filled. Also, for the logic to still work, the request results channel needs to be filled at the end of the function.