### PR TITLE
fixed issue where vulnerabilities were only getting logged when a fix…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,12 +57,14 @@ linters:
   disable:
   - exhaustive
   - exportloopref
+  - gci
   - gochecknoglobals
   - godox
   - goerr113
   - gofumpt
   - gosec
   - nolintlint
+  - nlreturn
   - sqlclosecheck
   - stylecheck
   - whitespace

--- a/cip.go
+++ b/cip.go
@@ -286,6 +286,13 @@ func main() {
 
 		if *severityThresholdPtr >= 0 {
 			klog.Info("********** START (VULN CHECK) **********")
+			klog.Info("DISCLAIMER: Vulnerabilities are found as issues with " +
+				"package binaries within image layers, not necessarily " +
+				"with the image layers themselves. So a \"fixable\" " +
+				"vulnerability may not necessarily be immediately" +
+				"actionable. For example, even though a fixed version " +
+				"of the binary is available, it doesn't necessarily mean " +
+				"that a new version of the image layer is available.")
 		} else if *dryRunPtr {
 			klog.Info("********** START (DRY RUN) **********")
 		} else {

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -54,16 +54,17 @@ type ImageSizeError struct {
 // ImageVulnError contains ImageVulnCheck information on images that contain a
 // vulnerability with a severity level at or above the defined threshold.
 type ImageVulnError struct {
-	ImageName     ImageName
-	Digest        Digest
-	Vulnerability *grafeaspb.VulnerabilityOccurrence
+	ImageName      ImageName
+	Digest         Digest
+	OccurrenceName string
+	Vulnerability  *grafeaspb.VulnerabilityOccurrence
 }
 
 // ImageVulnProducer is used by ImageVulnCheck to get the vulnerabilities for
 // an image and allows for custom vulnerability producers for testing.
 type ImageVulnProducer func(
 	edge PromotionEdge,
-) ([]*grafeaspb.VulnerabilityOccurrence, error)
+) ([]*grafeaspb.Occurrence, error)
 
 // CapturedRequests holds a map of all PromotionRequests that were generated. It
 // is used for both -dry-run and testing.


### PR DESCRIPTION
Fixing the issue where vulnerabilities were only getting logged when a fixable vulnerability was found. The current behavior after this fix is that the vulnerability check will fail if and only if a severe and fixable vulnerability is found; but the vulnerability check will always log all of the vulnerabilities it finds. Additionally, if a fix is not available for an issue, we now clear out some of the fields that would incorrectly imply to the user that there was a fix when logged. 