### PR TITLE
cloudbuild.yaml: Use bazelbuild:latest-2.2.0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   machineType: N1_HIGHCPU_32
 steps:
 # Start by just pushing the image
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1'
+- name: 'gcr.io/k8s-testimages/bazelbuild:latest-2.2.0'
   entrypoint: make
   env:
   - PROW_GIT_TAG=$_GIT_TAG


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Uses the `latest-2.2.0` tag of gcr.io/k8s-testimages/bazelbuild to support the bazel bump that was done in https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/264.

/assign @listx 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #271.

#### Special notes for your reviewer:

Confirmed working with https://console.cloud.google.com/cloud-build/builds/3ae22197-ff9d-422c-b61a-1d1a86269550?project=k8s-staging-artifact-promoter:

```console
$ time builder --project=k8s-staging-artifact-promoter --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb --env-passthrough=PULL_BASE_REF .
```

<details>

```console
2020/10/20 21:43:38 Build directory: .
2020/10/20 21:43:38 Config directory: /home/augustus/go/src/sigs.k8s.io/k8s-container-image-promoter
2020/10/20 21:43:38 cd-ing to build directory: .
2020/10/20 21:43:38 Creating source tarball at /tmp/969913337...
2020/10/20 21:43:39 Uploading /tmp/969913337 to gs://k8s-staging-artifact-promoter-gcb/source/b78246c3-d85a-40dc-a571-d8e582367781.tgz...
Copying file:///tmp/969913337 [Content-Type=application/octet-stream]...
/ [1 files][  6.2 MiB/  6.2 MiB]                                                
Operation completed over 1 objects/6.2 MiB.                                      
2020/10/20 21:43:43 Running build jobs...
2020/10/20 21:43:43 No variants.yaml, starting single build job...
Created [https://cloudbuild.googleapis.com/v1/projects/k8s-staging-artifact-promoter/builds/3ae22197-ff9d-422c-b61a-1d1a86269550].
Logs are available at [https://console.cloud.google.com/cloud-build/builds/3ae22197-ff9d-422c-b61a-1d1a86269550?project=675573440409].
------------------------------------------------------------------------------------------------------ REMOTE BUILD OUTPUT -------------------------------------------------------------------------------------------------------
starting build "3ae22197-ff9d-422c-b61a-1d1a86269550"

FETCHSOURCE
Fetching storage object: gs://k8s-staging-artifact-promoter-gcb/source/1603244623.398341-a498fec8b2674b159355b4bc7dbd99a1.tgz#1603244623653315
Copying gs://k8s-staging-artifact-promoter-gcb/source/1603244623.398341-a498fec8b2674b159355b4bc7dbd99a1.tgz#1603244623653315...
/ [1 files][  6.2 MiB/  6.2 MiB]                                                
Operation completed over 1 objects/6.2 MiB.                                      
BUILD
Pulling image: gcr.io/k8s-testimages/bazelbuild:latest-2.2.0
latest-2.2.0: Pulling from k8s-testimages/bazelbuild
f08d8e2a3ba1: Pulling fs layer
3baa9cb2483b: Pulling fs layer
94e5ff4c0b15: Pulling fs layer
1860925334f9: Pulling fs layer
a6e27eed707a: Pulling fs layer
fb1489a73c27: Pulling fs layer
a89ac7cb103a: Pulling fs layer
b16719f151bf: Pulling fs layer
e8f85db56179: Pulling fs layer
ba9d5b38da6c: Pulling fs layer
2c80e4aa7278: Pulling fs layer
ba9d5b38da6c: Waiting
a6e27eed707a: Waiting
a89ac7cb103a: Waiting
2c80e4aa7278: Waiting
e8f85db56179: Waiting
b16719f151bf: Waiting
fb1489a73c27: Waiting
1860925334f9: Waiting
94e5ff4c0b15: Verifying Checksum
94e5ff4c0b15: Download complete
3baa9cb2483b: Verifying Checksum
3baa9cb2483b: Download complete
1860925334f9: Verifying Checksum
1860925334f9: Download complete
f08d8e2a3ba1: Verifying Checksum
f08d8e2a3ba1: Download complete
a89ac7cb103a: Verifying Checksum
a89ac7cb103a: Download complete
f08d8e2a3ba1: Pull complete
3baa9cb2483b: Pull complete
94e5ff4c0b15: Pull complete
1860925334f9: Pull complete
b16719f151bf: Download complete
e8f85db56179: Verifying Checksum
e8f85db56179: Download complete
2c80e4aa7278: Download complete
a6e27eed707a: Verifying Checksum
a6e27eed707a: Download complete
fb1489a73c27: Verifying Checksum
fb1489a73c27: Download complete
a6e27eed707a: Pull complete
fb1489a73c27: Pull complete
a89ac7cb103a: Pull complete
b16719f151bf: Pull complete
e8f85db56179: Pull complete
ba9d5b38da6c: Pull complete
2c80e4aa7278: Pull complete
Digest: sha256:38b1ed2c74e8ea4c2126cf88449ed3ee30d8f7056809f11b24fdc200fef28a02
Status: Downloaded newer image for gcr.io/k8s-testimages/bazelbuild:latest-2.2.0
gcr.io/k8s-testimages/bazelbuild:latest-2.2.0
bazel build //:cip-docker-loadable.tar //cmd/promobot-files:image-bundle.tar
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
Loading: 
Loading: 0 packages loaded
Loading: 0 packages loaded
Loading: 0 packages loaded
DEBUG: Rule 'rules_python' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1564776078 -0400"
DEBUG: Call stack for the definition of repository 'rules_python' which is a git_repository (rule definition at /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/bazel_tools/tools/build_defs/repo/git.bzl:195:18):
 - <builtin>
 - /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/bazel_tools/tools/build_defs/repo/utils.bzl:201:9
 - /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/rules_pkg/deps.bzl:33:5
 - /workspace/WORKSPACE:15:1
Loading: 0 packages loaded
Loading: 0 packages loaded
Loading: 0 packages loaded
Loading: 0 packages loaded
Analyzing: 2 targets (2 packages loaded, 0 targets configured)
Analyzing: 2 targets (11 packages loaded, 6 targets configured)
Analyzing: 2 targets (11 packages loaded, 6 targets configured)
Analyzing: 2 targets (53 packages loaded, 6827 targets configured)
Analyzing: 2 targets (55 packages loaded, 6861 targets configured)
Analyzing: 2 targets (57 packages loaded, 6865 targets configured)
Analyzing: 2 targets (57 packages loaded, 6865 targets configured)
Analyzing: 2 targets (331 packages loaded, 8893 targets configured)
INFO: Analyzed 2 targets (335 packages loaded, 8992 targets configured).
INFO: Found 2 targets...
[0 / 234] [Prepa] BazelWorkspaceStatusAction stable-status.txt ... (4 actions, 0 running)
[85 / 738] Compiling external/com_google_protobuf/src/google/protobuf/generated_message_table_driven_lite.cc [for host]; 5s linux-sandbox ... (32 actions, 31 running)
[146 / 738] Compiling external/com_google_protobuf/src/google/protobuf/compiler/cpp/cpp_message.cc; 6s linux-sandbox ... (32 actions, 31 running)
[229 / 738] Compiling external/com_google_protobuf/src/google/protobuf/compiler/cpp/cpp_message.cc [for host]; 4s linux-sandbox ... (32 actions, 31 running)
[330 / 738] GUNZIP external/google-sdk-base/image/002.tar.gz.nogz; 11s linux-sandbox ... (32 actions, 31 running)
INFO: From Generating Descriptor Set proto_library @go_googleapis//grafeas/v1:grafeas_proto:
grafeas/v1/grafeas.proto:30:1: warning: Import grafeas/v1/provenance.proto but not used.
INFO: From Generating Descriptor Set proto_library @go_googleapis//google/devtools/containeranalysis/v1:containeranalysis_proto:
google/devtools/containeranalysis/v1/containeranalysis.proto:23:1: warning: Import google/protobuf/timestamp.proto but not used.
INFO: From Generating Descriptor Set proto_library @go_googleapis//google/logging/v2:logging_proto:
google/logging/v2/log_entry.proto:26:1: warning: Import google/rpc/status.proto but not used.
google/logging/v2/logging.proto:22:1: warning: Import google/logging/v2/logging_config.proto but not used.
google/logging/v2/logging.proto:23:1: warning: Import google/protobuf/duration.proto but not used.
google/logging/v2/logging.proto:25:1: warning: Import google/protobuf/timestamp.proto but not used.
google/logging/v2/logging_metrics.proto:23:1: warning: Import google/protobuf/field_mask.proto but not used.
INFO: From Generating into bazel-out/k8-fastbuild/bin/external/go_googleapis/google/devtools/containeranalysis/v1/linux_amd64_stripped/containeranalysis_go_proto%/google.golang.org/genproto/googleapis/devtools/containeranalysis/v1:
google/devtools/containeranalysis/v1/containeranalysis.proto: warning: Import google/protobuf/timestamp.proto but not used.
INFO: From Generating into bazel-out/k8-fastbuild/bin/external/go_googleapis/google/logging/v2/linux_amd64_stripped/logging_go_proto%/google.golang.org/genproto/googleapis/logging/v2:
google/logging/v2/log_entry.proto: warning: Import google/rpc/status.proto but not used.
google/logging/v2/logging.proto: warning: Import google/protobuf/duration.proto but not used.
google/logging/v2/logging.proto: warning: Import google/protobuf/timestamp.proto but not used.
google/logging/v2/logging.proto: warning: Import google/logging/v2/logging_config.proto but not used.
google/logging/v2/logging_metrics.proto: warning: Import google/protobuf/field_mask.proto but not used.
INFO: From Generating into bazel-out/k8-fastbuild/bin/external/go_googleapis/grafeas/v1/linux_amd64_stripped/grafeas_go_proto%/google.golang.org/genproto/googleapis/grafeas/v1:
grafeas/v1/grafeas.proto: warning: Import grafeas/v1/provenance.proto but not used.
[501 / 813] GUNZIP external/google-sdk-base/image/002.tar.gz.nogz; 22s linux-sandbox ... (10 actions, 1 running)
[811 / 813] JoinLayers cmd/promobot-files/image-bundle.tar; 5s linux-sandbox ... (2 actions running)
INFO: Elapsed time: 104.801s, Critical Path: 44.14s
INFO: 772 processes: 772 linux-sandbox.
INFO: Build completed successfully, 813 total actions
INFO: Build completed successfully, 813 total actions
bazel run :push-cip //cmd/promobot-files:push-image-bundle
Loading: 
Loading: 0 packages loaded
DEBUG: Rule 'rules_python' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1564776078 -0400"
DEBUG: Call stack for the definition of repository 'rules_python' which is a git_repository (rule definition at /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/bazel_tools/tools/build_defs/repo/git.bzl:195:18):
 - <builtin>
 - /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/bazel_tools/tools/build_defs/repo/utils.bzl:201:9
 - /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/rules_pkg/deps.bzl:33:5
 - /workspace/WORKSPACE:15:1
Analyzing: target //:push-cip (0 packages loaded, 0 targets configured)
INFO: Analyzed target //:push-cip (2 packages loaded, 22 targets configured).
INFO: Found 1 target...
[0 / 4] [Prepa] BazelWorkspaceStatusAction stable-status.txt
[40 / 52] GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/google/go-cmp/cmp/linux_amd64_stripped/cmp%/github.com/google/go-containerregistry/vendor/github.com/google/go-cmp/cmp.a [for host]; 0s linux-sandbox ... (2 actions running)
[41 / 52] GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/docker/docker-credential-helpers/client/linux_amd64_stripped/client%/github.com/google/go-containerregistry/vendor/github.com/docker/docker-credential-helpers/client.a [for host]; 1s linux-sandbox ... (2 actions running)
[41 / 52] GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/docker/docker-credential-helpers/client/linux_amd64_stripped/client%/github.com/google/go-containerregistry/vendor/github.com/docker/docker-credential-helpers/client.a [for host]; 2s linux-sandbox ... (2 actions running)
[44 / 52] GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/docker/cli/cli/config/configfile/linux_amd64_stripped/configfile%/github.com/google/go-containerregistry/vendor/github.com/docker/cli/cli/config/configfile.a [for host]; 0s linux-sandbox ... (2 actions running)
[46 / 52] [Prepa] GoCompilePkg external/com_github_google_go_containerregistry/vendor/github.com/docker/cli/cli/config/linux_amd64_stripped/config%/github.com/google/go-containerregistry/vendor/github.com/docker/cli/cli/config.a [for host]
[48 / 52] [Prepa] GoCompilePkg external/com_github_google_go_containerregistry/pkg/v1/remote/transport/linux_amd64_stripped/transport%/github.com/google/go-containerregistry/pkg/v1/remote/transport.a [for host]
[50 / 52] [Prepa] GoCompilePkg external/io_bazel_rules_docker/container/go/cmd/pusher/linux_amd64_stripped/pusher%/github.com/bazelbuild/rules_docker.a [for host]
[51 / 52] GoLink external/io_bazel_rules_docker/container/go/cmd/pusher/linux_amd64_stripped/pusher [for host]; 1s linux-sandbox
[51 / 52] GoLink external/io_bazel_rules_docker/container/go/cmd/pusher/linux_amd64_stripped/pusher [for host]; 2s linux-sandbox
Target //:push-cip up-to-date:
  bazel-bin/push-cip
INFO: Elapsed time: 14.535s, Critical Path: 14.00s
INFO: 26 processes: 26 linux-sandbox.
INFO: Build completed successfully, 34 total actions
INFO: Running command line: bazel-bin/push-cip //cmd/promobot-files:push-image-bundle
INFO: Build completed successfully, 34 total actions
2020/10/21 01:47:31 Destination {STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor:latest was resolved to gcr.io/k8s-staging-artifact-promoter/cip-auditor:latest after stamping.
2020/10/21 01:47:31 Destination {STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}:latest was resolved to gcr.io/k8s-staging-artifact-promoter/cip:latest after stamping.
2020/10/21 01:47:31 Destination {STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}:{IMG_TAG} was resolved to gcr.io/k8s-staging-artifact-promoter/cip:20201021-pkgv0.2.0-14-g2028df1e after stamping.
2020/10/21 01:47:31 Destination {STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor:{IMG_TAG} was resolved to gcr.io/k8s-staging-artifact-promoter/cip-auditor:20201021-pkgv0.2.0-14-g2028df1e after stamping.
2020/10/21 01:47:33 Successfully pushed Docker image to gcr.io/k8s-staging-artifact-promoter/cip:20201021-pkgv0.2.0-14-g2028df1e
2020/10/21 01:47:33 Successfully pushed Docker image to gcr.io/k8s-staging-artifact-promoter/cip-auditor:latest
2020/10/21 01:47:33 Successfully pushed Docker image to gcr.io/k8s-staging-artifact-promoter/cip-auditor:20201021-pkgv0.2.0-14-g2028df1e
2020/10/21 01:47:33 Successfully pushed Docker image to gcr.io/k8s-staging-artifact-promoter/cip:latest
PUSH
DONE
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

INFO: Display format: "
        table(
          id,
          createTime.date('%Y-%m-%dT%H:%M:%S%Oz', undefined='-'),
          duration(start=startTime,end=finishTime,precision=0,calendar=false,undefined="  -").slice(2:).join(""):label=DURATION,
          build_source(undefined="-"):label=SOURCE,
          build_images(undefined="-"):label=IMAGES,
          status
        )
      "
ID                                    CREATE_TIME                DURATION  SOURCE                                                                                                IMAGES  STATUS
3ae22197-ff9d-422c-b61a-1d1a86269550  2020-10-21T01:43:43+00:00  2M60S     gs://k8s-staging-artifact-promoter-gcb/source/1603244623.398341-a498fec8b2674b159355b4bc7dbd99a1.tgz  -       SUCCESS
2020/10/20 21:48:00 Successfully built image:  
2020/10/20 21:48:00 Finished.

real	4m22.677s
user	0m3.398s
sys	0m0.286s
```

</details>

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
