### PR TITLE
Remove Bazel from building and executing auditor within Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ all: test
 ##@ Build
 .PHONY: build
 build: ## Bazel build
-	bazel build //cmd/cip:cip \
-		//test-e2e/cip-auditor:cip-auditor-e2e
-	${REPO_ROOT}/go_with_version.sh build $(REPO_ROOT)/test-e2e/cip/e2e.go
+	bazel build //cmd/cip:cip
+	${REPO_ROOT}/go_with_version.sh build ${REPO_ROOT}/test-e2e/cip-auditor/cip-auditor-e2e.go
+	${REPO_ROOT}/go_with_version.sh build ${REPO_ROOT}/test-e2e/cip/e2e.go
 
 .PHONY: install
 install: ## Install
@@ -80,14 +80,17 @@ test-ci: download
 
 .PHONY: test-e2e-cip
 test-e2e-cip:
-	${REPO_ROOT}/go_with_version.sh run $(REPO_ROOT)/test-e2e/cip/e2e.go \
-		-tests=$(REPO_ROOT)/test-e2e/cip/tests.yaml \
-		-repo-root=$(REPO_ROOT) \
-		-key-file=$(CIP_E2E_KEY_FILE)
+	${REPO_ROOT}/go_with_version.sh run ${REPO_ROOT}/test-e2e/cip/e2e.go \
+		-tests=${REPO_ROOT}/test-e2e/cip/tests.yaml \
+		-repo-root=${REPO_ROOT} \
+		-key-file=${CIP_E2E_KEY_FILE}
 
 .PHONY: test-e2e-cip-auditor
 test-e2e-cip-auditor:
-	bazel run //test-e2e/cip-auditor:cip-auditor-e2e -- -tests=$(REPO_ROOT)/test-e2e/cip-auditor/tests.yaml -repo-root=$(REPO_ROOT) -key-file=$(CIP_E2E_KEY_FILE)
+	${REPO_ROOT}/go_with_version.sh run ${REPO_ROOT}/test-e2e/cip-auditor/cip-auditor-e2e.go \
+		-tests=${REPO_ROOT}/test-e2e/cip-auditor/tests.yaml \
+		-repo-root=${REPO_ROOT} \
+		-key-file=${CIP_E2E_KEY_FILE}
 
 ##@ Dependencies
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change replaces all invocations of `bazel build` with `./go_with_version.sh [build | run]` for the auditor. Bazel is now not required for building or running `cip-auditor-e2e.go`. Additionally, the auditor adopts the `internal/version` for standardized logging.

Partially satisfies #304

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
The function [getBazelOption](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/2638c8a3dea81fe8da2a85369008efe5c1791eeb/test-e2e/cip-auditor/cip-auditor-e2e.go#L327) was replaced with `getWorkspaceStatus`. This retrieves all variables within workspace_status.sh by returning a `map[string]string`. Such a change avoids printing the following output 4 times when triggering `test-e2e-cip-auditor`:
```
STABLE_GIT_COMMIT v1.337.0-23-g2638c8a-dirty
STABLE_IMG_REGISTRY gcr.io
STABLE_IMG_REPOSITORY k8s-staging-artifact-promoter
STABLE_IMG_NAME cip
STABLE_IMG_TAG v20210623-v1.337.0-23-g2638c8a-dirty
STABLE_TEST_AUDIT_PROD_IMG_REPOSITORY us.gcr.io/k8s-gcr-audit-test-prod
STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY gcr.io/k8s-gcr-audit-test-prod
STABLE_TEST_AUDIT_PROJECT_ID k8s-gcr-audit-test-prod
STABLE_TEST_AUDIT_PROJECT_NUMBER 375340694213
STABLE_TEST_AUDIT_INVOKER_SERVICE_ACCOUNT k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com
STABLE_TEST_STAGING_IMG_REPOSITORY gcr.io/k8s-staging-cip-test
```

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Simplify parsing of workspace_status.sh within cip-auditor-e2e.go
Remove Bazel invocations of auditor in favor of go_with_version.sh
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering