### PR TITLE
workspace_status.sh: Simplify git/image tagging logic

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,9 +71,9 @@ container_bundle(
     name = "cip-docker-loadable",
     images = {
         "{STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}:latest": "//:cip-with-gcloud",
-        "{STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}:{IMG_TAG}": "//:cip-with-gcloud",
+        "{STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}:{STABLE_IMG_TAG}": "//:cip-with-gcloud",
         "{STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor:latest": "//:cip-auditor",
-        "{STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor:{IMG_TAG}": "//:cip-auditor",
+        "{STABLE_IMG_REGISTRY}/{STABLE_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor:{STABLE_IMG_TAG}": "//:cip-auditor",
     },
 )
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,23 +1,32 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 1200s
+
 options:
   substitution_option: ALLOW_LOOSE
-  # Need a VM with bigger memory. Machine types are documented in
-  # https://cloud.google.com/compute/docs/machine-types, but the only ones
-  # supported in GCB are found in
-  # https://cloud.google.com/cloud-build/docs/api/reference/rest/Shared.Types/MachineType.
   machineType: N1_HIGHCPU_32
+
 steps:
-# Start by just pushing the image
 - name: 'gcr.io/k8s-testimages/bazelbuild:latest-2.2.0'
   entrypoint: make
   env:
-  - PROW_GIT_TAG=$_GIT_TAG
+  - GIT_TAG=$_GIT_TAG
   - PULL_BASE_REF=$_PULL_BASE_REF
   args:
   - image-push
+
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: '12345'
-  _PULL_BASE_REF: 'master'
+  _PULL_BASE_REF: 'dev'
+
+tags:
+- 'cip'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+
+images:
+  - 'gcr.io/$PROJECT_ID/cip:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/cip:latest'
+  - 'gcr.io/$PROJECT_ID/cip-auditor:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/cip-auditor:latest'

--- a/test-e2e/cip-auditor/BUILD.bazel
+++ b/test-e2e/cip-auditor/BUILD.bazel
@@ -57,7 +57,7 @@ container_bundle(
     name = "cip-docker-loadable-auditor-test",
     images = {
         "{STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor-test:latest": ":cip-auditor-test",
-        "{STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor-test:{IMG_TAG}": ":cip-auditor-test",
+        "{STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY}/{STABLE_IMG_NAME}-auditor-test:{STABLE_IMG_TAG}": ":cip-auditor-test",
     },
 )
 

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -33,56 +33,26 @@ p_() {
     fi
 }
 
-# If a PROW_GIT_TAG variable is provided by Prow's staging image building
-# mechanism, use it instead of asking `git` directly, because the repo we are in
-# might not actually be a Git repo.
-if [[ -n "${PROW_GIT_TAG:-}" ]]; then
-    # Ensure that the PROW_GIT_TAG fits a known pattern of
-    # vYYYYMMDD-tag-n-ghash. According to
-    # https://github.com/kubernetes/test-infra/blob/f7e21a3c18f4f4bbc7ee170675ed53e4544a0632/config/jobs/image-pushing/README.md#custom-substitutions,
-    # the PROW_GIT_TAG will be one of vYYYYMMDD-hash, vYYYYMMDD-tag, or
-    # vYYYYMMDD-tag-n-ghash.
-    if [[ "${PROW_GIT_TAG}" =~ v[0-9]{8}-[^-]+-[0-9]+-g[0-9a-f]{7} ]]; then
-        # In this case we have a "-n-ghash" suffix, which we can use to set the
-        # git_commit and git_desc information.
+build_date="$(date -u '+%Y%m%d')"
 
-        # Extract the last 7 characters.
-        git_commit="${PROW_GIT_TAG:(-7)}"
-        # Skip built-in date in PROW_GIT_TAG.
-        git_desc="${PROW_GIT_TAG:(10)}"
-    # If the -n-ghash bit is missing, then it must look like vYYYYMMDD-hash or
-    # vYYYYMMDD-tag. We can't easily tell if something is a hash or a tag, so we
-    # just use it as-is.
-    else
-        # Extract the hash or tag (we can't tell easily).
-        git_commit="${PROW_GIT_TAG:(10)}"
-        # We just reuse git_commit (could be a hash or tag) here because it's
-        # the best we can do.
-        git_desc="${git_commit}"
-    fi
+# Create a placeholder git commit value if the git env cannot be found
+null_git_commit="no-git-env"
+git_commit="$(git describe --tags --always --dirty)" || \
+    git_commit="$null_git_commit"
 
-    timestamp_utc_rfc3339=$(date -u +"%Y-%m-%d %H:%M:%S%z")
-    timestamp_utc_date_dashes="${timestamp_utc_rfc3339% *}"
-    timestamp_utc_date_no_dashes="${timestamp_utc_date_dashes//-/}"
-else
-    git_commit="$(git rev-parse HEAD)"
-    git_desc_raw="$(git describe --always --dirty --long)"
-    git_desc="${git_desc_raw//\//-}"
-    timestamp_utc_rfc3339=$(date -u +"%Y-%m-%d %H:%M:%S%z")
-    timestamp_utc_date_dashes="${timestamp_utc_rfc3339% *}"
-    timestamp_utc_date_no_dashes="${timestamp_utc_date_dashes//-/}"
+image_tag="v${build_date}-${git_commit}"
+if [[ ${git_commit} == "$null_git_commit" ]]; then
+    image_tag="${GIT_TAG}"
 fi
 
+p_ STABLE_GIT_COMMIT "${git_commit}"
+p_ STABLE_IMG_REGISTRY gcr.io
+p_ STABLE_IMG_REPOSITORY k8s-staging-artifact-promoter
+p_ STABLE_IMG_NAME cip
+p_ STABLE_IMG_TAG "${image_tag}"
 p_ STABLE_TEST_AUDIT_PROD_IMG_REPOSITORY us.gcr.io/k8s-gcr-audit-test-prod
 p_ STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY gcr.io/k8s-gcr-audit-test-prod
 p_ STABLE_TEST_AUDIT_PROJECT_ID k8s-gcr-audit-test-prod
 p_ STABLE_TEST_AUDIT_PROJECT_NUMBER 375340694213
 p_ STABLE_TEST_AUDIT_INVOKER_SERVICE_ACCOUNT k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com
 p_ STABLE_TEST_STAGING_IMG_REPOSITORY gcr.io/k8s-staging-cip-test
-p_ STABLE_IMG_REGISTRY gcr.io
-p_ STABLE_IMG_REPOSITORY k8s-staging-artifact-promoter
-p_ STABLE_IMG_NAME cip
-p_ STABLE_GIT_COMMIT "${git_commit}"
-p_ STABLE_GIT_DESC "${git_desc}"
-p_ TIMESTAMP_UTC_RFC3339 "${timestamp_utc_rfc3339}"
-p_ IMG_TAG "${timestamp_utc_date_no_dashes}-${git_desc}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-up to my review comments in https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/301#pullrequestreview-678116216.

workspace_status.sh: Simplify git/image tagging logic

- Match commit/date logic from k/test-infra@6b0cbad
- Ensure image tag is present in stable-status.txt
- Alpha-sort variables
- Add tags for GCB runs
- Add GCB images check

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/hold for additional cleanups in cloudbuild.yaml

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
