### PR TITLE
test-e2e: Fixup embeds and importpaths for go_image declarations

### DIFF
--- a/test-e2e/cip-auditor/BUILD.bazel
+++ b/test-e2e/cip-auditor/BUILD.bazel
@@ -29,8 +29,8 @@ go_binary(
 go_image(
     name = "e2e-image",
     base = "@distroless-base//image",
-    embed = [":go_default_library"],
-    importpath = "sigs.k8s.io/k8s-container-image-promoter/e2e",
+    embed = [":cip-auditor_lib"],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/test-e2e/cip-auditor",
 )
 
 container_image(

--- a/test-e2e/cip/BUILD.bazel
+++ b/test-e2e/cip/BUILD.bazel
@@ -26,8 +26,8 @@ go_binary(
 go_image(
     name = "e2e-image",
     base = "@distroless-base//image",
-    embed = [":go_default_library"],
-    importpath = "sigs.k8s.io/k8s-container-image-promoter/e2e",
+    embed = [":cip_lib"],
+    importpath = "sigs.k8s.io/k8s-container-image-promoter/test-e2e/cip",
 )
 
 # NOTE: Bazel's docker rules do not support building manifest lists (aka "fat"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

(Peeling some commits off of https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/291.)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
