### PR TITLE
[WIP] Attempt to pin gcloud version to 332.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN cp ./cip /bin/cip
 RUN mkdir /.docker
 RUN cp ./docker/config.json /.docker/config.json
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:latest AS gcloud-base
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:332.0.0 AS gcloud-base
 COPY --from=base / /
 
 FROM base AS test-variant

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -576,7 +576,7 @@ func getCmdShowLogs(projectID, uuid, pattern string) []string {
 		"logging",
 		"read",
 		"--format=value(textPayload)",
-		fmt.Sprintf("logName=%s resource.labels.project_id=%s %q", fullLogName, projectID, uuidAndPattern),
+		fmt.Sprintf("resource.type=project logName=%s resource.labels.project_id=%s %q", fullLogName, projectID, uuidAndPattern),
 		fmt.Sprintf("--project=%s", projectID),
 	}
 }

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -576,7 +576,7 @@ func getCmdShowLogs(projectID, uuid, pattern string) []string {
 		"logging",
 		"read",
 		"--format=value(textPayload)",
-		fmt.Sprintf("resource.type=project logName=%s resource.labels.project_id=%s %q", fullLogName, projectID, uuidAndPattern),
+		fmt.Sprintf("logName=%s resource.labels.project_id=%s %q", fullLogName, projectID, uuidAndPattern),
 		fmt.Sprintf("--project=%s", projectID),
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change attempts to use an older version of gcloud to determine if there is an API change with gcloud. If `pull-cip-auditor-e2e` tests pass, we can verify that this version (332.0.0) allows the use of `resource.type=project` for logging.

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Pin gcloud version to 332.0.0 for image building.
```
