### PR TITLE
Modify push-cip.sh to handle builds and pushes separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,22 @@ install: build ## Install
 
 ##@ Images
 
+.PHONY: image-build ## Build auditor and cip images
+image-build:
+	./hack/cip-image.sh build
+
+.PHONY: image-build-cip-auditor-e2e
+image-build-cip-auditor-e2e: ## Build auditor e2e images
+	./hack/cip-image.sh build --audit
+
 .PHONY: image-push
-image-push: ## Build and push auditor and cip images
-	./hack/push-cip.sh
+image-push: image-build ## Build and push auditor and cip images
+	./hack/cip-image.sh push
 
 .PHONY: image-push-cip-auditor-e2e
-image-push-cip-auditor-e2e: ## Build and push auditor e2e images
-	./hack/push-cip.sh --audit
+image-push-cip-auditor-e2e: image-build-cip-auditor-e2e ## Build and push auditor e2e images
+	./hack/cip-image.sh push --audit
+
 
 ##@ Lints
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change separates the build and push processes by modifying the `push-cip.sh` script - now called `cip-image.sh`. Such a separation allows for simplified testing of the build process only. If we were to test the original `push-cip.sh` script, a `docker push` would be unavoidable, requiring proper authentication. Now, this script can specify whether to build OR push images.

```
Usage: ./cip-image.sh <command> [--audit]
Commands:
  build     docker build images from the project's Dockerfile
  push      docker push images to their tagged location

Optional Flag:
  --audit   handle images for e2e test auditor
  ```

This simplifies the testing of #329
Partially satisfies #328 

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Replace cip-push.sh with cip-image.sh.
Add new make targets: image-build and image-build-cip-auditor-e2e.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering