### PR TITLE
Modified FakeTime to allow advances in time.

### DIFF
--- a/legacy/timewrapper/timewrapper.go
+++ b/legacy/timewrapper/timewrapper.go
@@ -35,13 +35,81 @@ func (RealTime) Now() time.Time { return time.Now() }
 // Sleep simply calls time.Sleep(d), using the given duration.
 func (RealTime) Sleep(d time.Duration) { time.Sleep(d) }
 
-// FakeTime holds the global fake time.
+// FakeTime is an advancing clock, supporting only a single sleeping goroutine.
 type FakeTime struct {
-	Time time.Time
+	Time      time.Time
+	Interval  time.Duration
+	CheckTime chan bool
+	Updated   chan bool
+}
+
+// NewFakeTime creates a new fake time with the provided start time.
+func NewFakeTime(startTime time.Time) FakeTime {
+	return FakeTime{
+		Time:      startTime,
+		CheckTime: make(chan bool),
+		Updated:   make(chan bool),
+	}
+}
+
+// Advance adds the duration to the global fake time by braking the
+// duration up into a series of time-steps. Each time-step is either less than
+// or equal to an observed sleep interval. This allows multiple sleep/wake cycles
+// to occur on time advancements that are orders longer than the given sleep interval.
+func (ft *FakeTime) Advance(d time.Duration) {
+	// Determine the number of time steps we must make.
+	var timeStep, timePast time.Duration
+	timePast = 0
+	for timePast < d {
+		timeStep = ft.Interval
+		if timePast+timeStep > d {
+			timeStep = d - timePast
+		}
+		// Make the time step.
+		ft.step(timeStep)
+		timePast += timeStep
+	}
+}
+
+// step increments time by the given duration. This duration should either be less than
+// or equal to the observed sleep interval.
+func (ft *FakeTime) step(d time.Duration) {
+	if d > ft.Interval {
+		panic("timewrapper.step received a duration greater than the observed time interval.")
+	}
+	ft.Time = ft.Time.Add(d)
+	// Notify the sleeping goroutine to check the current time.
+	ft.CheckTime <- true
+	// Wait for the sleeping goroutine to respond.
+	ft.WaitForSleeper()
 }
 
 // Now returns the global fake time.
-func (ft FakeTime) Now() time.Time { return ft.Time }
+func (ft *FakeTime) Now() time.Time { return ft.Time }
+
+// WaitForSleeper blocks until a goroutine has notified that it's up to date
+// with the current global fake time.
+func (ft *FakeTime) WaitForSleeper() {
+	<-ft.Updated
+}
 
 // Sleep does not block the current goroutine.
-func (ft FakeTime) Sleep(d time.Duration) {}
+func (ft *FakeTime) Sleep(d time.Duration) {
+	// Record the sleep interval for the Advance function to break up
+	// time advancement into a series of time-steps.
+	ft.Interval = d
+	// Determine when to wake up from sleep.
+	wakeAt := ft.Time.Add(d)
+	// Notify the goroutine is sleeping.
+	ft.Updated <- true
+	for {
+		// Blocking the current goroutine.
+		<-ft.CheckTime
+		if wakeAt.After(ft.Time) {
+			// Notify the goroutine has seen the fake time update.
+			ft.Updated <- true
+		} else {
+			return
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This feature modifies `FakeTime` to simulate advancement in time. This aids the testing of `wait()` within `reqcounter`, to support multiple sleep/wake cycles on time advancements. In order to simplify logic, this implementation ONLY supports a single sleeping goroutine for testing. Therefore `FakeTime` should not be used to test multiple request counters at once. If this behavior is necessary for future tests, a different structure can implement such logic.

#### Which issue(s) this PR fixes:
Part of #358 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
This PR blocks the actual use of the new `FakeTime` in #372 

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Modified FakeTime to allow advances in time.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering