### PR TITLE
Remove all Bazel invocations from test-e2e-cip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ all: test
 .PHONY: build
 build: ## Bazel build
 	bazel build //cmd/cip:cip \
-		//test-e2e/cip:e2e \
 		//test-e2e/cip-auditor:cip-auditor-e2e
+	${REPO_ROOT}/go_with_version.sh build $(REPO_ROOT)/test-e2e/cip/e2e.go
 
 .PHONY: install
 install: ## Install
@@ -80,7 +80,10 @@ test-ci: download
 
 .PHONY: test-e2e-cip
 test-e2e-cip:
-	bazel run //test-e2e/cip:e2e -- -tests=$(REPO_ROOT)/test-e2e/cip/tests.yaml -repo-root=$(REPO_ROOT) -key-file=$(CIP_E2E_KEY_FILE)
+	${REPO_ROOT}/go_with_version.sh run $(REPO_ROOT)/test-e2e/cip/e2e.go \
+		-tests=$(REPO_ROOT)/test-e2e/cip/tests.yaml \
+		-repo-root=$(REPO_ROOT) \
+		-key-file=$(CIP_E2E_KEY_FILE)
 
 .PHONY: test-e2e-cip-auditor
 test-e2e-cip-auditor:

--- a/go_with_version.sh
+++ b/go_with_version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# About: Stamp internal/version with logging information before either
+# building or running the provided go-code.
+# 
+# Usage:
+#   ./go_with_version.sh (build | run) path/to/code.go [args...]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+printUsage() {
+    echo "Usage: $0 (build | run) path/to/code.go [args...]"
+}
+
+if [[ $# < 2 ]]; then
+    >&2 echo "ERROR: Invalid number of arguments!"
+    printUsage
+    exit 1
+elif [ "$1" != build ] && [ "$1" != run ]; then
+    >&2 echo "ERROR: First argument was not 'build' or 'run'!"
+    printUsage
+    exit 1
+fi
+
+tool="$2"
+git_tree_state=dirty
+pkg=sigs.k8s.io/k8s-container-image-promoter/internal/version
+
+if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${git_status}" ]]; then
+git_tree_state=clean
+fi
+
+go $1 -v -ldflags "-s -w \
+    -X $pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+    -X $pkg.gitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) \
+    -X $pkg.gitTreeState=$git_tree_state \
+    -X $pkg.gitVersion=$(git describe --tags --abbrev=0 || echo unknown)" \
+    "${@:2}" \
+    || return 1
+
+echo "Finished running $tool"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change removes all invocations of `bazel run` in favor of `go run` within e2e.go. In addition, the `test-e2e-cip` make target, which executes e2e.go, no longer relies on Bazel.

Partially satisfies #304 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Replace bazel invocations, inside e2e.go, with go run command.
Remove Bazel invocation from make target: test-e2e-cip
```
