### PR TITLE
modify the vulnerability to check against fixable vulnerabilities

### DIFF
--- a/lib/dockerregistry/checks.go
+++ b/lib/dockerregistry/checks.go
@@ -334,7 +334,10 @@ func (check *ImageVulnCheck) Run() error {
 
 			severeOccurrences := 0
 			for _, occ := range occurrences {
-				if IsSevereOccurrence(occ, check.SeverityThreshold) {
+				// The vulnerability check should only reject a PR if it finds
+				// vulnerabilities that are both fixable and severe
+				if occ.GetFixAvailable() &&
+					IsSevereOccurrence(occ, check.SeverityThreshold) {
 					errors = append(errors, Error{
 						Context: "vulnerabilities severity check",
 						Error: ImageVulnError{

--- a/lib/dockerregistry/checks_test.go
+++ b/lib/dockerregistry/checks_test.go
@@ -380,12 +380,14 @@ func TestImageVulnCheck(t *testing.T) {
 			map[reg.Digest][]*grafeaspb.VulnerabilityOccurrence{
 				"sha256:000": {
 					{
-						Severity: grafeaspb.Severity_LOW,
+						Severity:     grafeaspb.Severity_LOW,
+						FixAvailable: true,
 					},
 				},
 				"sha256:111": {
 					{
-						Severity: grafeaspb.Severity_MEDIUM,
+						Severity:     grafeaspb.Severity_MEDIUM,
+						FixAvailable: true,
 					},
 				},
 			},
@@ -401,12 +403,14 @@ func TestImageVulnCheck(t *testing.T) {
 			map[reg.Digest][]*grafeaspb.VulnerabilityOccurrence{
 				"sha256:000": {
 					{
-						Severity: grafeaspb.Severity_HIGH,
+						Severity:     grafeaspb.Severity_HIGH,
+						FixAvailable: true,
 					},
 				},
 				"sha256:111": {
 					{
-						Severity: grafeaspb.Severity_HIGH,
+						Severity:     grafeaspb.Severity_HIGH,
+						FixAvailable: true,
 					},
 				},
 			},
@@ -424,15 +428,18 @@ func TestImageVulnCheck(t *testing.T) {
 			map[reg.Digest][]*grafeaspb.VulnerabilityOccurrence{
 				"sha256:000": {
 					{
-						Severity: grafeaspb.Severity_HIGH,
+						Severity:     grafeaspb.Severity_HIGH,
+						FixAvailable: true,
 					},
 				},
 				"sha256:111": {
 					{
-						Severity: grafeaspb.Severity_HIGH,
+						Severity:     grafeaspb.Severity_HIGH,
+						FixAvailable: true,
 					},
 					{
-						Severity: grafeaspb.Severity_CRITICAL,
+						Severity:     grafeaspb.Severity_CRITICAL,
+						FixAvailable: true,
 					},
 				},
 			},
@@ -450,12 +457,33 @@ func TestImageVulnCheck(t *testing.T) {
 			map[reg.Digest][]*grafeaspb.VulnerabilityOccurrence{
 				"sha256:111": {
 					{
-						Severity: grafeaspb.Severity_HIGH,
+						Severity:     grafeaspb.Severity_HIGH,
+						FixAvailable: true,
 					},
 				},
 			},
 			fmt.Errorf("VulnerabilityCheck: The following vulnerable images were found:\n" +
 				"    bar@sha256:111 [1 severe vulnerabilities, 1 total]"),
+		},
+		{
+			"Multiple vulnerabilities with no fix",
+			int(grafeaspb.Severity_MEDIUM),
+			map[reg.PromotionEdge]interface{}{
+				edge1: nil,
+			},
+			map[reg.Digest][]*grafeaspb.VulnerabilityOccurrence{
+				"sha256:000": {
+					{
+						Severity:     grafeaspb.Severity_HIGH,
+						FixAvailable: false,
+					},
+					{
+						Severity:     grafeaspb.Severity_CRITICAL,
+						FixAvailable: false,
+					},
+				},
+			},
+			nil,
 		},
 	}
 


### PR DESCRIPTION
Modifying the vulnerability check so that it only rejects a pull request if it finds vulnerabilities for an image that are BOTH too severe and have a fix available. All vulnerabilities will still be logged (regardless if they have a fix or not).