### PR TITLE
add the adapter and files needed for the vulnerability dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test-mac:
 		//pkg/api/files:go_default_test \
 		//lib/audit:go_default_test \
 		//lib/dockerregistry:go_default_test \
+		//dashboard/adapter:go_default_test \
 		//pkg/cmd:go_default_test
 test-ci: download
 	make build

--- a/cmd/promobot-files/BUILD.bazel
+++ b/cmd/promobot-files/BUILD.bazel
@@ -52,4 +52,3 @@ docker_push(
     name = "push-image-bundle",
     bundle = "image-bundle",
 )
-

--- a/dashboard/BUILD.bazel
+++ b/dashboard/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dashboard.go"],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/dashboard",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//dashboard/adapter:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "dashboard",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/dashboard/adapter/BUILD.bazel
+++ b/dashboard/adapter/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapter.go",
+        "types.go",
+    ],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/dashboard/adapter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_cloud_go//containeranalysis/apiv1:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+        "@go_googleapis//grafeas/v1:grafeas_go_proto",
+        "@org_golang_google_api//iterator:go_default_library",
+        "@org_golang_x_net//html:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["adapter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@go_googleapis//grafeas/v1:grafeas_go_proto",
+    ],
+)

--- a/dashboard/adapter/adapter.go
+++ b/dashboard/adapter/adapter.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	// nolint[lll]
+	containeranalysis "cloud.google.com/go/containeranalysis/apiv1"
+	"cloud.google.com/go/storage"
+	"golang.org/x/net/html"
+	"google.golang.org/api/iterator"
+	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
+)
+
+// nolint[errcheck]
+func uploadFile(directory, filename, bucket string) error {
+	const timeout = 60
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.NewClient: %v", err)
+	}
+	defer client.Close()
+
+	// Open local file
+	f, err := os.Open(directory + filename)
+	if err != nil {
+		return fmt.Errorf("os.Open: %v", err)
+	}
+	defer f.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*timeout)
+	defer cancel()
+
+	// Upload the object with storage.Writer
+	wc := client.Bucket(bucket).Object(filename).NewWriter(ctx)
+	if _, err = io.Copy(wc, f); err != nil {
+		return fmt.Errorf("io.Copy: %v", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("Writer.Close: %v", err)
+	}
+	return nil
+}
+
+// GetAllVulnerabilities gets all of the vulnerability occurrences associated
+// with images in a specific project using the Container Analysis Service.
+// nolint[errcheck]
+func GetAllVulnerabilities(
+	projectID string,
+) ([]*grafeaspb.Occurrence, error) {
+	ctx := context.Background()
+	client, err := containeranalysis.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	req := &grafeaspb.ListOccurrencesRequest{
+		Parent: fmt.Sprintf("projects/%s", projectID),
+		Filter: fmt.Sprintf("kind = %q", "VULNERABILITY"),
+	}
+
+	var occurrenceList []*grafeaspb.Occurrence
+	it := client.GetGrafeasClient().ListOccurrences(ctx, req)
+	for {
+		occ, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("occurrence iteration error: %v", err)
+		}
+		occurrenceList = append(occurrenceList, occ)
+	}
+	return occurrenceList, err
+}
+
+func parseImageResourceURL(resourceURL string) (string, string) {
+	FQIN := path.Base(resourceURL)
+	splitFQIN := strings.Split(FQIN, "@")
+	return splitFQIN[0], splitFQIN[1]
+}
+
+func parseVulnName(noteName string) string {
+	return path.Base(noteName)
+}
+
+// GenerateVulnerabilityBreakdown parses the a slice of vulnerability
+// occurrences into a breakdown that only contains the necessary information
+// for each vulnerability.
+func GenerateVulnerabilityBreakdown(
+	productionVulnerabilities []*grafeaspb.Occurrence,
+) map[string]ImageVulnBreakdown {
+	var vulnBreakdowns = make(map[string]ImageVulnBreakdown)
+	for _, occ := range productionVulnerabilities {
+		// resourceURI is a url pointing to a specific image
+		// in the form gcr.io/project/foo@sha256:111
+		if _, found := vulnBreakdowns[occ.ResourceUri]; !found {
+			imageName, imageDigest := parseImageResourceURL(occ.ResourceUri)
+			vulnBreakdowns[occ.ResourceUri] = ImageVulnBreakdown{
+				occ.ResourceUri,
+				imageName,
+				imageDigest,
+				0,
+				[]string{},
+				[]string{},
+			}
+		}
+
+		imageVulnBreakdown := vulnBreakdowns[occ.ResourceUri]
+		imageVulnBreakdown.NumVulnerabilities++
+
+		vulnName := parseVulnName(occ.NoteName)
+		vuln := occ.GetVulnerability()
+		if vuln.GetSeverity() == grafeaspb.Severity_CRITICAL {
+			imageVulnBreakdown.CriticalVulnerabilities = append(
+				imageVulnBreakdown.CriticalVulnerabilities,
+				vulnName,
+			)
+		}
+		if vuln.GetFixAvailable() {
+			imageVulnBreakdown.FixableVulnerabilities = append(
+				imageVulnBreakdown.FixableVulnerabilities,
+				vulnName,
+			)
+		}
+		vulnBreakdowns[occ.ResourceUri] = imageVulnBreakdown
+	}
+
+	return vulnBreakdowns
+}
+
+// UpdateVulnerabilityDashboard updates the vulnerability dashboard by uploading
+// the lastest versions of all the vulnerability dashboard's files.
+func UpdateVulnerabilityDashboard(
+	dashboardPath string,
+	vulnProject string,
+	dashboardBucket string,
+) error {
+	htmlReader, _ := os.Open(dashboardPath + "dashboard.html")
+	_, err := html.Parse(htmlReader)
+	if err != nil {
+		return fmt.Errorf("dashboard.html is not valid HTML: %v", err)
+	}
+	err = uploadFile(dashboardPath, "dashboard.html", dashboardBucket)
+	if err != nil {
+		return fmt.Errorf("Unable to upload latest version of "+
+			"dashboard HTML: %v", err)
+	}
+
+	err = uploadFile(dashboardPath, "dashboard.js", dashboardBucket)
+	if err != nil {
+		return fmt.Errorf("Unable to upload latest version of "+
+			"dashboard JS: %v", err)
+	}
+
+	productionVulnerabilities, _ := GetAllVulnerabilities(vulnProject)
+	vulnBreakdowns := GenerateVulnerabilityBreakdown(productionVulnerabilities)
+	jsonFile, err := json.MarshalIndent(vulnBreakdowns, "", " ")
+	if err != nil {
+		return fmt.Errorf("Unable to generate dashboard json: %v", err)
+	}
+
+	err = ioutil.WriteFile(dashboardPath+"dashboard.json",
+		jsonFile, os.ModeTemporary)
+	if err != nil {
+		return fmt.Errorf("Unable to create temporary local"+
+			"JSON file for the dashboard: %v", err)
+	}
+	err = uploadFile(dashboardPath, "dashboard.json", dashboardBucket)
+	if err != nil {
+		return fmt.Errorf("Unable to upload latest version of "+
+			"dashboard JSON: %v", err)
+	}
+	return nil
+}

--- a/dashboard/adapter/adapter_test.go
+++ b/dashboard/adapter/adapter_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
+	adapter "sigs.k8s.io/k8s-container-image-promoter/dashboard/adapter"
+)
+
+func checkEqual(got, expected interface{}) error {
+	if !reflect.DeepEqual(got, expected) {
+		return fmt.Errorf(
+			`<<<<<<< got (type %T)
+%v
+=======
+%v
+>>>>>>> expected (type %T)`,
+			got,
+			got,
+			expected,
+			expected)
+	}
+	return nil
+}
+
+func checkError(t *testing.T, err error, msg string) {
+	if err != nil {
+		fmt.Printf("\n%v", msg)
+		fmt.Println(err)
+		fmt.Println()
+		t.Fail()
+	}
+}
+
+func TestGenerateVulnerabilityBreakdown(t *testing.T) {
+	var tests = []struct {
+		name            string
+		vulnerabilities []*grafeaspb.Occurrence
+		expected        map[string]adapter.ImageVulnBreakdown
+	}{
+		{
+			"No critical and no fixable vulnerabilities",
+			[]*grafeaspb.Occurrence{
+				{
+					ResourceUri: "foo/bar1@sha256:111",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_HIGH,
+							FixAvailable: false,
+						},
+					},
+				},
+				{
+					ResourceUri: "foo/bar2@sha256:000",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_HIGH,
+							FixAvailable: false,
+						},
+					},
+				},
+			},
+			map[string]adapter.ImageVulnBreakdown{
+				"foo/bar1@sha256:111": {
+					"foo/bar1@sha256:111",
+					"bar1",
+					"sha256:111",
+					1,
+					[]string{},
+					[]string{},
+				},
+				"foo/bar2@sha256:000": {
+					"foo/bar2@sha256:000",
+					"bar2",
+					"sha256:000",
+					1,
+					[]string{},
+					[]string{},
+				},
+			},
+		},
+		{
+			"No critical and Multiple fixable vulnerabilities",
+			[]*grafeaspb.Occurrence{
+				{
+					ResourceUri: "foo/bar1@sha256:111",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_HIGH,
+							FixAvailable: true,
+						},
+					},
+				},
+				{
+					ResourceUri: "foo/bar2@sha256:000",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_MEDIUM,
+							FixAvailable: true,
+						},
+					},
+				},
+			},
+			map[string]adapter.ImageVulnBreakdown{
+				"foo/bar1@sha256:111": {
+					"foo/bar1@sha256:111",
+					"bar1",
+					"sha256:111",
+					1,
+					[]string{},
+					[]string{
+						"CVE-2000",
+					},
+				},
+				"foo/bar2@sha256:000": {
+					"foo/bar2@sha256:000",
+					"bar2",
+					"sha256:000",
+					1,
+					[]string{},
+					[]string{
+						"CVE-2000",
+					},
+				},
+			},
+		},
+		{
+			"Multiple critical and no fixable vulnerabilities",
+			[]*grafeaspb.Occurrence{
+				{
+					ResourceUri: "foo/bar1@sha256:111",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_CRITICAL,
+							FixAvailable: false,
+						},
+					},
+				},
+				{
+					ResourceUri: "foo/bar2@sha256:000",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_CRITICAL,
+							FixAvailable: false,
+						},
+					},
+				},
+			},
+			map[string]adapter.ImageVulnBreakdown{
+				"foo/bar1@sha256:111": {
+					"foo/bar1@sha256:111",
+					"bar1",
+					"sha256:111",
+					1,
+					[]string{
+						"CVE-2000",
+					},
+					[]string{},
+				},
+				"foo/bar2@sha256:000": {
+					"foo/bar2@sha256:000",
+					"bar2",
+					"sha256:000",
+					1,
+					[]string{
+						"CVE-2000",
+					},
+					[]string{},
+				},
+			},
+		},
+		{
+			"Multiple critical and fixable vulnerabilities",
+			[]*grafeaspb.Occurrence{
+				{
+					ResourceUri: "foo/bar1@sha256:111",
+					NoteName:    "vuln/CVE-2000",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_CRITICAL,
+							FixAvailable: true,
+						},
+					},
+				},
+				{
+					ResourceUri: "foo/bar2@sha256:000",
+					NoteName:    "vuln/CVE-2001",
+					Details: &grafeaspb.Occurrence_Vulnerability{
+						Vulnerability: &grafeaspb.VulnerabilityOccurrence{
+							Severity:     grafeaspb.Severity_CRITICAL,
+							FixAvailable: true,
+						},
+					},
+				},
+			},
+			map[string]adapter.ImageVulnBreakdown{
+				"foo/bar1@sha256:111": {
+					"foo/bar1@sha256:111",
+					"bar1",
+					"sha256:111",
+					1,
+					[]string{
+						"CVE-2000",
+					},
+					[]string{
+						"CVE-2000",
+					},
+				},
+				"foo/bar2@sha256:000": {
+					"foo/bar2@sha256:000",
+					"bar2",
+					"sha256:000",
+					1,
+					[]string{
+						"CVE-2001",
+					},
+					[]string{
+						"CVE-2001",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testBreakdown := adapter.GenerateVulnerabilityBreakdown(test.vulnerabilities)
+		err := checkEqual(testBreakdown, test.expected)
+		checkError(t, err, fmt.Sprintf("checkError: test: %v (GenerateDashboardJSON)\n", test.name))
+	}
+}

--- a/dashboard/adapter/types.go
+++ b/dashboard/adapter/types.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+// ImageVulnBreakdown is used by the adapter in order to store the information
+// from image vulnerability occurrencess that the dashboard needs.
+type ImageVulnBreakdown struct {
+	ResourceURI             string
+	ImageName               string
+	ImageDigest             string
+	NumVulnerabilities      int
+	CriticalVulnerabilities []string
+	FixableVulnerabilities  []string
+}

--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"k8s.io/klog"
+	adapter "sigs.k8s.io/k8s-container-image-promoter/dashboard/adapter"
+)
+
+// nolint[gocyclo]
+func main() {
+	// klog uses the "v" flag in order to set the verbosity level
+	klog.InitFlags(nil)
+	dashboardPath := flag.String(
+		"dashboard-file-path",
+		"",
+		"The path to the local dashboard files")
+	vulnProject := flag.String(
+		"vuln-target-project",
+		"",
+		"The project which the vulnerability dashboard will display information for")
+	dashboardBucket := flag.String(
+		"dashboard-bucket",
+		"",
+		"GCS bucket where dashboard files are stored")
+	flag.Parse()
+
+	if *dashboardPath == "" || *vulnProject == "" || *dashboardBucket == "" {
+		klog.Fatal(fmt.Errorf("all of -dashboard-file-path, -vuln-target-project, -dashboard-bucket are required flags"))
+	}
+
+	klog.Info("********** STARTING (UPDATING VULN DASHBOARD) **********")
+	adapter.UpdateVulnerabilityDashboard(*dashboardPath, *vulnProject, *dashboardBucket)
+	klog.Info("********** FINISHED (UPDATING VULN DASHBOARD) **********")
+}

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://storage.googleapis.com/k8s-artifacts-prod-vuln-dashboard/dashboard.js"></script>
+</head>
+
+<body>
+    <h1>Vulnerability Dashboard</h1>
+    <p>There's nothing here. This is just a test.</p>
+    <input onclick="ToggleFixableVulnerabiliyFilter()" type="checkbox" id="fixfilter" name="fixfilter" value="fixfiltertoggle">
+    <label for="fixfilter"> Show only vulnerabilities with a fix available</label><br>
+    <table align="center" id="table" border="1">
+    </table>
+</body>
+
+</html>

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,0 +1,77 @@
+const DASHBOARD_JSON = "https://storage.googleapis.com/k8s-artifacts-prod-vuln-dashboard/dashboard.json";
+const VULNERABILITY_URL_PREFIX = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=";
+const TABLE = "#table";
+var JSON;
+var filtering = false;
+
+console.log("Starting up");
+
+$.getJSON(DASHBOARD_JSON, function (data) {
+    console.log(data);
+    JSON = data;
+    constructTable();
+})
+
+function constructTable() {
+    $(TABLE).empty();
+    // Getting the all column names 
+    var headers = Headers();
+
+    // Traversing the JSON data 
+    for (var resourceURI in JSON) {
+        var ignoreRow = false;
+        var row = $('<tr/>');
+        for (var index = 0; index < headers.length; index++) {
+            var val = JSON[resourceURI][headers[index]];
+            
+            // If there is any key, which is matching 
+            // with the column name 
+            if (val == null) val = "";
+            if (filtering && headers[index] == "NumVulnerabilities"
+            && val != "" && parseInt(val) <= 0) {
+                ignoreRow = true;
+                break;
+            }
+            if (headers[index] == "ResourceURI") {
+                var link = $('<a href="' + val + '">' + val + '</a>')
+                row.append($('<td/>').html(link));
+            } else if (headers[index] == "CriticalVulnerabilities"
+            || headers[index] == "FixableVulnerabilities") {
+                var column = $('<div>');
+                for (var i = 0; i < val.length; i++) {
+                    $('<a style=\'display :block; width: 100%;\' href="' + VULNERABILITY_URL_PREFIX + val[i] + '">' + val[i] + '</a>').appendTo($div);
+                }
+                row.append($('<td/>').html(column));
+            } else row.append($('<td/>').html(val));
+        }
+
+        if (ignoreRow) continue;
+        // Adding each row to the table 
+        $(TABLE).append(row);
+    }
+}
+
+function Headers() {
+    var headers = [];
+    var header = $('<tr/>');
+    for (var resourceURI in JSON) {
+        var row = JSON[resourceURI];
+        for (var k in row) {
+            if ($.inArray(k, headers) == -1) {
+                headers.push(k);
+
+                // Creating the header 
+                header.append($('<th/>').html(k));
+            }
+        }
+    }
+
+    // Appending the header to the table 
+    $(TABLE).append(header);
+    return headers;
+}
+
+function ToggleFixableVulnerabiliyFilter() {
+    filtering = !filtering;
+    constructTable();
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/storage v1.5.0
 	github.com/google/go-containerregistry v0.0.0-20200219182403-4336215636f7
 	github.com/google/uuid v1.1.1
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	google.golang.org/api v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,7 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/lib/dockerregistry/BUILD.bazel
+++ b/lib/dockerregistry/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//lib/stream:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/types:go_default_library",
         "@go_googleapis//grafeas/v1:grafeas_go_proto",
-        "@io_k8s_klog//:go_default_library",
         "@org_golang_x_xerrors//:go_default_library",
     ],
 )


### PR DESCRIPTION
This PR is meant to implement the vulnerability dashboard described in Issue #253.
I added the adapter which reads vulnerability information for the entire Kubernetes' production project ("k8s-artifacts-prod") and parses into a simple JSON containing all the necessary information. That JSON is then uploaded to the dashboard's bucket in GCS. 
I also added the HTML and JS files necessary for the dashboard, which are also uploaded to the dashboard's bucket in GCS.
This PR will eventually be run in a Prow job that acts as a cron job at the start of each day.