### PR TITLE
Add more detailed logging statement in auditor

### DIFF
--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -322,7 +322,7 @@ func getWorkspaceStatus(repoRoot string) map[string]string {
 	for idx, line := range strings.Split(strings.TrimSuffix(stdout, "\n"), "\n") {
 		words := strings.Split(line, " ")
 		if len(words) != 2 {
-			klog.Fatalf("Unexpected key value pair in line: %d!\n", idx)
+			klog.Fatalf("ERROR: Unexpected key value pair when parsing workspace_status.sh. Line %d: %q", idx, line)
 		}
 		status[words[0]] = words[1]
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change fixes an unaddressed concern in #316. When finding a malformed key value pair, while parsing `workspace_status.sh`, the error will log the content of the malformed line.

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
If the auditor finds a malformed key-value pair, this would be an example of the log output:
```
F0625 00:06:56.732779    2663 cip-auditor-e2e.go:325] Error: Unexpected key value pair when parsing workspace_status.sh.
Line: "SOME_MALFORMED_KEY foo bar"
```

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Printing contents of malformed line in getWorkspaceStatus. 
```
cc: @listx @amwat @justaugustus 