### PR TITLE
Disable new golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,11 +55,15 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+  - exhaustive
+  - exportloopref
   - gochecknoglobals
   - godox
   - goerr113
+  - gofumpt
   - gosec
   - nolintlint
+  - sqlclosecheck
   - stylecheck
   - whitespace
   - wsl


### PR DESCRIPTION
golangci-lint v1.28.0 and further have added multiple new linters such as gofumpt that are extremely strict and have been causing linter issues for our pull requests. Also, only v1.27.0 is available on Mac. Let's disable these new linters until they are needed in the future.