### PR TITLE
Introduce a request counter to the auditor

### DIFF
--- a/legacy/cli/audit.go
+++ b/legacy/cli/audit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/audit"
+	"sigs.k8s.io/k8s-container-image-promoter/legacy/reqcounter"
 )
 
 type AuditOptions struct {
@@ -52,6 +53,11 @@ func RunAuditCmd(opts *AuditOptions) error {
 	)
 	if err != nil {
 		return errors.Wrap(err, "creating auditor context")
+	}
+
+	if opts.Verbose {
+		// Initialize global counter to track the number of HTTP requests made to GCR.
+		reqcounter.Init()
 	}
 
 	auditorContext.RunAuditor()

--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reqcounter
+
+import "sync"
+
+// RequestCounter records the number of HTTP requests to GCR.
+type RequestCounter struct {
+	mutex    sync.Mutex
+	requests uint64
+}
+
+var (
+	// enableCounting will only become true if the Init function is called. This allows
+	// requests to be counted and logged.
+	enableCounting = false
+	// counter will continuously be modified by the Increment function to count all
+	// HTTP requests to GCR.
+	counter = RequestCounter{}
+)
+
+// Init allows request counting to begin.
+func Init() {
+	enableCounting = true
+	counter = RequestCounter{
+		mutex:    sync.Mutex{},
+		requests: 0,
+	}
+}
+
+// Increment increases the request counter by 1, signifying an HTTP
+// request to GCR has been made.
+func Increment() {
+	if enableCounting {
+		counter.mutex.Lock()
+		counter.requests++
+		counter.mutex.Unlock()
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change creates a simple request counter, able to concurrently keep track of all HTTP requests  made to GCR. The counter is only enabled when the user passes the `--verbose` flag. In the future, this counter will be logged to gain visibility in the network performance of the auditor.

Supersedes #356
#### Which issue(s) this PR fixes:
Partially satisfies #358 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
The auditor does not yet call `Increment()` to add to the counter. This would perpetually increase the value of the counter if enabled. Once the concurrent logger is implemented (part of #358), which resets the counter every 10min, will the auditor call `Increment()`.

Less importantly, this package is made specifically for the auditor, it can just as easily be used for other commands, like `cip run --snapshot`. 

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Triggering request counter for the auditor when --verbose flag is present.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering