### PR TITLE
Added --verbose flag for extra logging info

### DIFF
--- a/cmd/cip/cmd/audit.go
+++ b/cmd/cip/cmd/audit.go
@@ -73,5 +73,12 @@ func init() {
 		"manifest path (relative to the root of promoter manifest repo)",
 	)
 
+	auditCmd.PersistentFlags().BoolVar(
+		&auditOpts.Verbose,
+		"verbose",
+		auditOpts.Verbose,
+		"include extra logging information",
+	)
+
 	rootCmd.AddCommand(auditCmd)
 }

--- a/legacy/audit/types.go
+++ b/legacy/audit/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package audit
 
 import (
+	"github.com/sirupsen/logrus"
+
 	reg "sigs.k8s.io/k8s-container-image-promoter/legacy/dockerregistry"
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/logclient"
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/remotemanifest"
@@ -41,6 +43,14 @@ type ServerContext struct {
 	ErrorReportingFacility report.ReportingFacility
 	LoggingFacility        logclient.LoggingFacility
 	GcrReadingFacility     GcrReadingFacility
+	VerboseLogging         bool
+}
+
+// Debug only logs the given message if the VerboseLogging option is set.
+func (s *ServerContext) Debug(args ...interface{}) {
+	if s.VerboseLogging {
+		logrus.Debug(args...)
+	}
 }
 
 // PubSubMessageInner is the inner struct that holds the actual Pub/Sub

--- a/legacy/cli/audit.go
+++ b/legacy/cli/audit.go
@@ -32,6 +32,7 @@ type AuditOptions struct {
 	RepoBranch   string
 	ManifestPath string
 	UUID         string
+	Verbose      bool
 }
 
 func RunAuditCmd(opts *AuditOptions) error {
@@ -47,6 +48,7 @@ func RunAuditCmd(opts *AuditOptions) error {
 		opts.RepoBranch,
 		opts.ManifestPath,
 		opts.UUID,
+		opts.Verbose,
 	)
 	if err != nil {
 		return errors.Wrap(err, "creating auditor context")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change adds the `--verbose` flag to the audit command. When enabled, this provides information on the Process Id of the auditor as well as notify:
- when the k/k8s.io repo is being cloned
- when GCR is being queried

Helping gain insight to issue #353 
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
None
Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
The `cip audit -h` now reveals our new flag:
```
cip audit - Image auditor

Start an audit server that responds to Pub/Sub push events.

Usage:
  cip audit [flags]

Flags:
      --branch string    git branch of the promoter manifest repo to checkout
  -h, --help             help for audit
      --path string      manifest path (relative to the root of promoter manifest repo)
      --project string   GCP project name (used for labeling error reporting logs in GCP)
      --url string       repository URL for promoter manifests
      --verbose          include extra logging information

Global Flags:
      --dry-run            test run promotion without modifying any registry
      --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warning', 'info', 'debug', 'trace' (default "info")
```

```release-note
Adding --verbose flag to cip tool for extra logging info.
```

cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering