### PR TITLE
Remove unused make target: image-load-cip-auditor-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,6 @@ image-load: image ## Build image and load it
 image-push: image ## Build image and push
 	bazel run :push-cip
 
-.PHONY: image-load-cip-auditor-e2e
-image-load-cip-auditor-e2e: ## Build and load image cip-auditor-e2e
-	bazel build //test-e2e/cip-auditor:cip-docker-loadable-auditor-test.tar
-	docker load -i bazel-bin/test-e2e/cip-auditor/cip-docker-loadable-auditor-test.tar
-
 .PHONY: image-push-cip-auditor-e2e
 image-push-cip-auditor-e2e: ## Push image cip-auditor-e2e
 	./test-e2e/cip-auditor/push-cip-auditor-test.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This make target builds the `cip-auditor` image with Bazel and loads the image into docker for use. Since docker is now leveraged for the creation of `cip-audior` images, it's no longer needed.

Partially satisfies #304
Part of effort to [reduce build maintenance](https://docs.google.com/document/d/1tQTb8dqKQtsL1a5jmCDbRg2MEDMkAnT07vrrxyZxLfk/edit?usp=sharing).

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
- [x] Requires the merging of #318 

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove make target: image-load-cip-auditor-e2e.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering