### PR TITLE
Building cip with go CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ all: test
 
 ##@ Build
 .PHONY: build
-build: ## Bazel build
-	bazel build //cmd/cip:cip
+build: ## Go build
+	go build -o cip ${REPO_ROOT}/cmd/cip/...
 	${REPO_ROOT}/go_with_version.sh build ${REPO_ROOT}/test-e2e/cip-auditor/cip-auditor-e2e.go
 	${REPO_ROOT}/go_with_version.sh build ${REPO_ROOT}/test-e2e/cip/e2e.go
 
 .PHONY: install
-install: ## Install
-	bazel run //:install-cip -c opt -- $(shell go env GOPATH)/bin
+install: build ## Install
+	cp cip $(shell go env GOPATH)/bin
 
 ##@ Images
 
@@ -97,12 +97,6 @@ download: ## Download go modules
 update: ## Update go modules (source of truth!).
 	GO111MODULE=on go mod verify
 	GO111MODULE=on go mod tidy
-	# Update bazel rules to use these new dependencies.
-	bazel run //:gazelle -- update-repos \
-		--from_file=go.mod --to_macro=repos.bzl%go_repositories \
-		--build_file_generation=on --build_file_proto_mode=disable_global \
-		--prune
-	bazel run //:gazelle -- fix
 
 ##@ Verify
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This replaces Bazel, for building go code, with the go CLI. Since Bazel is no longer building any binaries within this project, Gazell's dependency tracking can also be removed.

Partially satisfies #300 
Part of the effort to [reduce build maintenance](https://docs.google.com/document/d/1tQTb8dqKQtsL1a5jmCDbRg2MEDMkAnT07vrrxyZxLfk/edit?usp=sharing).

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove Bazel build and installation, in favor of the go CLI.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering