### PR TITLE
test-go.sh: exit with an error upon test failure

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -46,6 +46,7 @@ mkdir -p "${ARTIFACTS}"
 
 go_test_flags=(
     -v
+    -failfast
     -count=1
     -timeout="${TEST_TIMEOUT}s"
     -cover -coverprofile "${ARTIFACTS}/coverage.out"
@@ -54,6 +55,11 @@ go_test_flags=(
 packages=()
 mapfile -t packages < <(go list ./... | grep -v 'sigs.k8s.io/k8s-container-image-promoter/cmd\|test-e2e')
 
-GO111MODULE=on go test "${go_test_flags[@]}" "${packages[@]}"
+for p in "${packages[@]}"; do
+    if ! GO111MODULE=on go test "${go_test_flags[@]}" "${p}"; then
+        # Exit early.
+        exit 1
+    fi
+done
 
 go tool cover -html "${ARTIFACTS}/coverage.out" -o "${ARTIFACTS}/coverage.html"


### PR DESCRIPTION
Also, we break early if any one of the unit tests fail. Previously even
if a unit test failed, we would still exit with successfully.

The `-failfast' option makes go stop executing more Test* functions in
the package if a failure is encountered.

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE
