### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,10 +3,12 @@
 approvers:
 - sig-release-leads
 - release-engineering-approvers
+- wg-k8s-infra-leads
 - cip-approvers
 reviewers:
 - release-engineering-approvers
 - release-engineering-reviewers
+- wg-k8s-infra-leads
 - cip-approvers
 - cip-reviewers
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- sig-release-leads
+- release-engineering-approvers
 - cip-approvers
 reviewers:
+- release-engineering-approvers
+- release-engineering-reviewers
 - cip-approvers
 - cip-reviewers
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dims
-- hh
-- listx
-- tpepper
-- bartsmykla
+- cip-approvers
 reviewers:
-- dims
-- hh
-- listx
-- tpepper
-- ps882
-- bartsmykla
+- cip-approvers
+- cip-reviewers
 
 labels:
 - sig/release
+- area/release-eng
+- wg/k8s-infra

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  cip-approvers:
+    - dims
+    - hh
+    - listx
+    - tpepper
+    - bartsmykla
+  cip-reviewers:
+    - dims
+    - hh
+    - listx
+    - tpepper
+    - ps882
+    - bartsmykla

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,12 +4,16 @@ aliases:
   cip-approvers:
     - dims
     - hh
+    - justaugustus
+    - justinsb
     - listx
     - tpepper
     - bartsmykla
   cip-reviewers:
     - dims
     - hh
+    - justaugustus
+    - justinsb
     - listx
     - tpepper
     - ps882

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,20 +18,15 @@ aliases:
     - hoegaarden # Release Manager
     - idealhack # Release Manager
     - xmudrii # Release Manager
+  wg-k8s-infra-leads:
+    - bartsmykla
+    - dims
+    - spiffxp
   cip-approvers:
-    - dims
-    - hh
     - justaugustus
     - justinsb
     - listx
-    - tpepper
-    - bartsmykla
   cip-reviewers:
-    - dims
-    - hh
     - justaugustus
     - justinsb
     - listx
-    - tpepper
-    - ps882
-    - bartsmykla

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,23 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 aliases:
+  sig-release-leads:
+    - alejandrox1
+    - justaugustus
+    - saschagrunert
+    - tpepper
+  release-engineering-approvers:
+    - justaugustus # subproject owner / Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - tpepper # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - cpanato # Release Manager
+    - dougm # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager
+    - hoegaarden # Release Manager
+    - idealhack # Release Manager
+    - xmudrii # Release Manager
   cip-approvers:
     - dims
     - hh


### PR DESCRIPTION
- Move reviewers/approvers to aliases and update repo labels
- Add @justaugustus and @justinsb as approvers
- Add SIG Release + RelEng reviewers/approvers
- Add wg-k8s-infra-leads alias and remove inactive

/assign @listx @justinsb 
cc: @kubernetes-sigs/release-engineering @dims @spiffxp @bartsmykla 