### PR TITLE
Created a timewrapper package to mock time functions

### DIFF
--- a/legacy/timewrapper/timewrapper.go
+++ b/legacy/timewrapper/timewrapper.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timewrapper
+
+import (
+	"time"
+)
+
+// Time groups the functions mocked by FakeTime.
+type Time interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+}
+
+// RealTime is a wrapper for actual time functions.
+type RealTime struct{}
+
+// Now simply calls time.Now()
+func (RealTime) Now() time.Time { return time.Now() }
+
+// Sleep simply calls time.Sleep(d), using the given duration.
+func (RealTime) Sleep(d time.Duration) { time.Sleep(d) }
+
+// FakeTime holds the global fake time.
+type FakeTime struct {
+	Time time.Time
+}
+
+// Now returns the global fake time.
+func (ft FakeTime) Now() time.Time { return ft.Time }
+
+// Sleep does not block the current goroutine.
+func (ft FakeTime) Sleep(d time.Duration) {}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change adds the `timewrapper` package to abstract time functions behind a simple interface for easy testing. This enables [reqcounter.go](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/legacy/reqcounter/reqcounter.go) to use the `RealTime` wrapper for access to the actual `time` package. Tests can then use the `FakeTime` wrapper to hold a static time for added stability.
#### Which issue(s) this PR fixes:
Part of #358

#### Special notes for your reviewer:
#370 will follow after the merging of this PR.

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adding a timewrapper package to simplify mocking of time.Now() and time.Sleep() functions.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering