### PR TITLE
Fixing malformed auditor logging message

### DIFF
--- a/legacy/cli/audit.go
+++ b/legacy/cli/audit.go
@@ -90,10 +90,10 @@ func (o *AuditOptions) set() {
 	logrus.Infof(
 		// nolint: lll
 		"Image auditor options: [GCP project: %s, repo URL: %s, repo branch: %s, path: %s, UUID: %s]",
+		o.ProjectID,
 		o.RepoURL,
 		o.RepoBranch,
 		o.ManifestPath,
-		o.ProjectID,
 		o.UUID,
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change fixes the formatting for auditor logs. Current logs in GCP show this output:
![pantheon corp google com_run_detail_us-central1_cip-auditor_logs_folder= organizationId= project=k8s-artifacts-prod (1)](https://user-images.githubusercontent.com/20875599/126381855-ae3e2e25-e526-4fc1-a0e2-ba7947a8e0e8.png)

If you look closely, the labels do not match the content.
#### Which issue(s) this PR fixes:
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixing malformed auditor logging message.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering