### PR TITLE
Abstract a request counter's cycle logic from watch()

### DIFF
--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -64,14 +64,20 @@ func (rc *RequestCounter) reset() {
 	rc.Since = Clock.Now()
 }
 
-// watch continuously logs the request counter at the specified intervals.
+// watch indefinitely performs repeated sleep/log cycles.
 func (rc *RequestCounter) watch() {
+	// TODO: @tylerferrara create a way to cleanly terminate this goroutine.
 	go func() {
 		for {
-			Clock.Sleep(rc.Interval)
-			rc.Flush()
+			rc.Cycle()
 		}
 	}()
+}
+
+// Cycle sleeps for the request counter's interval and flushes itself.
+func (rc *RequestCounter) Cycle() {
+	Clock.Sleep(rc.Interval)
+	rc.Flush()
 }
 
 // RequestCounters holds multiple request counters.

--- a/legacy/timewrapper/timewrapper.go
+++ b/legacy/timewrapper/timewrapper.go
@@ -41,7 +41,9 @@ type FakeTime struct {
 }
 
 // Now returns the global fake time.
-func (ft FakeTime) Now() time.Time { return ft.Time }
+func (ft *FakeTime) Now() time.Time { return ft.Time }
 
-// Sleep does not block the current goroutine.
-func (ft FakeTime) Sleep(d time.Duration) {}
+// Sleep adds the given duration to the global fake time.
+func (ft *FakeTime) Sleep(d time.Duration) {
+	ft.Time = ft.Time.Add(d)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change separates sleep/log cycles from the `watch()` function within `reqcounter`. Abstracting this repeated logic from watch's anonymous goroutine allows for simple deterministic testing of sleep/log behavior. Now there is no need to `TestWatch` (#372), as it simply executes Cycle() indefinitely. 

#### Which issue(s) this PR fixes:
Partially satisfies #358 

#### Special notes for your reviewer:
This approach is much more favorable than previous attempts to test the logging of request counters. Since request counters spawn goroutines in `watch()`, advancing time forward involves complicated synchronization patterns to ensure a sleep/log cycle has finished. Instead, if we only test sleep/log behavior, we avoid unwanted complexity while still resulting in equivalent code coverage. 

Supersedes: #372 #368 #369
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Abstract sleep/log logic from a request counter's watch() function.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering