### PR TITLE
[WIP] Added TestWatch to ensure request counters log at regular intervals.

### DIFF
--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -64,8 +64,8 @@ func (rc *RequestCounter) reset() {
 	rc.Since = Clock.Now()
 }
 
-// watch continuously logs the request counter at the specified intervals.
-func (rc *RequestCounter) watch() {
+// Watch continuously logs the request counter at the specified intervals.
+func (rc *RequestCounter) Watch() {
 	go func() {
 		for {
 			Clock.Sleep(rc.Interval)
@@ -92,7 +92,7 @@ func (nm *NetworkMonitor) increment() {
 // Log begins logging each request counter at their specified intervals.
 func (nm *NetworkMonitor) Log() {
 	for _, rc := range nm.RequestCounters {
-		rc.watch()
+		rc.Watch()
 	}
 }
 

--- a/legacy/timewrapper/timewrapper.go
+++ b/legacy/timewrapper/timewrapper.go
@@ -35,13 +35,81 @@ func (RealTime) Now() time.Time { return time.Now() }
 // Sleep simply calls time.Sleep(d), using the given duration.
 func (RealTime) Sleep(d time.Duration) { time.Sleep(d) }
 
-// FakeTime holds the global fake time.
+// FakeTime is an advancing clock, supporting only a single sleeping goroutine.
 type FakeTime struct {
-	Time time.Time
+	Time      time.Time
+	Interval  time.Duration
+	CheckTime chan bool
+	Updated   chan bool
+}
+
+// NewFakeTime creates a new fake time with the provided start time.
+func NewFakeTime(startTime time.Time) FakeTime {
+	return FakeTime{
+		Time:      startTime,
+		CheckTime: make(chan bool),
+		Updated:   make(chan bool),
+	}
+}
+
+// Advance adds the duration to the global fake time by breaking the
+// duration up into a series of time-steps. Each time-step is either less than
+// or equal to an observed sleep interval. This allows multiple sleep/wake cycles
+// to occur on time advancements that are orders longer than the given sleep interval.
+func (ft *FakeTime) Advance(d time.Duration) {
+	// Determine the number of time steps we must make.
+	var timeStep, timePast time.Duration
+	timePast = 0
+	for timePast < d {
+		timeStep = ft.Interval
+		if timePast+timeStep > d {
+			timeStep = d - timePast
+		}
+		// Make the time step.
+		ft.step(timeStep)
+		timePast += timeStep
+	}
+}
+
+// step increments time by the given duration. This duration should either be less than
+// or equal to the observed sleep interval.
+func (ft *FakeTime) step(d time.Duration) {
+	if d > ft.Interval {
+		panic("timewrapper.step received a duration greater than the observed time interval.")
+	}
+	ft.Time = ft.Time.Add(d)
+	// Notify the sleeping goroutine to check the current time.
+	ft.CheckTime <- true
+	// Wait for the sleeping goroutine to respond.
+	ft.WaitForSleeper()
 }
 
 // Now returns the global fake time.
-func (ft FakeTime) Now() time.Time { return ft.Time }
+func (ft *FakeTime) Now() time.Time { return ft.Time }
+
+// WaitForSleeper blocks until a goroutine has notified that it's up to date
+// with the current global fake time.
+func (ft *FakeTime) WaitForSleeper() {
+	<-ft.Updated
+}
 
 // Sleep does not block the current goroutine.
-func (ft FakeTime) Sleep(d time.Duration) {}
+func (ft *FakeTime) Sleep(d time.Duration) {
+	// Record the sleep interval for the Advance function to break up
+	// time advancement into a series of time-steps.
+	ft.Interval = d
+	// Determine when to wake up from sleep.
+	wakeAt := ft.Time.Add(d)
+	// Notify the goroutine is sleeping.
+	ft.Updated <- true
+	for {
+		// Blocking the current goroutine.
+		<-ft.CheckTime
+		if wakeAt.After(ft.Time) {
+			// Notify the goroutine has seen the fake time update.
+			ft.Updated <- true
+		} else {
+			return
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change creates a new test for `reqcounter`, ensuring every request counter will sleep and log at regular intervals. Testing this behavior requires the modified `FakeTime` wrapper to advance the global fake time in a series of time-steps. A simple request counter  is used to log new requests upon every time advancement. Since `FakeTime` makes time advancements in a series of intervals, the request counter can wake, log, and sleep several times in one `fakeTime.Advance()` call. This simulates real world behavior, ensuring the correct logs are produced on every advancement.

#### Which issue(s) this PR fixes:
Partially satisfies #358 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Blocked by the merging of #373 
Supersedes #372
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added TestWatch to ensure request counters log at regular intervals.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering