### PR TITLE
[WIP] Log when GCR requests exceed quota

### DIFF
--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -40,8 +40,18 @@ func (rc *RequestCounter) log() {
 	// Log the number of requests found.
 	msg := fmt.Sprintf("Since %s there have been %d requests to GCR.", counter.since.Format("01-02-2006 15:04:05"), counter.requests)
 	logrus.Debug(msg)
+	// Warn of GCR scaling when requests exceed quota.
+	rc.warn()
 	// Reset the counter.
 	rc.reset()
+}
+
+// warn only logs a warning if the number of requests has exceeded the quota.
+func (rc *RequestCounter) warn() {
+	if rc.requests > rc.quota {
+		msg := fmt.Sprintf("The GCR quota of \"%d requests per %d min\" has been exceeded.", quotaLimit, measurementWindow/10)
+		logrus.Warn(msg)
+	}
 }
 
 // reset clears the number of requests and stamps the object with the current time of reset.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change logs a warning when the auditor is observed to make more HTTP requests than the [GCR quota](https://cloud.google.com/container-registry/quotas): 50,000 requests per 10min. In this scenario, the auditor is expected to be throttled by GCR and experience longer response times from each request. This behavior should be avoided at all costs, since throttling will also slow the verification process of each GCR change. In the worst case, this slowdown may leave multiple Pub/Sub messages unacknowledged causing a backup of verifications and cause alerts to fire. This change looks to gain visibility into when, if at all, this behavior occurs.


#### Which issue(s) this PR fixes:
Partially satisfies #358
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
This warning will only occur if the request counting is enabled in the first place. Therefore, the auditor must be run with the `--verbose` flag to gain such visibility.

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Log a warning when the number of GCR requests exceeds quota.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering