### PR TITLE
inventory: sort the images based on the sorted tags and not in the hash

### DIFF
--- a/lib/container/set.go
+++ b/lib/container/set.go
@@ -31,6 +31,7 @@ func (a Set) Minus(b Set) Set {
 	for k := range b {
 		delete(c, k)
 	}
+
 	return c
 }
 
@@ -43,6 +44,7 @@ func (a Set) Union(b Set) Set {
 	for k, v := range b {
 		c[k] = v
 	}
+
 	return c
 }
 
@@ -55,5 +57,6 @@ func (a Set) Intersection(b Set) Set {
 			c[k] = v
 		}
 	}
+
 	return c
 }

--- a/lib/dockerregistry/grow_manifest.go
+++ b/lib/dockerregistry/grow_manifest.go
@@ -293,6 +293,7 @@ func Union(a, b RegInvImage) RegInvImage {
 		// injection.
 		if a[imageName] == nil {
 			a[imageName] = digestTags
+
 			continue
 		}
 		for digest, tags := range digestTags {
@@ -300,6 +301,7 @@ func Union(a, b RegInvImage) RegInvImage {
 			// and all associated tags.
 			if a[imageName][digest] == nil {
 				a[imageName][digest] = tags
+
 				continue
 			}
 			// If c has the digest already, try to inject those tags in b that
@@ -307,6 +309,7 @@ func Union(a, b RegInvImage) RegInvImage {
 			tagSlice := TagSlice{}
 			for tag := range tags.Union(a[imageName][digest]) {
 				if tag == "latest" {
+
 					continue
 				}
 				tagSlice = append(tagSlice, tag)

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -1771,8 +1771,9 @@ func (rii *RegInvImage) ToSorted() []ImageWithDigestSlice {
 				tags: tags,
 			})
 		}
+		// sort the digest beased on the first tag which was sorted above
 		sort.Slice(digests, func(i, j int) bool {
-			return digests[i].hash < digests[j].hash
+			return digests[i].tags[0] < digests[j].tags[0]
 		})
 
 		images = append(images, ImageWithDigestSlice{

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -2666,6 +2666,7 @@ func (payload GCRPubSubPayload) matchImage(
 	for _, tag := range tags {
 		if payload.Tag == tag {
 			m.TagMatch = true
+
 			break
 		}
 	}


### PR DESCRIPTION
Context:
We generate the image promotion for K/K artifacts and we notice the yaml file produced was something like

```yaml
- name: conformance
  dmap:
    "sha256:10b30e54a6367e69c52c22998f6f154475b7c94b7a674324f1b96b549048c50e": ["v1.19.0-rc.2"]
    "sha256:288138b199735aa767b042a2bbdc211fb852bf2e5e8368ab45e42fa1ddb0373f": ["v1.19.0-rc.3"]
    "sha256:4fccdf9bfd019a8871729a23d9be4055466b98f857fd811b2141f90bc60c86cc": ["v1.19.0-rc.4"]
- name: conformance-amd64
  dmap:
    "sha256:8c053fbfe74da394cf2c9ace242a060a27f62cb701b0d76f1377e14c0cc7ce4e": ["v1.19.0-rc.2"]
    "sha256:c84f41a851478e60c143e9dd98fe9ab3caca08ed598652a8e308d47855c3ab43": ["v1.19.0-rc.3"]
    "sha256:ea2b4c82b7b524aa1dc86da3d75ac142bc6ccd188e57df2f06cc220052c1eb9c": ["v1.19.0-rc.4"]
- name: conformance-arm
  dmap:
    "sha256:aac6803b665bc435193caa03ced25d7dfc4dd06f5e671fffcf8866abcefbdc15": ["v1.19.0-rc.3"]
    "sha256:b92cc0d5f677e10243fe886d049647fc3b2b6fed1f69ac3d4fd2ece6a36f207e": ["v1.19.0-rc.4"]
    "sha256:de8a15f9c32e0c025bd3231ccfc8e8a0872b6978ab225a0c262d2e04cbe9cad7": ["v1.19.0-rc.2"]
- name: conformance-arm64
  dmap:
    "sha256:255fe1e95ccd523817357db40eb56cef8ab6d93bb4fe30972a08dbc2f2be1ddf": ["v1.19.0-rc.2"]
    "sha256:2f9aaecaa147cfe2c33d89a4d23c15de9585ba444d756e21eb26f35400550930": ["v1.19.0-rc.3"]
    "sha256:9a85df6915994be54e2f4bfdb0447eb52dfb13ffdd7840847a8ec1d19cfc2be7": ["v1.19.0-rc.4"]
- name: conformance-ppc64le
  dmap:
    "sha256:2f7821c58fef43dec3d7cd8a92f6406c80855c60ce1cf80046c169859a3cf9ea": ["v1.19.0-rc.2"]
    "sha256:790627063d4c15d7e1fb75c49f86b78bd82de60d0c5fa288837af23be6803770": ["v1.19.0-rc.4"]
    "sha256:e296f92d5a5255c69eec77ab34ddd63048a839b58074c6bb58041a096651ce5e": ["v1.19.0-rc.3"]
....
```
*(can see the full file in this [PR](https://github.com/kubernetes/k8s.io/pull/1106))*
The Images are sorted by the hashes and @hasheddan came with the idea if we can sort that by the tags. Maybe is useful and this PR address that

Looking at the code when we are doing the sort the first step is to sort the tags because it can have multiple tags for the same hash. And then it sort the items by the hash.

the change here switch to sort by the tag, and since the tags is already sorted we take the first element in the tag array and use that to sort the items.

Applying that to the same PR that we did above we get

```yaml
- name: conformance
  dmap:
    "sha256:10b30e54a6367e69c52c22998f6f154475b7c94b7a674324f1b96b549048c50e": ["v1.19.0-rc.2"]
    "sha256:288138b199735aa767b042a2bbdc211fb852bf2e5e8368ab45e42fa1ddb0373f": ["v1.19.0-rc.3"]
    "sha256:4fccdf9bfd019a8871729a23d9be4055466b98f857fd811b2141f90bc60c86cc": ["v1.19.0-rc.4"]
- name: conformance-amd64
  dmap:
    "sha256:8c053fbfe74da394cf2c9ace242a060a27f62cb701b0d76f1377e14c0cc7ce4e": ["v1.19.0-rc.2"]
    "sha256:c84f41a851478e60c143e9dd98fe9ab3caca08ed598652a8e308d47855c3ab43": ["v1.19.0-rc.3"]
    "sha256:ea2b4c82b7b524aa1dc86da3d75ac142bc6ccd188e57df2f06cc220052c1eb9c": ["v1.19.0-rc.4"]
- name: conformance-arm
  dmap:
    "sha256:de8a15f9c32e0c025bd3231ccfc8e8a0872b6978ab225a0c262d2e04cbe9cad7": ["v1.19.0-rc.2"]
    "sha256:aac6803b665bc435193caa03ced25d7dfc4dd06f5e671fffcf8866abcefbdc15": ["v1.19.0-rc.3"]
    "sha256:b92cc0d5f677e10243fe886d049647fc3b2b6fed1f69ac3d4fd2ece6a36f207e": ["v1.19.0-rc.4"]
- name: conformance-arm64
  dmap:
    "sha256:255fe1e95ccd523817357db40eb56cef8ab6d93bb4fe30972a08dbc2f2be1ddf": ["v1.19.0-rc.2"]
    "sha256:2f9aaecaa147cfe2c33d89a4d23c15de9585ba444d756e21eb26f35400550930": ["v1.19.0-rc.3"]
    "sha256:9a85df6915994be54e2f4bfdb0447eb52dfb13ffdd7840847a8ec1d19cfc2be7": ["v1.19.0-rc.4"]
- name: conformance-ppc64le
  dmap:
    "sha256:2f7821c58fef43dec3d7cd8a92f6406c80855c60ce1cf80046c169859a3cf9ea": ["v1.19.0-rc.2"]
    "sha256:e296f92d5a5255c69eec77ab34ddd63048a839b58074c6bb58041a096651ce5e": ["v1.19.0-rc.3"]
    "sha256:790627063d4c15d7e1fb75c49f86b78bd82de60d0c5fa288837af23be6803770": ["v1.19.0-rc.4"]
```

Which is now sorted by the tags.

Feel free to close this PR if that makes no sense.

/assign @listx @dims @tpepper 
/cc @saschagrunert @hasheddan 


thanks for the idea Daniel!


