### PR TITLE
[WIP] Add archive verification to Prow pre-submits.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,9 @@ update: ## Update go modules (source of truth!).
 
 ##@ Verify
 
-.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod
+.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod verify-archives
 
-verify: verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod ## Runs verification scripts to ensure correct execution
+verify: verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod verify-archives ## Runs verification scripts to ensure correct execution
 
 verify-boilerplate: ## Runs the file header check
 	./hack/verify-boilerplate.sh


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change guards the archives for each PR by adding the existing `verify-archives` target to Prow presubmits. However, the current image that runs current verification scripts `pull-cip-verify` does not have docker installed.
```
docker run gcr.io/k8s-staging-releng/releng-ci:latest-go1.15 whereis docker 
docker:
```

Therefore, in order to run the verification, a new image must be used.

#326 

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add archive verification to Prow pre-submits.
```
