### PR TITLE
gitignore: add tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ WORKSPACE
 
 # downloaded and built binaries
 bin
+# tmp files
+tmp/
 
 # vscode settings
 .vscode


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently, `make test` dumps coverage artifacts in `tmp/`, and then `git
status` will show untracked files.  I doubt we want these checked in.

So, add `tmp/` to .gitignore.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```