### PR TITLE
gcb: Temporarily disable incorrectly failing `images` check

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,8 +25,10 @@ tags:
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
 
-images:
-  - 'gcr.io/$PROJECT_ID/cip:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/cip:latest'
-  - 'gcr.io/$PROJECT_ID/cip-auditor:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/cip-auditor:latest'
+# TODO: Temporarily disabling this check, which is currently failing in
+#       postsubmit: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/312
+#images:
+#  - 'gcr.io/$PROJECT_ID/cip:$_GIT_TAG'
+#  - 'gcr.io/$PROJECT_ID/cip:latest'
+#  - 'gcr.io/$PROJECT_ID/cip-auditor:$_GIT_TAG'
+#  - 'gcr.io/$PROJECT_ID/cip-auditor:latest'


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/312
cc: @tylerferrara @listx @kubernetes-sigs/release-engineering 

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold I'm going to try and fix the optional presubmit here too
/test ls

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
