### PR TITLE
Use `sigs.k8s.io/release-utils/command`

### DIFF
--- a/legacy/gcloud/BUILD.bazel
+++ b/legacy/gcloud/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["token.go"],
     importpath = "sigs.k8s.io/k8s-container-image-promoter/legacy/gcloud",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_sirupsen_logrus//:logrus"],
+    deps = [
+        "@com_github_sirupsen_logrus//:logrus",
+        "@io_k8s_sigs_release_utils//command",
+    ],
 )

--- a/test-e2e/cip-auditor/BUILD.bazel
+++ b/test-e2e/cip-auditor/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_k8s_klog_v2//:klog",
+        "@io_k8s_sigs_release_utils//command",
     ],
 )
 

--- a/test-e2e/cip/BUILD.bazel
+++ b/test-e2e/cip/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//legacy/stream",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_k8s_klog_v2//:klog",
+        "@io_k8s_sigs_release_utils//command",
     ],
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use [sigs.k8s.io/release-utils/command](https://pkg.go.dev/sigs.k8s.io/release-utils@v0.2.1/command)
  
Instances of `exec.Command` (`os/exec`) are replaced with
`sigs.k8s.io/release-utils/command`, which is used across Release Engineering
tooling to minimize duplication and accidental misuse of `exec` functions 

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use [sigs.k8s.io/release-utils/command](https://pkg.go.dev/sigs.k8s.io/release-utils@v0.2.1/command)
  
Instances of `exec.Command` (`os/exec`) are replaced with
`sigs.k8s.io/release-utils/command`, which is used across Release Engineering
tooling to minimize duplication and accidental misuse of `exec` functions
```
