### PR TITLE
Support multiple request counters

### DIFF
--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -25,70 +25,127 @@ import (
 )
 
 // RequestCounter records the number of HTTP requests to GCR.
+// TODO: @tylerferrara in the future, add a field 'persistent bool' to determine if
+// the request counter should ever reset.
 type RequestCounter struct {
-	mutex    sync.Mutex // Lock to prevent race-conditions with concurrent processes.
-	requests uint64     // Number of HTTP requests since recording started.
-	since    time.Time  // When the current counter began recording requests.
+	Mutex    sync.Mutex    // Lock to prevent race-conditions with concurrent processes.
+	Requests uint64        // Number of HTTP requests since recording started.
+	Since    time.Time     // When the current request counter began recording requests.
+	Interval time.Duration // The duration of time between each log.
 }
 
-// log records the number of HTTP requests found and resets the counter.
-func (rc *RequestCounter) log() {
-	// Hold onto the lock when reading & writing the counter.
-	rc.mutex.Lock()
-	defer rc.mutex.Unlock()
+// increment adds 1 to the request counter, signifying another call to GCR.
+func (rc *RequestCounter) Increment() {
+	rc.Mutex.Lock()
+	rc.Requests++
+	rc.Mutex.Unlock()
+}
+
+// Flush records the number of HTTP requests found and resets the request counter.
+func (rc *RequestCounter) Flush() {
+	// Hold onto the lock when reading & writing the request counter.
+	rc.Mutex.Lock()
+	defer rc.Mutex.Unlock()
 
 	// Log the number of requests within this measurement window.
-	msg := fmt.Sprintf("Since %s there have been %d requests to GCR.", counter.since.Format("2006-01-02 15:04:05"), rc.requests)
-	logrus.Debug(msg)
+	msg := fmt.Sprintf("From %s to %s [%d min] there have been %d requests to GCR.", rc.Since.Format(timestampFormat), time.Now().Format(timestampFormat), rc.Interval/time.Minute, rc.Requests)
+	Debug(msg)
 
-	// Reset the counter.
-	rc.requests = 0
-	rc.since = time.Now()
+	// Reset the request counter.
+	rc.reset()
+}
+
+// reset clears the request counter and stamps the current time of reset.
+// TODO: @tylerferrara in the future, use the request counter field 'persistent' to check
+// if it must be reset.
+func (rc *RequestCounter) reset() {
+	rc.Requests = 0
+	rc.Since = time.Now()
+}
+
+// watch continuously logs the request counter at the specified intervals.
+func (rc *RequestCounter) watch() {
+	go func() {
+		for {
+			Sleep(rc.Interval)
+			rc.Flush()
+		}
+	}()
+}
+
+// RequestCounters holds multiple request counters.
+type RequestCounters []*RequestCounter
+
+// NetworkMonitor is the primary means of monitoring network traffic between CIP and GCR.
+type NetworkMonitor struct {
+	RequestCounters RequestCounters
+}
+
+// increment adds 1 to each request counter, signifying a new request has been made to GCR.
+func (nm *NetworkMonitor) increment() {
+	for _, rc := range nm.RequestCounters {
+		rc.Increment()
+	}
+}
+
+// Log begins logging each request counter at their specified intervals.
+func (nm *NetworkMonitor) Log() {
+	for _, rc := range nm.RequestCounters {
+		rc.watch()
+	}
 }
 
 const (
-	// measurementWindow specifies the length of time to wait before logging the RequestCounter. Since Google's
+	// MeasurementWindow specifies the length of time to wait before logging the request counters. Since Google's
 	// Container Registry specifies a quota of 50,000 HTTP requests per 10 min, the window
 	// for recording requests is set to 10 min.
+	// NOTE: This metric is only a rough approximation of the actual GCR quota. The specific 10min measurement
+	// is ambiguous, as the start and end time are not specified in the docs. Therefore, it's impossible for our
+	// requests counters to perfectly line up with the actual GCR quota.
 	// Source: https://cloud.google.com/container-registry/quotas
-	measurementWindow = time.Minute * 10
+	MeasurementWindow time.Duration = time.Minute * 10
+	// timestampFormat specifies the syntax for logging time stamps of request counters.
+	timestampFormat string = "2006-01-02 15:04:05"
 )
 
 var (
-	// enableCounting will only become true if the Init function is called. This allows
+	// EnableCounting will only become true if the Init function is called. This allows
 	// requests to be counted and logged.
-	enableCounting = false
-	// counter will continuously be modified by the Increment function to count all
-	// HTTP requests to GCR.
-	counter = &RequestCounter{}
+	EnableCounting bool
+	// NetMonitor holds all request counters for recording HTTP requests to GCR.
+	NetMonitor *NetworkMonitor
+	// Debug is defined to simplify testing of logrus.Debug calls.
+	Debug func(args ...interface{}) = logrus.Debug
+	// Sleep is defined to allow mocking of the time.Sleep function in tests.
+	Sleep func(d time.Duration) = time.Sleep
 )
 
 // Init allows request counting to begin.
 func Init() {
-	enableCounting = true
-	counter = &RequestCounter{
-		mutex:    sync.Mutex{},
-		requests: 0,
-		since:    time.Now(),
+	EnableCounting = true
+
+	// Create a request counter for logging traffic every 10mins. This aims to mimic the actual
+	// GCR quota, but acts as a rough estimation of this quota, indicating when throttling may occur.
+	requestCounter := &RequestCounter{
+		Mutex:    sync.Mutex{},
+		Requests: 0,
+		Since:    time.Now(),
+		Interval: MeasurementWindow,
 	}
-	// Trigger the logger to run in the background.
-	go requestLogger(measurementWindow)
+
+	// Create a new network monitor.
+	NetMonitor = &NetworkMonitor{
+		RequestCounters: RequestCounters{requestCounter},
+	}
+
+	// Begin logging network traffic.
+	NetMonitor.Log()
 }
 
-// Increment increases the request counter by 1, signifying an HTTP
+// Increment increases the all request counters by 1, signifying an HTTP
 // request to GCR has been made.
 func Increment() {
-	if enableCounting {
-		counter.mutex.Lock()
-		counter.requests++
-		counter.mutex.Unlock()
-	}
-}
-
-// requestLogger continuously logs the number of recorded HTTP requests every interval.
-func requestLogger(interval time.Duration) {
-	for {
-		time.Sleep(interval)
-		counter.log()
+	if EnableCounting {
+		NetMonitor.increment()
 	}
 }

--- a/legacy/reqcounter/reqcounter_test.go
+++ b/legacy/reqcounter/reqcounter_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reqcounter_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	rc "sigs.k8s.io/k8s-container-image-promoter/legacy/reqcounter"
+)
+
+// defaultTime should be used as a timestamp for all request counters.
+// The actual time represents: September 22, 2002 at 05:03:16.
+var defaultTime, _ = time.Parse("020106 150405", "020106 150405")
+
+// NewRequestCounter returns a new request counter with the given number of requests.
+// All other object fields are set to default values.
+func NewRequestCounter(requests uint64) rc.RequestCounter {
+	return rc.RequestCounter{
+		Mutex:    sync.Mutex{},
+		Requests: requests,
+		Since:    defaultTime,
+		Interval: time.Second,
+	}
+}
+
+func TestInit(t *testing.T) {
+	rc.Init()
+	// Ensure request counting is enabled.
+	require.True(t, rc.EnableCounting, "Init did not enable counting.")
+	// Ensure request counters are created.
+	require.Greater(t, len(rc.NetMonitor.RequestCounters), 0, "Init did not create any request counters within the global Monitor.")
+	// Ensure at least one request counter uses the MeasurementWindow.
+	found := false
+	for _, requestCounter := range rc.NetMonitor.RequestCounters {
+		if requestCounter.Interval == rc.MeasurementWindow {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "No request counters are using the Interval: MeasurementWindow.")
+}
+
+func TestIncrement(t *testing.T) {
+	// Create request counters which use these request counts and
+	// populate the Monitor global variable.
+	requestCounters := []rc.RequestCounter{
+		NewRequestCounter(0),
+		NewRequestCounter(9),
+		NewRequestCounter(2839),
+	}
+	netMonitor := &rc.NetworkMonitor{
+		RequestCounters: rc.RequestCounters{
+			&requestCounters[0],
+			&requestCounters[1],
+			&requestCounters[2],
+		},
+	}
+	// Create the request counters we expect to get after calling rc.Increment.
+	expectedCounters := []rc.RequestCounter{
+		NewRequestCounter(1),
+		NewRequestCounter(10),
+		NewRequestCounter(2840),
+	}
+	expectedNetMonitor := &rc.NetworkMonitor{
+		RequestCounters: rc.RequestCounters{
+			&expectedCounters[0],
+			&expectedCounters[1],
+			&expectedCounters[2],
+		},
+	}
+	// Set the global network monitor.
+	rc.NetMonitor = netMonitor
+	// Ensure request counter modification can only occur when counting is enabled. Therefore,
+	// the global network monitor should not be mutated with this call to Increment.
+	rc.EnableCounting = false
+	rc.Increment()
+	require.EqualValues(t, netMonitor, rc.NetMonitor, "Request counters were modified while counting was disabled.")
+	// Ensure the Increment function actually increments each request counter's requests field.
+	rc.EnableCounting = true
+	rc.Increment()
+	require.EqualValues(t, expectedNetMonitor, rc.NetMonitor, "Request counters were not incremented correctly.")
+}
+
+func TestFlush(t *testing.T) {
+	// Create a local invocation of time.
+	requestCounter := NewRequestCounter(33)
+	// Mock the logrus.Debug function.
+	debugCalls := 0
+	rc.Debug = func(args ...interface{}) {
+		debugCalls++
+	}
+	requestCounter.Flush()
+	// Ensure logrus.Debug was called.
+	require.Equal(t, 1, debugCalls, "Flush() failed to trigger a debug statement.")
+	// Ensure the request counter is reset, where time advances and the requests are zeroed.
+	require.Equal(t, uint64(0), requestCounter.Requests, "Calling Flush() did not reset the request counter to 0.")
+	require.True(t, defaultTime.Before(requestCounter.Since), "Calling Flush() did not reset the request counter timestamp.")
+}
+
+func TestRequestCounterIncrement(t *testing.T) {
+	// Create a simple request counter.
+	requestCounter := NewRequestCounter(36)
+	// Create a request counter expected after Increment is called.
+	expected := NewRequestCounter(37)
+	// Increment the counter.
+	requestCounter.Increment()
+	// Ensure the request counter was incremented.
+	require.EqualValues(t, &expected, &requestCounter, "The request counter failed to increment its request field.")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change modifies the `reqcounter` package to easily extend support for multiple counters. Each request counter can now independently log itself at self defined intervals. This allows us to capture HTTP traffic in a variety of intervals: 10min, 30min, 24hrs. 

Why is this helpful?
According to the Container Registry [quota docs](https://cloud.google.com/container-registry/quotas), there are two measurements for inspecting traffic volume.
- 50,000 HTTP requests every 10 minutes
- 1,000,000 HTTP requests per day

This feature allows us to track both metrics for HTTP requests to GCR.

#### Which issue(s) this PR fixes:
Partially satisfies #358

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE


```release-note
Extend support for multiple request counters to log at individual intervals.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering