### PR TITLE
[WIP] Add test-cip-image-build make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-ci: download
 	make test
 
 .PHONY: test-e2e-cip
-test-e2e-cip:
+test-e2e-cip: test-cip-image-build
 	${REPO_ROOT}/go_with_version.sh run ${REPO_ROOT}/test-e2e/cip/e2e.go \
 		-tests=${REPO_ROOT}/test-e2e/cip/tests.yaml \
 		-repo-root=${REPO_ROOT} \
@@ -87,6 +87,10 @@ test-e2e-cip-auditor:
 		-tests=${REPO_ROOT}/test-e2e/cip-auditor/tests.yaml \
 		-repo-root=${REPO_ROOT} \
 		-key-file=${CIP_E2E_KEY_FILE}
+
+.PHONY: test-cip-image-build
+test-cip-image-build:
+	./hack/test-cip-image.sh
 
 ##@ Dependencies
 

--- a/hack/test-cip-image.sh
+++ b/hack/test-cip-image.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# About: This script tests the build process of the cip-image.sh script for both
+# variants (cip and auditor).
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+# Ensures the provided images are built locally.
+validateImages() {
+    local images="${*}"
+    local img_id
+    # Look for every image locally.
+    for img in $images; do
+        # Obtain the image ID.
+        img_id=$(docker image ls "$img" --format '{{.ID}}')
+        # Ensure the image exists.
+        if [[ -z "$img_id" ]]; then
+            >&2 echo "ERROR: Image \"$img\" was not found locally."
+            exit 1
+        fi
+    done
+}
+
+# Validate the container build process for the given variant.
+testVariant() {
+    # Build based on the variant.
+    if [[ "$1" == "auditor" ]]; then
+        make image-build-cip-auditor-e2e
+    else
+        make image-build
+    fi
+
+    # Check required images are built locally.
+    shift
+    validateImages "${*}"
+}
+
+# Program entrypoint.
+main() {
+    # Inject workspace variables.
+    source <("${repo_root}"/workspace_status.sh inject)
+
+    # Assemble image tag prefixes.
+    local stable_tag_prefix=${STABLE_IMG_REGISTRY}/${STABLE_IMG_REPOSITORY}/${STABLE_IMG_NAME}
+    local test_tag_prefix=${STABLE_TEST_AUDIT_STAGING_IMG_REPOSITORY}/${STABLE_IMG_NAME}
+
+    # Test each variant.
+    testVariant "cip" \
+        "${stable_tag_prefix}-auditor:latest" \
+        "${stable_tag_prefix}-auditor:${STABLE_IMG_TAG}" \
+        "${stable_tag_prefix}:latest" \
+        "${stable_tag_prefix}:${STABLE_IMG_TAG}"
+
+    testVariant "auditor" \
+        "${test_tag_prefix}-auditor-test:latest" \
+        "${test_tag_prefix}-auditor-test:${STABLE_IMG_TAG}"
+
+    >&2 echo "$0" finished.
+}
+
+main


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This make target introduces a new script, `test-cip-image.sh`, which validates the build process for [cip-image.sh](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/hack/cip-image.sh). More specifically, it ensures the expected images are built after triggering make targets: [image-build and image-build-cip-auditor-e2e](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/Makefile#L35-L41). After merging, this test will be triggered for every PR by a new Prow pre-submit [#22736](https://github.com/kubernetes/test-infra/pull/22736). Until then, the new target: `test-cip-image-build` will be triggered within the `pull-cip-e2e` pre-submit.

Partially satisfies #328 
Must be merged:
- [x] #323
- [x] #331 

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
This PR must first be merged in order to create the new pre-submit.

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Create new test-push-cip make target.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering