### PR TITLE
Init v2 module

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,9 +9,10 @@ http_archive(
     ],
     sha256 = "aeca78988341a2ee1ba097641056d168320ecc51372ef7ff8e64b139516a4937",
 )
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-rules_pkg_dependencies()
 
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
 
 # You *must* import the Go rules before setting up the go_image rules.
 http_archive(
@@ -62,6 +63,7 @@ load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
+
 container_repositories()
 
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")

--- a/cip.go
+++ b/cip.go
@@ -23,11 +23,12 @@ import (
 
 	// nolint[lll]
 	guuid "github.com/google/uuid"
+
 	"k8s.io/klog"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/audit"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/audit"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/gcloud"
 )
 
 // GitDescribe is stamped by bazel.

--- a/cmd/cip-mm/main.go
+++ b/cmd/cip-mm/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
 )
 
 func main() {

--- a/cmd/promobot-files/main.go
+++ b/cmd/promobot-files/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/cmd"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/cmd"
 )
 
 func main() {

--- a/cmd/promobot-generate-manifest/main.go
+++ b/cmd/promobot-generate-manifest/main.go
@@ -24,8 +24,9 @@ import (
 	"path/filepath"
 
 	"golang.org/x/xerrors"
+
 	"k8s.io/klog"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/cmd"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/cmd"
 	"sigs.k8s.io/yaml"
 )
 

--- a/dashboard/adapter/adapter_test.go
+++ b/dashboard/adapter/adapter_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
-	adapter "sigs.k8s.io/k8s-container-image-promoter/dashboard/adapter"
+
+	adapter "sigs.k8s.io/k8s-container-image-promoter/v2/dashboard/adapter"
 )
 
 func checkEqual(got, expected interface{}) error {

--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog"
-	adapter "sigs.k8s.io/k8s-container-image-promoter/dashboard/adapter"
+	adapter "sigs.k8s.io/k8s-container-image-promoter/v2/dashboard/adapter"
 )
 
 // nolint[gocyclo]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/k8s-container-image-promoter
+module sigs.k8s.io/k8s-container-image-promoter/v2
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -394,7 +394,6 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -565,7 +564,6 @@ k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
 k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
-k8s.io/apimachinery v0.18.5 h1:Lh6tgsM9FMkC12K5T5QjRm7rDs6aQN5JHkA0JomULDM=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=
 k8s.io/cloud-provider v0.17.0/go.mod h1:Ze4c3w2C0bRsjkBUoHpFi+qWe3ob1wI2/7cUn+YQIDE=

--- a/lib/audit/auditor.go
+++ b/lib/audit/auditor.go
@@ -26,11 +26,12 @@ import (
 	"runtime/debug"
 
 	"cloud.google.com/go/errorreporting"
+
 	"k8s.io/klog"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/logclient"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/remotemanifest"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/report"
 )
 
 // InitRealServerContext creates a ServerContext with facilities that are meant

--- a/lib/audit/auditor_test.go
+++ b/lib/audit/auditor_test.go
@@ -26,12 +26,12 @@ import (
 	"regexp"
 	"testing"
 
-	"sigs.k8s.io/k8s-container-image-promoter/lib/audit"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/audit"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/logclient"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/remotemanifest"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/report"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
 )
 
 func checkMatch(haystack []byte, re *regexp.Regexp) error {

--- a/lib/audit/types.go
+++ b/lib/audit/types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package audit
 
 import (
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/logclient"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/remotemanifest"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/report"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/logclient"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/remotemanifest"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/report"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
 )
 
 // GcrReadingFacility holds functions used to create streams for reading the

--- a/lib/dockerregistry/checks.go
+++ b/lib/dockerregistry/checks.go
@@ -34,7 +34,8 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
+
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
 )
 
 // MBToBytes converts a value from MiB to Bytes.

--- a/lib/dockerregistry/checks_test.go
+++ b/lib/dockerregistry/checks_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
 )
 
 func TestImageRemovalCheck(t *testing.T) {

--- a/lib/dockerregistry/grow_manifest_test.go
+++ b/lib/dockerregistry/grow_manifest_test.go
@@ -24,7 +24,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
 )
 
 func TestFindManifest(t *testing.T) {

--- a/lib/dockerregistry/inventory.go
+++ b/lib/dockerregistry/inventory.go
@@ -29,17 +29,17 @@ import (
 	"strings"
 	"sync"
 
-	yaml "gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
-
 	"github.com/google/go-containerregistry/pkg/crane"
 	ggcrV1 "github.com/google/go-containerregistry/pkg/v1"
 	ggcrV1Google "github.com/google/go-containerregistry/pkg/v1/google"
 	ggcrV1Types "github.com/google/go-containerregistry/pkg/v1/types"
-	cipJson "sigs.k8s.io/k8s-container-image-promoter/lib/json"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
+	yaml "gopkg.in/yaml.v2"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	cipJson "sigs.k8s.io/k8s-container-image-promoter/v2/lib/json"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/gcloud"
 )
 
 // GetSrcRegistry gets the source registry.

--- a/lib/dockerregistry/inventory_test.go
+++ b/lib/dockerregistry/inventory_test.go
@@ -26,9 +26,10 @@ import (
 	"testing"
 
 	cr "github.com/google/go-containerregistry/pkg/v1/types"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/json"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
+
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/json"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
 )
 
 func checkEqual(got, expected interface{}) error {

--- a/lib/dockerregistry/set.go
+++ b/lib/dockerregistry/set.go
@@ -17,7 +17,7 @@ limitations under the License.
 package inventory
 
 // nolint[lll]
-import "sigs.k8s.io/k8s-container-image-promoter/lib/container"
+import "sigs.k8s.io/k8s-container-image-promoter/v2/lib/container"
 
 // Various set manipulation operations. Some set operations are missing,
 // because, we don't use them.

--- a/lib/dockerregistry/types.go
+++ b/lib/dockerregistry/types.go
@@ -20,11 +20,11 @@ import (
 	"sync"
 
 	cr "github.com/google/go-containerregistry/pkg/v1/types"
-
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
+
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/gcloud"
 )
 
 // RequestResult contains information about the result of running a request

--- a/lib/remotemanifest/fake.go
+++ b/lib/remotemanifest/fake.go
@@ -17,7 +17,7 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
 )
 
 // Fake is a fake remote manifest. It is fake in the sense that it

--- a/lib/remotemanifest/git.go
+++ b/lib/remotemanifest/git.go
@@ -25,8 +25,9 @@ import (
 
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+
 	"k8s.io/klog"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
 )
 
 const (

--- a/lib/remotemanifest/types.go
+++ b/lib/remotemanifest/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
 )
 
 // Facility requires a single method, called Fetch(), which corresponds to

--- a/pkg/api/files/manifest_test.go
+++ b/pkg/api/files/manifest_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
 )
 
 func TestValidateFilestores(t *testing.T) {

--- a/pkg/cmd/hash.go
+++ b/pkg/cmd/hash.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 
 	"golang.org/x/xerrors"
-	api "sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/filepromoter"
+
+	api "sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/filepromoter"
 )
 
 // GenerateManifestOptions holds the parameters for a hash-files operation.

--- a/pkg/cmd/hash_test.go
+++ b/pkg/cmd/hash_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 
 	"k8s.io/utils/diff"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/cmd"
 	"sigs.k8s.io/yaml"
-
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/cmd"
 )
 
 func TestHash(t *testing.T) {

--- a/pkg/cmd/promotefiles.go
+++ b/pkg/cmd/promotefiles.go
@@ -27,9 +27,10 @@ import (
 	"sort"
 
 	"golang.org/x/xerrors"
+
 	"k8s.io/klog"
-	api "sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/filepromoter"
+	api "sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/filepromoter"
 )
 
 // PromoteFilesOptions holds the flag-values for a file promotion

--- a/pkg/cmd/readmanifest_test.go
+++ b/pkg/cmd/readmanifest_test.go
@@ -19,9 +19,8 @@ package cmd_test
 import (
 	"testing"
 
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/cmd"
 	"sigs.k8s.io/yaml"
-
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/cmd"
 )
 
 func TestReadManifests(t *testing.T) {

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -26,7 +26,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
-	api "sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
+	api "sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
 )
 
 // syncFileInfo tracks a file during the synchronization operation.

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -25,8 +25,9 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
+
 	"k8s.io/klog"
-	api "sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
+	api "sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
 )
 
 // FilestorePromoter manages the promotion of files.

--- a/pkg/filepromoter/gcs.go
+++ b/pkg/filepromoter/gcs.go
@@ -27,8 +27,9 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
+
 	"k8s.io/klog"
-	api "sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
+	api "sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
 )
 
 type gcsSyncFilestore struct {

--- a/pkg/filepromoter/manifest.go
+++ b/pkg/filepromoter/manifest.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog"
-	api "sigs.k8s.io/k8s-container-image-promoter/pkg/api/files"
+	api "sigs.k8s.io/k8s-container-image-promoter/v2/pkg/api/files"
 )
 
 // ManifestPromoter promotes files as described in Manifest.

--- a/pkg/filepromoter/token.go
+++ b/pkg/filepromoter/token.go
@@ -20,8 +20,9 @@ import (
 	"sync"
 
 	"golang.org/x/oauth2"
+
 	"k8s.io/klog"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/gcloud"
 )
 
 // gcloudTokenSource implements oauth2.TokenSource.

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -12,12 +12,12 @@ import (
 
 	guuid "github.com/google/uuid"
 	yaml "gopkg.in/yaml.v2"
-	"k8s.io/klog"
 
-	"sigs.k8s.io/k8s-container-image-promoter/lib/audit"
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
+	"k8s.io/klog"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/audit"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/gcloud"
 )
 
 // GitDescribe is stamped by bazel.

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
-	"k8s.io/klog"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/lib/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/lib/stream"
-	"sigs.k8s.io/k8s-container-image-promoter/pkg/gcloud"
+	"k8s.io/klog"
+	reg "sigs.k8s.io/k8s-container-image-promoter/v2/lib/dockerregistry"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/lib/stream"
+	"sigs.k8s.io/k8s-container-image-promoter/v2/pkg/gcloud"
 )
 
 // GitDescribe is stamped by bazel.


### PR DESCRIPTION
Now that we're attempting to integrate the manifest merging capabilities into k/release (https://github.com/kubernetes/release/pull/1619), we're running into the dreaded v2 semantic import versioning problem:

```console
require sigs.k8s.io/k8s-container-image-promoter: version "v2.4.0" invalid: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```

ref: https://github.com/kubernetes/release/pull/1619#discussion_r502631879, https://blog.golang.org/v2-go-modules, https://donatstudios.com/Go-v2-Modules, https://peter.bourgon.org/blog/2020/09/14/siv-is-unsound.html

This PR establishes a v2 module for CIP, so that consumers can use the libraries in this repo.

/kind feature
/assign @listx @dims 
cc: @kubernetes-sigs/release-engineering @bytecook