### PR TITLE
MkRequestsCapturer: do not manually decrement semaphore

### DIFF
--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2092,7 +2092,7 @@ func getRegistriesToRead(
 	return rcsFinal
 }
 
-// Promote perferms container image promotion by realizing the intent in the
+// Promote performs container image promotion by realizing the intent in the
 // Manifest.
 //
 // nolint[gocyclo]

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2288,12 +2288,12 @@ func (pr *PromotionRequest) PrettyValue() string {
 }
 
 // MkRequestCapturer returns a function that simply records requests as they are
-// captured (slured out from the reqs channel).
+// captured (slurped out from the reqs channel).
 func MkRequestCapturer(captured *CapturedRequests) ProcessRequest {
 	return func(
 		sc *SyncContext,
 		reqs chan stream.ExternalRequest,
-		errs chan<- RequestResult,
+		requestResults chan<- RequestResult,
 		wg *sync.WaitGroup,
 		mutex *sync.Mutex) {
 
@@ -2302,7 +2302,10 @@ func MkRequestCapturer(captured *CapturedRequests) ProcessRequest {
 			mutex.Lock()
 			(*captured)[pr]++
 			mutex.Unlock()
-			wg.Add(-1)
+			// Add a request result to signal the processing of this "request".
+			// This is necessary because ExecRequests() is the sole function in
+			// the codebase that decrements the WaitGroup semaphore.
+			requestResults <- RequestResult{}
 		}
 	}
 }

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -2719,7 +2719,7 @@ func TestGarbageCollection(t *testing.T) {
 	var processRequestFake reg.ProcessRequest = func(
 		sc *reg.SyncContext,
 		reqs chan stream.ExternalRequest,
-		errs chan<- reg.RequestResult,
+		requestResults chan<- reg.RequestResult,
 		wg *sync.WaitGroup,
 		mutex *sync.Mutex) {
 
@@ -2728,7 +2728,7 @@ func TestGarbageCollection(t *testing.T) {
 			mutex.Lock()
 			captured[pr]++
 			mutex.Unlock()
-			wg.Add(-1)
+			requestResults <- reg.RequestResult{}
 		}
 	}
 
@@ -2855,7 +2855,7 @@ func TestGarbageCollectionMulti(t *testing.T) {
 	var processRequestFake reg.ProcessRequest = func(
 		sc *reg.SyncContext,
 		reqs chan stream.ExternalRequest,
-		errs chan<- reg.RequestResult,
+		requestResults chan<- reg.RequestResult,
 		wg *sync.WaitGroup,
 		mutex *sync.Mutex) {
 
@@ -2864,7 +2864,7 @@ func TestGarbageCollectionMulti(t *testing.T) {
 			mutex.Lock()
 			captured[pr]++
 			mutex.Unlock()
-			wg.Add(-1)
+			requestResults <- reg.RequestResult{}
 		}
 	}
 


### PR DESCRIPTION
As the semaphore decrementing duty has been simplified to be strictly
within ExecRequests() [1], the decrementing logic here must be replaced with
an empty RequestResult{} being pushed into the requestResults channel.

Also, fix a typo and rename `errs` to `requestResults` to be in line
with the rest of the codebase.

[1]: https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/238