### PR TITLE
cmd/cip: Default to non-production runs with `--confirm`

### DIFF
--- a/cmd/cip/cmd/root.go
+++ b/cmd/cip/cmd/root.go
@@ -52,13 +52,6 @@ func init() {
 		"info",
 		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
 	)
-
-	rootCmd.PersistentFlags().BoolVar(
-		&rootOpts.DryRun,
-		"dry-run",
-		rootOpts.DryRun,
-		"test run promotion without modifying any registry",
-	)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/cmd/cip/cmd/run.go
+++ b/cmd/cip/cmd/run.go
@@ -49,6 +49,13 @@ var runOpts = &cli.RunOptions{}
 // TODO: Function 'init' is too long (171 > 60) (funlen)
 // nolint: funlen
 func init() {
+	runCmd.PersistentFlags().BoolVar(
+		&runOpts.Confirm,
+		"confirm",
+		runOpts.Confirm,
+		"initiate a PRODUCTION image promotion",
+	)
+
 	// TODO: Move this into a default options function in pkg/promobot
 	runCmd.PersistentFlags().StringVar(
 		&runOpts.Manifest,

--- a/legacy/cli/root.go
+++ b/legacy/cli/root.go
@@ -24,7 +24,6 @@ import (
 
 type RootOptions struct {
 	LogLevel string
-	DryRun   bool
 }
 
 func printVersion() {

--- a/legacy/cli/run.go
+++ b/legacy/cli/run.go
@@ -40,7 +40,7 @@ type RunOptions struct {
 	Threads                 int
 	MaxImageSize            int
 	SeverityThreshold       int
-	DryRun                  bool
+	Confirm                 bool
 	JSONLogSummary          bool
 	ParseOnly               bool
 	MinimalSnapshot         bool
@@ -142,7 +142,7 @@ func RunPromoteCmd(opts *RunOptions) error {
 		sc, err = reg.MakeSyncContext(
 			mfests,
 			opts.Threads,
-			opts.DryRun,
+			opts.Confirm,
 			opts.UseServiceAcct,
 		)
 		if err != nil {
@@ -159,8 +159,9 @@ func RunPromoteCmd(opts *RunOptions) error {
 		sc, err = reg.MakeSyncContext(
 			mfests,
 			opts.Threads,
-			opts.DryRun,
-			opts.UseServiceAcct)
+			opts.Confirm,
+			opts.UseServiceAcct,
+		)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -210,10 +211,10 @@ So a 'fixable' vulnerability may not necessarily be immediately actionable. For
 example, even though a fixed version of the binary is available, it doesn't
 necessarily mean that a new version of the image layer is available.`,
 			)
-		} else if opts.DryRun {
-			logrus.Info("********** START (DRY RUN) **********")
-		} else {
+		} else if opts.Confirm {
 			logrus.Info("********** START **********")
+		} else {
+			logrus.Info("********** START (DRY RUN) **********")
 		}
 	}
 
@@ -249,7 +250,7 @@ necessarily mean that a new version of the image layer is available.`,
 			sc, err = reg.MakeSyncContext(
 				mfests,
 				opts.Threads,
-				opts.DryRun,
+				opts.Confirm,
 				opts.UseServiceAcct,
 			)
 			if err != nil {
@@ -302,7 +303,7 @@ necessarily mean that a new version of the image layer is available.`,
 	}
 
 	// Check the pull request
-	if opts.DryRun {
+	if !opts.Confirm {
 		err = sc.RunChecks([]reg.PreCheck{})
 		if err != nil {
 			return errors.Wrap(err, "running prechecks before promotion")
@@ -362,10 +363,10 @@ necessarily mean that a new version of the image layer is available.`,
 
 	if opts.SeverityThreshold >= 0 {
 		logrus.Info("********** FINISHED (VULN CHECK) **********")
-	} else if opts.DryRun {
-		logrus.Info("********** FINISHED (DRY RUN) **********")
-	} else {
+	} else if opts.Confirm {
 		logrus.Info("********** FINISHED **********")
+	} else {
+		logrus.Info("********** FINISHED (DRY RUN) **********")
 	}
 
 	return nil

--- a/legacy/dockerregistry/types.go
+++ b/legacy/dockerregistry/types.go
@@ -78,7 +78,7 @@ type CollectedLogs struct {
 // SyncContext is the main data structure for performing the promotion.
 type SyncContext struct {
 	Threads           int
-	DryRun            bool
+	Confirm           bool
 	UseServiceAccount bool
 	Inv               MasterInventory
 	InvIgnore         []ImageName

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -328,7 +328,7 @@ func (t *E2ETest) clearRepositories() error {
 			{Registries: t.Registries},
 		},
 		10,
-		false,
+		true,
 		true)
 	if err != nil {
 		return err

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -132,10 +132,8 @@ func checkSnapshot(
 
 	diff := cmp.Diff(got, expected)
 	if diff != "" {
-		return errors.Errorf(
-			"expected equivalent image sets, but the following diff exists: %s",
-			diff,
-		)
+		fmt.Printf("the following diff exists: %s", diff)
+		return errors.Errorf("expected equivalent image sets")
 	}
 
 	return nil

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -165,7 +165,7 @@ func runPromotion(repoRoot string, t *E2ETest) error {
 		"run",
 		fmt.Sprintf("%s/cmd/cip/main.go", repoRoot),
 		"run",
-		"--dry-run=false",
+		"--confirm",
 		"--log-level=debug",
 		"--use-service-account",
 		// There is no need to use -key-files=... because we already activated


### PR DESCRIPTION
#### What type of PR is this?

/kind bug regression
/priority critical-urgent

#### What this PR does / why we need it:

- test-e2e: Minor cleanup for cmp.Diff() output
- cmd/cip: Use `--confirm` instead of `--dry-run`

  Similar to our `--nomock` flags for other tools, we use a `--confirm`
  flag for `cip`, since the default nil value for booleans is `false`.
  
  Meaning: If `--dry-run` is not explicitly set to `true`, our tooling
  will initiate an image promotion.

- Flip confirm logic in cip/cip-auditor e2e MakeSyncContext() calls

/assign @hasheddan @xmudrii 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- cmd/cip: Use `--confirm` instead of `--dry-run`

  Similar to our `--nomock` flags for other tools, we use a `--confirm`
  flag for `cip`, since the default nil value for booleans is `false`.
  
  Meaning: If `--dry-run` is not explicitly set to `true`, our tooling
  will initiate an image promotion.
```