### PR TITLE
add vulnerability dashboard documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,3 +358,21 @@ the VERSION file often as the Docker images will always get a unique identifier.
 [bazel]:https://bazel.build/
 [k8sio-manifests-dir]:https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io
 [cip-prow-integration]:https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md#prow-integration
+
+## Checks Interface
+Read more [here](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/checks_interface.md).
+
+The addition of the checks interface to the Container Image Promoter is meant
+to make it easy to add checks against pull requests affecting the promoter
+manifests. The interface allows engineers to add checks without worrying about
+any pre-existing checks and test their own checks individually, while also
+giving freedom as to what conditionals or tags might be necessary for the
+check to occur.
+
+## Vulnerability Dashboard
+Read more [here](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/dashboard/vulnerability_dashboard.md).
+
+The vulnerability dashboard is intended to surface the vulnerabilities of
+images in the Kubernetes production project - k8s-artifacts-prod. The
+dashboard can be accessed by visiting this
+[page](https://storage.googleapis.com/k8s-artifacts-prod-vuln-dashboard/dashboard.html).

--- a/dashboard/vulnerability_dashboard.md
+++ b/dashboard/vulnerability_dashboard.md
@@ -1,0 +1,45 @@
+# Image Vulnerability Dashboard
+The vulnerability dashboard is intended to surface the vulnerabilities of 
+images in the Kubernetes production project - k8s-artifacts-prod. The
+dashboard operates as a static HTML page hosted on Google Cloud Storage.
+It can be accessed by visiting this
+[page](https://storage.googleapis.com/k8s-artifacts-prod-vuln-dashboard/dashboard.html).
+
+## Information Flow
+
+### CAS Adapter
+The dashboard utilizes the Container Analysis Service in order to actually get
+the vulnerabilities it displays. However, the vulnerability information can't be used
+as provided by CAS. This is because CAS provides lots of unnecessary information which
+make it difficult to parse into an HTML table; not to mention, the large file size due
+to the sheer amount of information for each of Kubernetes' production images.
+
+In order to use this information, we use an adapter which processes the vulnerability
+occurrences returned from the CAS into a new
+[struct](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/dashboard/adapter/types.go)
+containing only the info that the dashboard needs in order to create its table. This
+information is then uploaded as a JSON file to Google Cloud Storage, where it can be parsed
+into an easy-to-read HTML table. The adapter is implemented in
+[adapter.go](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/dashboard/adapter/adapter.go).
+
+### JS Parser
+The CAS adapter described above writes the processed vulnerability information to a JSON
+stored in the vulnerability dashbaord's GCS bucket. In order to convert this JSON to a
+HTML table, a simple JavaScript file is also placed in the GCS bucket which can read in
+the contents of the JSON and create the table.
+
+The most updated versions of both the
+[JavaScript](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/dashboard/dashboard.js)
+file and the static
+[HTML](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/dashboard/dashboard.html)
+page are also uploaded to Google Cloud Storage whenever the adapter runs.
+
+## Integration With Prow
+In order to have the dashboard display the most up to date vulnerability information
+from the Container Analysis Service, a
+[periodic](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md)
+Prow job has been set up -
+[k8sio-vuln-dashboard-cron](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml).
+This Prow job runs once every 24 hours, and runs the adapter in order to get the most
+recent vulnerabilities and upload any new updates to the dashboard files stored in
+Google Cloud Storage.


### PR DESCRIPTION
Added some simple documentation that explains the vulnerability dashboard. Also made slight modifications to the repo readme to link to the checks interface readme and the new vulnerability dashboard readme.