### PR TITLE
Log request counter every 10min

### DIFF
--- a/legacy/dockerregistry/inventory.go
+++ b/legacy/dockerregistry/inventory.go
@@ -40,6 +40,7 @@ import (
 
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/gcloud"
 	cipJson "sigs.k8s.io/k8s-container-image-promoter/legacy/json"
+	"sigs.k8s.io/k8s-container-image-promoter/legacy/reqcounter"
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/stream"
 )
 
@@ -1715,6 +1716,9 @@ func (sc *SyncContext) ExecRequests(
 			} else {
 				logrus.Infof("Request %v: OK\n", reqRes.Context.RequestParams)
 			}
+
+			// Log the HTTP request to GCR.
+			reqcounter.Increment()
 
 			wg.Add(-1)
 		}

--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -16,13 +16,43 @@ limitations under the License.
 
 package reqcounter
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
 
 // RequestCounter records the number of HTTP requests to GCR.
 type RequestCounter struct {
-	mutex    sync.Mutex
-	requests uint64
+	mutex    sync.Mutex // Lock to prevent race-conditions with concurrent processes.
+	requests uint64     // Number of HTTP requests since recording started.
+	since    time.Time  // When the current counter began recording requests.
 }
+
+// log records the number of HTTP requests found and resets the counter.
+func (rc *RequestCounter) log() {
+	// Hold onto the lock when reading & writing the counter.
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+
+	// Log the number of requests within this measurement window.
+	msg := fmt.Sprintf("Since %s there have been %d requests to GCR.", counter.since.Format("2006-01-02 15:04:05"), rc.requests)
+	logrus.Debug(msg)
+
+	// Reset the counter.
+	rc.requests = 0
+	rc.since = time.Now()
+}
+
+const (
+	// measurementWindow specifies the length of time to wait before logging the RequestCounter. Since Google's
+	// Container Registry specifies a quota of 50,000 HTTP requests per 10 min, the window
+	// for recording requests is set to 10 min.
+	// Source: https://cloud.google.com/container-registry/quotas
+	measurementWindow = time.Minute * 10
+)
 
 var (
 	// enableCounting will only become true if the Init function is called. This allows
@@ -30,16 +60,19 @@ var (
 	enableCounting = false
 	// counter will continuously be modified by the Increment function to count all
 	// HTTP requests to GCR.
-	counter = RequestCounter{}
+	counter = &RequestCounter{}
 )
 
 // Init allows request counting to begin.
 func Init() {
 	enableCounting = true
-	counter = RequestCounter{
+	counter = &RequestCounter{
 		mutex:    sync.Mutex{},
 		requests: 0,
+		since:    time.Now(),
 	}
+	// Trigger the logger to run in the background.
+	go requestLogger(measurementWindow)
 }
 
 // Increment increases the request counter by 1, signifying an HTTP
@@ -49,5 +82,13 @@ func Increment() {
 		counter.mutex.Lock()
 		counter.requests++
 		counter.mutex.Unlock()
+	}
+}
+
+// requestLogger continuously logs the number of recorded HTTP requests every interval.
+func requestLogger(interval time.Duration) {
+	for {
+		time.Sleep(interval)
+		counter.log()
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change logs the number of HTTP requests to GCR every 10min if the auditor is passed the `--verbose` flag. If enabled, the request counter will continuously produce logs that look like this:
```
Since 2006-01-02 15:04:05 there have been 3402 requests to GCR.
```

Since the actual Container Registry defines it's [quota](https://cloud.google.com/container-registry/quotas) as 50,000 HTTP requests every 10 minutes, this feature will give us insight into how close the auditor is getting to this upper-limit.

**NOTE:** If the auditor surpasses this GCR quota, the responses will be throttled, resulting in slower image verification. Depending on the number of Pub/Sub messages it must respond to, this can lead to unacknowledged messages. 
#### Which issue(s) this PR fixes:
Partially satisfies #358 

#### Special notes for your reviewer:
The `--verbose` flag will not be added to auditor builds (the Dockerfile) until tests validate all behavior.

Accidentally closed #360, this PR contains all of this work.
#### Does this PR introduce a user-facing change?
NONE

```release-note
Continuously log request counter every 10min. 
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering