### PR TITLE
cmd/cip: Depend on k/release/pkg/cip/cli

### DIFF
--- a/cmd/cip/cmd/BUILD.bazel
+++ b/cmd/cip/cmd/BUILD.bazel
@@ -11,15 +11,10 @@ go_library(
     importpath = "sigs.k8s.io/k8s-container-image-promoter/cmd/cip/cmd",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_google_uuid//:uuid",
         "@com_github_pkg_errors//:errors",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_cobra//:cobra",
-        "@io_k8s_release//pkg/cip/audit",
-        "@io_k8s_release//pkg/cip/dockerregistry",
-        "@io_k8s_release//pkg/cip/gcloud",
-        "@io_k8s_release//pkg/cip/stream",
+        "@io_k8s_release//pkg/cip/cli",
         "@io_k8s_release//pkg/log",
-        "@io_k8s_release//pkg/version",
     ],
 )

--- a/cmd/cip/cmd/audit.go
+++ b/cmd/cip/cmd/audit.go
@@ -17,14 +17,10 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-
-	guuid "github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/cip/audit"
+	"k8s.io/release/pkg/cip/cli"
 )
 
 // auditCmd represents the base command when called without any subcommands
@@ -40,119 +36,42 @@ Start an audit server that responds to Pub/Sub push events.
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(
-			runImageAuditor(auditOpts),
+			cli.RunAuditCmd(auditOpts),
 			"run `cip audit`",
 		)
 	},
 }
 
-// TODO: Push these into a package.
-type auditOptions struct {
-	projectID    string
-	repoURL      string
-	repoBranch   string
-	manifestPath string
-	uuid         string
-}
-
-var auditOpts = &auditOptions{}
+var auditOpts = &cli.AuditOptions{}
 
 func init() {
 	auditCmd.PersistentFlags().StringVar(
-		&auditOpts.projectID,
+		&auditOpts.ProjectID,
 		"project",
 		"",
 		"GCP project name (used for labeling error reporting logs in GCP)",
 	)
 
 	auditCmd.PersistentFlags().StringVar(
-		&auditOpts.repoURL,
+		&auditOpts.RepoURL,
 		"url",
 		"",
 		"repository URL for promoter manifests",
 	)
 
 	auditCmd.PersistentFlags().StringVar(
-		&auditOpts.repoBranch,
+		&auditOpts.RepoBranch,
 		"branch",
 		"",
 		"git branch of the promoter manifest repo to checkout",
 	)
 
 	auditCmd.PersistentFlags().StringVar(
-		&auditOpts.manifestPath,
+		&auditOpts.ManifestPath,
 		"path",
 		"",
 		"manifest path (relative to the root of promoter manifest repo)",
 	)
 
 	rootCmd.AddCommand(auditCmd)
-}
-
-func runImageAuditor(opts *auditOptions) error {
-	opts.set()
-
-	if err := validateAuditOptions(opts); err != nil {
-		return errors.Wrap(err, "validating audit options")
-	}
-
-	auditorContext, err := audit.InitRealServerContext(
-		opts.projectID,
-		opts.repoURL,
-		opts.repoBranch,
-		opts.manifestPath,
-		opts.uuid,
-	)
-	if err != nil {
-		return errors.Wrap(err, "creating auditor context")
-	}
-
-	auditorContext.RunAuditor()
-
-	return nil
-}
-
-func (o *auditOptions) set() {
-	logrus.Infof("Setting image auditor options...")
-
-	if o.projectID == "" {
-		o.projectID = os.Getenv("CIP_AUDIT_GCP_PROJECT_ID")
-	}
-
-	if o.repoURL == "" {
-		o.repoURL = os.Getenv("CIP_AUDIT_MANIFEST_REPO_URL")
-	}
-
-	if o.repoBranch == "" {
-		o.repoBranch = os.Getenv("CIP_AUDIT_MANIFEST_REPO_BRANCH")
-	}
-
-	if o.manifestPath == "" {
-		o.manifestPath = os.Getenv("CIP_AUDIT_MANIFEST_REPO_MANIFEST_DIR")
-	}
-
-	// TODO: Should we allow this to be configurable via the command line?
-	o.uuid = os.Getenv("CIP_AUDIT_TESTCASE_UUID")
-	if len(o.uuid) > 0 {
-		logrus.Infof("Starting auditor in Test Mode (%s)", o.uuid)
-	} else {
-		o.uuid = guuid.New().String()
-		logrus.Infof("Starting auditor in Regular Mode (%s)", o.uuid)
-	}
-
-	logrus.Infof(
-		// nolint: lll
-		"Image auditor options: [GCP project: %s, repo URL: %s, repo branch: %s, path: %s, UUID: %s]",
-		o.repoURL,
-		o.repoBranch,
-		o.manifestPath,
-		o.projectID,
-		o.uuid,
-	)
-}
-
-func validateAuditOptions(o *auditOptions) error {
-	// TODO: Validate root options
-	// TODO: Validate audit options
-	return nil
 }

--- a/cmd/cip/cmd/root.go
+++ b/cmd/cip/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"k8s.io/release/pkg/cip/cli"
 	"k8s.io/release/pkg/log"
 )
 
@@ -45,13 +46,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: initLogging,
 }
 
-type rootOptions struct {
-	logLevel string
-	dryRun   bool
-	version  bool
-}
-
-var rootOpts = &rootOptions{}
+var rootOpts = &cli.RootOptions{}
 
 // Execute adds all child commands to the root command and sets flags.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -63,33 +58,27 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(
-		&rootOpts.logLevel,
+		&rootOpts.LogLevel,
 		"log-level",
 		"info",
 		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
 	)
 
 	rootCmd.PersistentFlags().BoolVar(
-		&rootOpts.dryRun,
+		&rootOpts.DryRun,
 		"dry-run",
-		rootOpts.dryRun,
+		rootOpts.DryRun,
 		"test run promotion without modifying any registry",
 	)
 
 	rootCmd.PersistentFlags().BoolVar(
-		&rootOpts.version,
+		&rootOpts.Version,
 		"version",
-		rootOpts.version,
+		rootOpts.Version,
 		"print version",
 	)
 }
 
 func initLogging(*cobra.Command, []string) error {
-	return log.SetupGlobalLogger(rootOpts.logLevel)
-}
-
-func printVersion() {
-	fmt.Printf("Built:   %s\n", TimestampUtcRfc3339)
-	fmt.Printf("Version: %s\n", GitDescribe)
-	fmt.Printf("Commit:  %s\n", GitCommit)
+	return log.SetupGlobalLogger(rootOpts.LogLevel)
 }

--- a/cmd/cip/cmd/run.go
+++ b/cmd/cip/cmd/run.go
@@ -18,15 +18,11 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/cip/gcloud"
-	"k8s.io/release/pkg/cip/stream"
+	"k8s.io/release/pkg/cip/cli"
 )
 
 // runCmd represents the base command when called without any subcommands
@@ -42,68 +38,29 @@ Promote images from a staging registry to production
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(
-			runImagePromotion(runOpts),
+			cli.RunPromoteCmd(runOpts),
 			"run `cip run`",
 		)
 	},
 }
 
-// TODO: Push these into a package.
-type runOptions struct {
-	manifest                string
-	thinManifestDir         string
-	keyFiles                string
-	snapshot                string
-	snapshotTag             string
-	outputFormat            string
-	snapshotSvcAcct         string
-	manifestBasedSnapshotOf string
-	threads                 int
-	maxImageSize            int
-	severityThreshold       int
-	jsonLogSummary          bool
-	parseOnly               bool
-	minimalSnapshot         bool
-	useServiceAcct          bool
-}
-
-var runOpts = &runOptions{}
-
-const (
-	// TODO: Push these into a package.
-	defaultThreads           = 10
-	defaultOutputFormat      = "yaml"
-	defaultMaxImageSize      = 2048
-	defaultSeverityThreshold = -1
-
-	// flags.
-	manifestFlag                = "manifest"
-	thinManifestDirFlag         = "thin-manifest-dir"
-	snapshotFlag                = "snapshot"
-	manifestBasedSnapshotOfFlag = "manifest-based-snapshot-of"
-	outputFlag                  = "output"
-)
-
-var allowedOutputFormats = []string{
-	"csv",
-	"yaml",
-}
+var runOpts = &cli.RunOptions{}
 
 // TODO: Function 'init' is too long (171 > 60) (funlen)
 // nolint: funlen
 func init() {
 	// TODO: Move this into a default options function in pkg/promobot
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.manifest,
-		manifestFlag,
-		runOpts.manifest,
+		&runOpts.Manifest,
+		cli.PromoterManifestFlag,
+		runOpts.Manifest,
 		"the manifest file to load",
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.thinManifestDir,
-		thinManifestDirFlag,
-		runOpts.thinManifestDir,
+		&runOpts.ThinManifestDir,
+		cli.PromoterThinManifestDirFlag,
+		runOpts.ThinManifestDir,
 		`recursively read in all manifests within a folder, but all manifests
 MUST be 'thin' manifests named 'promoter-manifest.yaml', which are like regular
 manifests but instead of defining the 'images: ...' field directly, the
@@ -112,115 +69,118 @@ the 'images: ...' contents`,
 	)
 
 	runCmd.PersistentFlags().IntVar(
-		&runOpts.threads,
+		&runOpts.Threads,
 		"threads",
-		defaultThreads,
+		cli.PromoterDefaultThreads,
 		"number of concurrent goroutines to use when talking to GCR",
 	)
 
 	runCmd.PersistentFlags().BoolVar(
-		&runOpts.jsonLogSummary,
+		&runOpts.JSONLogSummary,
 		"json-log-summary",
-		runOpts.jsonLogSummary,
+		runOpts.JSONLogSummary,
 		"only log a JSON summary of important errors",
 	)
 
 	runCmd.PersistentFlags().BoolVar(
-		&runOpts.parseOnly,
+		&runOpts.ParseOnly,
 		"parse-only",
-		runOpts.parseOnly,
+		runOpts.ParseOnly,
 		"only check that the given manifest file is parsable as a Manifest",
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.keyFiles,
+		&runOpts.KeyFiles,
 		"key-files",
-		runOpts.keyFiles,
+		runOpts.KeyFiles,
 		`CSV of service account key files that must be activated for the
 promotion (<json-key-file-path>,...)`,
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.snapshot,
-		snapshotFlag,
-		runOpts.snapshot,
+		&runOpts.Snapshot,
+		cli.PromoterSnapshotFlag,
+		runOpts.Snapshot,
 		"read all images in a repository and print to stdout",
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.snapshotTag,
+		&runOpts.SnapshotTag,
 		"snapshot-tag",
-		runOpts.snapshotTag,
+		runOpts.SnapshotTag,
 		"only snapshot images with the given tag",
 	)
 
 	runCmd.PersistentFlags().BoolVar(
-		&runOpts.minimalSnapshot,
+		&runOpts.MinimalSnapshot,
 		"minimal-snapshot",
-		runOpts.minimalSnapshot,
+		runOpts.MinimalSnapshot,
 		fmt.Sprintf(`(only works with '--%s' or '--%s') discard tagless images
 from snapshot output if they are referenced by a manifest list`,
-			snapshotFlag,
-			manifestBasedSnapshotOfFlag,
+			cli.PromoterSnapshotFlag,
+			cli.PromoterManifestBasedSnapshotOfFlag,
 		),
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.outputFormat,
-		outputFlag,
-		defaultOutputFormat,
+		&runOpts.OutputFormat,
+		cli.PromoterOutputFlag,
+		cli.PromoterDefaultOutputFormat,
 		fmt.Sprintf(`(only works with '--%s' or '--%s') choose output
 format of the snapshot (allowed values: %q)`,
-			snapshotFlag,
-			manifestBasedSnapshotOfFlag,
-			allowedOutputFormats,
+			cli.PromoterSnapshotFlag,
+			cli.PromoterManifestBasedSnapshotOfFlag,
+			cli.PromoterAllowedOutputFormats,
 		),
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.snapshotSvcAcct,
+		&runOpts.SnapshotSvcAcct,
 		"snapshot-service-account",
-		runOpts.snapshotSvcAcct,
-		fmt.Sprintf("service account to use for '--%s'", snapshotFlag),
+		runOpts.SnapshotSvcAcct,
+		fmt.Sprintf(
+			"service account to use for '--%s'",
+			cli.PromoterSnapshotFlag,
+		),
 	)
 
 	runCmd.PersistentFlags().StringVar(
-		&runOpts.manifestBasedSnapshotOf,
-		manifestBasedSnapshotOfFlag,
-		runOpts.manifestBasedSnapshotOf,
+		&runOpts.ManifestBasedSnapshotOf,
+		cli.PromoterManifestBasedSnapshotOfFlag,
+		runOpts.ManifestBasedSnapshotOf,
 		fmt.Sprintf(`read all images in either '--%s' or '--%s' and print all
-images that should be promoted to the given registry (assuming the given
+images that should be promoted to the given registry (assuming the given,
 registry is empty); this is like '--%s', but instead of reading over the
 network from a registry, it reads from the local manifests only`,
-			manifestFlag,
-			thinManifestDirFlag,
-			snapshotFlag,
+			cli.PromoterManifestFlag,
+			cli.PromoterThinManifestDirFlag,
+			cli.PromoterSnapshotFlag,
 		),
 	)
 
 	runCmd.PersistentFlags().BoolVar(
-		&runOpts.useServiceAcct,
+		&runOpts.UseServiceAcct,
 		"use-service-account",
-		runOpts.useServiceAcct,
+		runOpts.UseServiceAcct,
 		"pass '--account=...' to all gcloud calls",
 	)
 
 	runCmd.PersistentFlags().IntVar(
-		&runOpts.maxImageSize,
+		&runOpts.MaxImageSize,
 		"max-image-size",
-		defaultMaxImageSize,
+		cli.PromoterDefaultMaxImageSize,
 		"the maximum image size (in MiB) allowed for promotion",
 	)
 
 	// TODO: Set this in a function instead
-	if runOpts.maxImageSize <= 0 {
-		runOpts.maxImageSize = 2048
+	if runOpts.MaxImageSize <= 0 {
+		runOpts.MaxImageSize = 2048
 	}
 
 	runCmd.PersistentFlags().IntVar(
-		&runOpts.severityThreshold,
+		&runOpts.SeverityThreshold,
 		"vuln-severity-threshold",
-		defaultSeverityThreshold,
+		cli.PromoterDefaultSeverityThreshold,
 		`Using this flag will cause the promoter to only run the vulnerability
 check. Found vulnerabilities at or above this threshold will result in the
 vulnerability check failing [severity levels between 0 and 5; 0 - UNSPECIFIED,
@@ -228,321 +188,4 @@ vulnerability check failing [severity levels between 0 and 5; 0 - UNSPECIFIED,
 	)
 
 	rootCmd.AddCommand(runCmd)
-}
-
-// TODO: Function 'runImagePromotion' has too many statements (97 > 40) (funlen)
-// nolint: funlen,gocognit,gocyclo
-func runImagePromotion(opts *runOptions) error {
-	if rootOpts.version {
-		printVersion()
-		return nil
-	}
-
-	if err := validateImageOptions(opts); err != nil {
-		return errors.Wrap(err, "validating image options")
-	}
-
-	// Activate service accounts.
-	if opts.useServiceAcct && opts.keyFiles != "" {
-		if err := gcloud.ActivateServiceAccounts(opts.keyFiles); err != nil {
-			return errors.Wrap(err, "activating service accounts")
-		}
-	}
-
-	var (
-		mfest       reg.Manifest
-		srcRegistry *reg.RegistryContext
-		err         error
-		mfests      []reg.Manifest
-	)
-
-	promotionEdges := make(map[reg.PromotionEdge]interface{})
-	sc := reg.SyncContext{}
-	mi := make(reg.MasterInventory)
-
-	// TODO: Move this into the validation function
-	if opts.snapshot != "" || opts.manifestBasedSnapshotOf != "" {
-		if opts.snapshot != "" {
-			srcRegistry = &reg.RegistryContext{
-				Name:           reg.RegistryName(opts.snapshot),
-				ServiceAccount: opts.snapshotSvcAcct,
-				Src:            true,
-			}
-		} else {
-			srcRegistry = &reg.RegistryContext{
-				Name:           reg.RegistryName(opts.manifestBasedSnapshotOf),
-				ServiceAccount: opts.snapshotSvcAcct,
-				Src:            true,
-			}
-		}
-
-		mfests = []reg.Manifest{
-			{
-				Registries: []reg.RegistryContext{
-					*srcRegistry,
-				},
-				Images: []reg.Image{},
-			},
-		}
-		// TODO: Move this into the validation function
-	} else if opts.manifest == "" && opts.thinManifestDir == "" {
-		logrus.Fatalf(
-			"either %s or %s flag is required",
-			manifestFlag,
-			thinManifestDirFlag,
-		)
-	}
-
-	doingPromotion := false
-
-	// TODO: is deeply nested (complexity: 5) (nestif)
-	// nolint: nestif
-	if opts.manifest != "" {
-		mfest, err = reg.ParseManifestFromFile(opts.manifest)
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
-		mfests = append(mfests, mfest)
-		for _, registry := range mfest.Registries {
-			mi[registry.Name] = nil
-		}
-
-		sc, err = reg.MakeSyncContext(
-			mfests,
-			opts.threads,
-			rootOpts.dryRun,
-			opts.useServiceAcct,
-		)
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
-		doingPromotion = true
-	} else if opts.thinManifestDir != "" {
-		mfests, err = reg.ParseThinManifestsFromDir(opts.thinManifestDir)
-		if err != nil {
-			return errors.Wrap(err, "parsing thin manifest directory")
-		}
-
-		sc, err = reg.MakeSyncContext(
-			mfests,
-			opts.threads,
-			rootOpts.dryRun,
-			opts.useServiceAcct)
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
-		doingPromotion = true
-	}
-
-	if opts.parseOnly {
-		return nil
-	}
-
-	// If there are no images in the manifest, it may be a stub manifest file
-	// (such as for brand new registries that would be watched by the promoter
-	// for the very first time).
-	// TODO: is deeply nested (complexity: 6) (nestif)
-	// nolint: nestif
-	if doingPromotion && opts.manifestBasedSnapshotOf == "" {
-		promotionEdges, err = reg.ToPromotionEdges(mfests)
-		if err != nil {
-			return errors.Wrap(
-				err,
-				"converting list of manifests to edges for promotion",
-			)
-		}
-
-		imagesInManifests := false
-		for _, mfest := range mfests {
-			if len(mfest.Images) > 0 {
-				imagesInManifests = true
-				break
-			}
-		}
-		if !imagesInManifests {
-			logrus.Info("No images in manifest(s) --- nothing to do.")
-			return nil
-		}
-
-		// Print version to make Prow logs more self-explanatory.
-		printVersion()
-
-		// nolint: gocritic
-		if opts.severityThreshold >= 0 {
-			logrus.Info("********** START (VULN CHECK) **********")
-			logrus.Info(
-				`DISCLAIMER: Vulnerabilities are found as issues with package
-binaries within image layers, not necessarily with the image layers themselves.
-So a 'fixable' vulnerability may not necessarily be immediately actionable. For
-example, even though a fixed version of the binary is available, it doesn't
-necessarily mean that a new version of the image layer is available.`,
-			)
-		} else if rootOpts.dryRun {
-			logrus.Info("********** START (DRY RUN) **********")
-		} else {
-			logrus.Info("********** START **********")
-		}
-	}
-
-	// TODO: is deeply nested (complexity: 12) (nestif)
-	// nolint: nestif
-	if len(opts.snapshot) > 0 || len(opts.manifestBasedSnapshotOf) > 0 {
-		rii := make(reg.RegInvImage)
-		if len(opts.manifestBasedSnapshotOf) > 0 {
-			promotionEdges, err = reg.ToPromotionEdges(mfests)
-			if err != nil {
-				return errors.Wrap(
-					err,
-					"converting list of manifests to edges for promotion",
-				)
-			}
-
-			rii = reg.EdgesToRegInvImage(
-				promotionEdges,
-				opts.manifestBasedSnapshotOf,
-			)
-
-			if opts.minimalSnapshot {
-				sc.ReadRegistries(
-					[]reg.RegistryContext{*srcRegistry},
-					true,
-					reg.MkReadRepositoryCmdReal,
-				)
-
-				sc.ReadGCRManifestLists(reg.MkReadManifestListCmdReal)
-				rii = sc.RemoveChildDigestEntries(rii)
-			}
-		} else {
-			sc, err = reg.MakeSyncContext(
-				mfests,
-				opts.threads,
-				rootOpts.dryRun,
-				opts.useServiceAcct,
-			)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-
-			sc.ReadRegistries(
-				[]reg.RegistryContext{*srcRegistry},
-				// Read all registries recursively, because we want to produce a
-				// complete snapshot.
-				true,
-				reg.MkReadRepositoryCmdReal,
-			)
-
-			rii = sc.Inv[mfests[0].Registries[0].Name]
-			if opts.snapshotTag != "" {
-				rii = reg.FilterByTag(rii, opts.snapshotTag)
-			}
-
-			if opts.minimalSnapshot {
-				logrus.Info("removing tagless child digests of manifest lists")
-				sc.ReadGCRManifestLists(reg.MkReadManifestListCmdReal)
-				rii = sc.RemoveChildDigestEntries(rii)
-			}
-		}
-
-		var snapshot string
-		switch strings.ToLower(opts.outputFormat) {
-		case "csv":
-			snapshot = rii.ToCSV()
-		case "yaml":
-			snapshot = rii.ToYAML(reg.YamlMarshalingOpts{})
-		default:
-			logrus.Errorf(
-				"invalid value %s for '--%s'; defaulting to %s",
-				opts.outputFormat,
-				outputFlag,
-				defaultOutputFormat,
-			)
-
-			snapshot = rii.ToYAML(reg.YamlMarshalingOpts{})
-		}
-
-		fmt.Print(snapshot)
-		return nil
-	}
-
-	if opts.jsonLogSummary {
-		defer sc.LogJSONSummary()
-	}
-
-	// Check the pull request
-	if rootOpts.dryRun {
-		err = sc.RunChecks([]reg.PreCheck{})
-		if err != nil {
-			return errors.Wrap(err, "running prechecks before promotion")
-		}
-	}
-
-	// Promote.
-	mkProducer := func(
-		srcRegistry reg.RegistryName,
-		srcImageName reg.ImageName,
-		destRC reg.RegistryContext,
-		imageName reg.ImageName,
-		digest reg.Digest, tag reg.Tag, tp reg.TagOp,
-	) stream.Producer {
-		var sp stream.Subprocess
-		sp.CmdInvocation = reg.GetWriteCmd(
-			destRC,
-			sc.UseServiceAccount,
-			srcRegistry,
-			srcImageName,
-			imageName,
-			digest,
-			tag,
-			tp,
-		)
-
-		return &sp
-	}
-
-	promotionEdges, ok := sc.FilterPromotionEdges(promotionEdges, true)
-	// If any funny business was detected during a comparison of the manifests
-	// with the state of the registries, then exit immediately.
-	if !ok {
-		return errors.New("encountered errors during edge filtering")
-	}
-
-	if opts.severityThreshold >= 0 {
-		err = sc.RunChecks(
-			[]reg.PreCheck{
-				reg.MKImageVulnCheck(
-					sc,
-					promotionEdges,
-					opts.severityThreshold,
-					nil,
-				),
-			},
-		)
-		if err != nil {
-			return errors.Wrap(err, "checking image vulnerabilities")
-		}
-	} else {
-		err = sc.Promote(promotionEdges, mkProducer, nil)
-		if err != nil {
-			return errors.Wrap(err, "promoting images")
-		}
-	}
-
-	// nolint: gocritic
-	if opts.severityThreshold >= 0 {
-		logrus.Info("********** FINISHED (VULN CHECK) **********")
-	} else if rootOpts.dryRun {
-		logrus.Info("********** FINISHED (DRY RUN) **********")
-	} else {
-		logrus.Info("********** FINISHED **********")
-	}
-
-	return nil
-}
-
-func validateImageOptions(o *runOptions) error {
-	// TODO: Validate options
-	return nil
 }

--- a/cmd/cip/cmd/version.go
+++ b/cmd/cip/cmd/version.go
@@ -17,19 +17,12 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/version"
+	"k8s.io/release/pkg/cip/cli"
 )
 
-type versionOptions struct {
-	json bool
-}
-
-var versionOpts = &versionOptions{}
+var versionOpts = &cli.VersionOptions{}
 
 // versionCmd is the command when calling `cip version`.
 var versionCmd = &cobra.Command{
@@ -38,13 +31,13 @@ var versionCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runVersion(versionOpts)
+		return cli.RunVersionCmd(versionOpts)
 	},
 }
 
 func init() {
 	versionCmd.PersistentFlags().BoolVarP(
-		&versionOpts.json,
+		&versionOpts.JSON,
 		"json",
 		"j",
 		false,
@@ -52,20 +45,4 @@ func init() {
 	)
 
 	rootCmd.AddCommand(versionCmd)
-}
-
-func runVersion(opts *versionOptions) error {
-	v := version.Get()
-	res := v.String()
-
-	if opts.json {
-		j, err := v.JSONString()
-		if err != nil {
-			return errors.Wrap(err, "unable to generate JSON from version info")
-		}
-		res = j
-	}
-
-	fmt.Println(res)
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/release v0.6.1-0.20201128190848-6313f6964945
+	k8s.io/release v0.6.1-0.20201130132450-1c35c3fb1498
 )

--- a/go.sum
+++ b/go.sum
@@ -1201,8 +1201,8 @@ k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C
 k8s.io/legacy-cloud-providers v0.17.4/go.mod h1:FikRNoD64ECjkxO36gkDgJeiQWwyZTuBkhu+yxOc1Js=
 k8s.io/release v0.3.2-0.20200513161026-05b87eb96960/go.mod h1:fcMNfhJFSHSBFv4BSrzJV2mesdz3yJeEqsqKs8cxjGU=
 k8s.io/release v0.4.2/go.mod h1:Kuj+iBm1aa/xxVyK8SVHrmxXn3g1IZUlB3ekJwx+NTw=
-k8s.io/release v0.6.1-0.20201128190848-6313f6964945 h1:rLwlBL1B7OQFnQJuTt5vccbtkZlglry9CwEzejRGmUQ=
-k8s.io/release v0.6.1-0.20201128190848-6313f6964945/go.mod h1:pDCajrEHI5pK4jWzmYAq4b52cKiWkdJKi6lxeU7pF5A=
+k8s.io/release v0.6.1-0.20201130132450-1c35c3fb1498 h1:kCfSspBiMFDJO95etxqMWKoOCBV0xSVu7UBrc07MvvE=
+k8s.io/release v0.6.1-0.20201130132450-1c35c3fb1498/go.mod h1:pDCajrEHI5pK4jWzmYAq4b52cKiWkdJKi6lxeU7pF5A=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTUt3aVoBpi2DqRsU=

--- a/repos.bzl
+++ b/repos.bzl
@@ -3462,8 +3462,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",
         importpath = "k8s.io/release",
-        sum = "h1:rLwlBL1B7OQFnQJuTt5vccbtkZlglry9CwEzejRGmUQ=",
-        version = "v0.6.1-0.20201128190848-6313f6964945",
+        sum = "h1:kCfSspBiMFDJO95etxqMWKoOCBV0xSVu7UBrc07MvvE=",
+        version = "v0.6.1-0.20201130132450-1c35c3fb1498",
     )
     go_repository(
         name = "io_k8s_sigs_mdtoc",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1804.

- go.mod: Update k/release to https://github.com/kubernetes/release/tree/1c35c3fb149890bf886c5c6c41024d01cafeed58
- cmd/cip: Depend on k/release/pkg/cip/cli

  Much of the command logic has been moved into k/release/pkg/cip/cli (to
  make it easier to refactor), so we pull in the new package here.

/assign @hasheddan @saschagrunert @cpanato
cc: @kubernetes-sigs/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- go.mod: Update k/release to 1c35c3fb149890bf886c5c6c41024d01cafeed58
- cmd/cip: Depend on k/release/pkg/cip/cli

  Much of the command logic has been moved into k/release/pkg/cip/cli (to
  make it easier to refactor), so we pull in the new package here.
```
