### PR TITLE
Remove --version flag from cip command.

### DIFF
--- a/cmd/cip/cmd/root.go
+++ b/cmd/cip/cmd/root.go
@@ -59,13 +59,6 @@ func init() {
 		rootOpts.DryRun,
 		"test run promotion without modifying any registry",
 	)
-
-	rootCmd.PersistentFlags().BoolVar(
-		&rootOpts.Version,
-		"version",
-		rootOpts.Version,
-		"print version",
-	)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/legacy/cli/root.go
+++ b/legacy/cli/root.go
@@ -25,7 +25,6 @@ import (
 type RootOptions struct {
 	LogLevel string
 	DryRun   bool
-	Version  bool
 }
 
 func printVersion() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change removes the `--version` flag in favor of the existing `version` command. Currently the flag does not actually change any behavior in CIP, nor does it actually print the version. Since we already have a command responsible for producing version information, we no longer need this flag.

Such a change WILL effect our users, as it's an API change of the `cip` CLI. Therefore, this should be pointed out within the release notes of the next CIP major version.

#### Which issue(s) this PR fixes:
#345 

#### Special notes for your reviewer:
**This API change should be documented in the next release.**

#### Does this PR introduce a user-facing change?
YES

The flag `--version` no longer exists. 

```release-note
Remove the version flag from the cobra cli.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering