### PR TITLE
Added --verbose flag to auditor builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /e2e-fixtures
 RUN cp -r ./test-e2e/cip-auditor/fixture/* /e2e-fixtures
 # Trigger the auditor on startup.
 ENV HOME=/
-ENTRYPOINT ["cip", "audit"]
+ENTRYPOINT ["cip", "audit", "--verbose"]
 
 FROM gcloud-base as prod-variant
 ENV HOME=/


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change enables the verbosity feature for auditor builds. By passing the `--verbose` flag, additional debug statements are logged to show the state changes within image audits. Additionally, this feature enables request counters to track the number of HTTP requests made to GCR. This provides additional visibility into the network usage of the auditor, and gives a rough estimate of how close to the actual GCR [quota](https://cloud.google.com/container-registry/quotas) this service is getting.

#### Which issue(s) this PR fixes:
Related k8s.io noisy audit alers: [#2364](https://github.com/kubernetes/k8s.io/issues/2364)
Part of #259 #353

#### Special notes for your reviewer:
Once deployed to Cloud Run, every 10min the logs should report a debug statement like this:
`From 2021-07-26 15:00:0 to 2021-07-26 15:10:00 [10 min] there have been 1429 requests to GCR.`
#### Does this PR introduce a user-facing change?
YES
Logs will now report audit state changes & GCR usage.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enabled verbose logging feature to auditor builds.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering
