### PR TITLE
Allow file manifest export to filter by prefix

### DIFF
--- a/cmd/promobot-generate-manifest/main.go
+++ b/cmd/promobot-generate-manifest/main.go
@@ -43,6 +43,9 @@ func main() {
 func run(ctx context.Context) error {
 	klog.InitFlags(nil)
 
+	var opt cmd.GenerateManifestOptions
+	opt.PopulateDefaults()
+
 	src := ""
 	flag.StringVar(
 		&src,
@@ -50,14 +53,17 @@ func run(ctx context.Context) error {
 		src,
 		"the base directory to copy from")
 
+	flag.StringVar(
+		&opt.Prefix,
+		"prefix",
+		opt.Prefix,
+		"restrict the exported files; only export those starting with the provided prefix")
+
 	flag.Parse()
 
 	if src == "" {
 		return xerrors.New("must specify --src")
 	}
-
-	var opt cmd.GenerateManifestOptions
-	opt.PopulateDefaults()
 
 	s, err := filepath.Abs(src)
 	if err != nil {

--- a/pkg/cmd/hash.go
+++ b/pkg/cmd/hash.go
@@ -31,6 +31,13 @@ import (
 type GenerateManifestOptions struct {
 	// BaseDir is the directory containing the files to hash
 	BaseDir string
+
+	// Prefix exports only files matching the specified prefix.
+	//
+	// If we were instead to change BaseDir, we would also
+	// restrict the files, but the relative paths would also
+	// change.
+	Prefix string
 }
 
 // PopulateDefaults sets the default values for GenerateManifestOptions.
@@ -59,6 +66,10 @@ func GenerateManifest(ctx context.Context, options GenerateManifestOptions) (*ap
 		}
 		if !strings.HasPrefix(p, basedir) {
 			return xerrors.Errorf("expected path %q to have prefix %q", p, basedir)
+		}
+
+		if !strings.HasPrefix(p, filepath.Join(basedir, options.Prefix)) {
+			return nil
 		}
 
 		if !info.IsDir() {


### PR DESCRIPTION
This is useful when we want to separate files by version.