### PR TITLE
Adding verify-archives.sh to verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,9 @@ update: ## Update go modules (source of truth!).
 
 ##@ Verify
 
-.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod
+.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod verify-archives
 
-verify: verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod ## Runs verification scripts to ensure correct execution
+verify: verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod verify-archives ## Runs verification scripts to ensure correct execution
 
 verify-boilerplate: ## Runs the file header check
 	./hack/verify-boilerplate.sh


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change introduces the verify-archives.sh script to run during the pre-submit: `pull-cip-verify`. Now we can protect the golden-archive images for every PR we push.

Requires the merging of:
- [x] Add docker-in-docker to pull-cip-verify [#2827](https://github.com/kubernetes/test-infra/pull/22827)

#### Which issue(s) this PR fixes:
#326 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Trigger the verify-archives.sh script within the pre-submit: pull-cip-verify.
```
cc: @listx @amwat @justaugustus