### PR TITLE
Auditor Hotfix

### DIFF
--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -576,7 +576,7 @@ func getCmdShowLogs(projectID, uuid, pattern string) []string {
 		"logging",
 		"read",
 		"--format=value(textPayload)",
-		fmt.Sprintf("resource.type=project logName=%s resource.labels.project_id=%s %q", fullLogName, projectID, uuidAndPattern),
+		fmt.Sprintf("logName=%s resource.labels.project_id=%s %q", fullLogName, projectID, uuidAndPattern),
 		fmt.Sprintf("--project=%s", projectID),
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change fixes the failing e2e auditor tests. Inside these tests, the command `gcloud logging read ...` attempts to pull the logging info from the staging project for verification. However, these logs were coming up empty. [Here is an example log](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_k8s-container-image-promoter/341/pull-cip-auditor-e2e/1413286408977649664), where the section "checking logs" should reveal the output of the `gcloud logging read ...` command.

Upon further investigation, the command: `gcloud logging read --format="value(textPayload)" --project="k8s-gcr-audit-test-prod" "resource.type=project ..."` is too specific. Removing the `resource.type=project` will yield the logs we are looking for. Available resource types can be found [here](https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types).

Looking at the [release notes](https://cloud.google.com/release-notes) for gcloud, I could not identify this as an API change. Therefore, the test PR (#343) was created to try an older version of gcloud for image building. It attempts to use `resource.type=project` to verify if there was an API change between versions. However these tests still fail, so removing this is currently our only option. 

Partially satisfies #332
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Including the resource type yields no output:
```bash
$ gcloud logging read --format="value(textPayload)" --project="k8s-gcr-audit-test-prod" "resource.type=project logName=projects/k8s-gcr-audit-test-prod/logs/cip-audit-log resource.labels.project_id=k8s-gcr-audit-test-prod"
```
However, if we don't define the resource type, our logs are found:
```bash
$ gcloud logging read --format="value(textPayload)" --project="k8s-gcr-audit-test-prod" "logName=projects/k8s-gcr-audit-test-prod/logs/cip-audit-log resource.labels.project_id=k8s-gcr-audit-test-prod"

(94eea909-fe83-4055-8ea8-6dbd2ee50ddc): reading srcRegistries [{gcr.io/k8s-gcr-audit-test-prod/golden-bar k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com  true}] for "{Action: \"INSERT\", FQIN: \"us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b\", PQIN: \"us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:2.0\", Path: \"us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar\", Digest: \"sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b\", Tag: \"2.0\"}"

(94eea909-fe83-4055-8ea8-6dbd2ee50ddc): could not find direct manifest entry for {Action: "INSERT", FQIN: "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b", PQIN: "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:2.0", Path: "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar", Digest: "sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b", Tag: "2.0"}; assuming child manifest

(94eea909-fe83-4055-8ea8-6dbd2ee50ddc) RemoteManifestFacility: &{0xc000292090  /e2e-fixtures/basic}

(94eea909-fe83-4055-8ea8-6dbd2ee50ddc) gcrPayload: {Action: "INSERT", FQIN: "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar@sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b", PQIN: "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar:2.0", Path: "us.gcr.io/k8s-gcr-audit-test-prod/golden-bar/bar", Digest: "sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b", Tag: "2.0"}
```
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove 'resource.type=project' from gcloud logging query.
```

cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering