### PR TITLE
Create archive bundle for auditor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# About: This dockerfile builds the cip binary for use in auditor e2e tests.
+
+FROM golang:latest
+# Transfer all project files to container.
+WORKDIR /go/src/app
+COPY . .
+# Build and export cip command.
+RUN ./go_with_version.sh build ./cmd/cip
+RUN cp ./cip /bin/cip
+# Include cip-auditor testing fixtures.
+RUN mkdir /e2e-fixtures
+RUN cp -r ./test-e2e/cip-auditor/fixture/* /e2e-fixtures
+# Provide docker config for repo information.
+RUN mkdir /.docker
+RUN cp ./docker/config.json /.docker/config.json
+# Trigger the auditor on startup.
+ENV HOME=/
+ENTRYPOINT ["cip", "audit"]

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ image-load-cip-auditor-e2e: ## Build and load image cip-auditor-e2e
 
 .PHONY: image-push-cip-auditor-e2e
 image-push-cip-auditor-e2e: ## Push image cip-auditor-e2e
-	bazel run //test-e2e/cip-auditor:push-cip-auditor-test
+	./test-e2e/cip-auditor/push-cip-auditor-test.sh
 
 ##@ Lints
 

--- a/test-e2e/cip-auditor/push-cip-auditor-test.sh
+++ b/test-e2e/cip-auditor/push-cip-auditor-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# About: This script pushes auditor test images to the auditor's staging
+# location (defined in workspace_status.sh) for e2e tests.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+
+# Inject workspace variables.
+source <("${repo_root}"/workspace_status.sh inject)
+
+# Build docker container from Dockerfile.
+output=$(docker build "$repo_root" | tail -1)
+# Grab only the container ID. Expected to transform a line like
+# "Successfully built 703827382376" into "703827382376".
+container_id=$(echo "$output" | cut -d ' ' -f 3)
+# Asesmble image names.
+latest="${STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY}/${STABLE_IMG_NAME}-auditor-test:latest"
+stable="${STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY}/${STABLE_IMG_NAME}-auditor-test:${STABLE_IMG_TAG}"
+# Assign additional tags to the image.
+docker tag "$container_id" "$latest"
+docker tag "$container_id" "$stable"
+# Push images.
+docker push "$latest"
+docker push "$stable"
+
+echo "$0" finished.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change aims at removing the reliance of Bazel within the make target: `image-push-cip-auditor-e2e`. This target builds a container image, specifically designed to run the `cip audit` command. After the image is built, it's tagged with `latest` and the current git commit, then pushed to the defined staging location: `gcr.io/k8s-gcr-audit-test-prod/`.

The target is relied on by [cip-auditor-e2e.go](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/c9f0cecf768715a5d1364fb1533a952181b36ed5/test-e2e/cip-auditor/cip-auditor-e2e.go#L602-L604) and thus apart of the `pull-cip-auditor-e2e` prow job.

To accomplish this without Bazel, a new push-audit-test.sh script was designed to reliably automate this process. The container is built with a new Dockerfile, at the project root, mimicking the previous [cip-auditor container image](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/12bfa911ee15e66eef6085ccc677b9353c140af9/BUILD.bazel#L53-L65).

Partially satisfies #304
Part of effort to [reduce build maintenance](https://docs.google.com/document/d/1tQTb8dqKQtsL1a5jmCDbRg2MEDMkAnT07vrrxyZxLfk/edit?usp=sharing).

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
The accompanying make target `image-load-cip-auditor-e2e` is not used by any tests or targets. After the merging of this PR, #320 will remove this unused make target. 

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove reliance of Bazel in the image-push-cip-auditor-e2e make target.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering