### PR TITLE
Enable verbose log lvl when passing --verbose flag

### DIFF
--- a/legacy/audit/auditor.go
+++ b/legacy/audit/auditor.go
@@ -38,7 +38,7 @@ import (
 // for production use (going over the network to fetch actual official promoter
 // manifests from GitHub, for example).
 func InitRealServerContext(
-	gcpProjectID, repoURLStr, branch, path, uuid string, verbose bool,
+	gcpProjectID, repoURLStr, branch, path, uuid string,
 ) (*ServerContext, error) {
 	remoteManifestFacility, err := remotemanifest.NewGit(
 		repoURLStr,
@@ -64,7 +64,6 @@ func InitRealServerContext(
 			ReadRepo:         reg.MkReadRepositoryCmdReal,
 			ReadManifestList: reg.MkReadManifestListCmdReal,
 		},
-		VerboseLogging: verbose,
 	}
 
 	return &serverContext, nil
@@ -72,7 +71,7 @@ func InitRealServerContext(
 
 // RunAuditor runs an HTTP server.
 func (s *ServerContext) RunAuditor() {
-	s.Debug("Running on Process ID (PID):", os.Getgid())
+	logrus.Debug("Running on Process ID (PID):", os.Getgid())
 	logrus.Info("Starting Auditor")
 	logrus.Infoln(s)
 
@@ -217,7 +216,7 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	logInfo.Println(msg)
 
 	// (2) Clone fresh repo (or use one already on disk).
-	s.Debug("Cloning GCR repo...")
+	logrus.Debug("Cloning GCR repo...")
 	manifests, err := s.RemoteManifestFacility.Fetch()
 	if err != nil {
 		logError.Println(err)
@@ -299,7 +298,7 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logInfo.Printf("(%s): reading srcRegistries %v for %q", s.ID, srcRegistries, gcrPayload)
-	s.Debug("Querying GCR repository...")
+	logrus.Debug("Querying GCR repository...")
 
 	sc.ReadRegistries(
 		srcRegistries,

--- a/legacy/audit/types.go
+++ b/legacy/audit/types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package audit
 
 import (
-	"github.com/sirupsen/logrus"
-
 	reg "sigs.k8s.io/k8s-container-image-promoter/legacy/dockerregistry"
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/logclient"
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/remotemanifest"
@@ -43,14 +41,6 @@ type ServerContext struct {
 	ErrorReportingFacility report.ReportingFacility
 	LoggingFacility        logclient.LoggingFacility
 	GcrReadingFacility     GcrReadingFacility
-	VerboseLogging         bool
-}
-
-// Debug only logs the given message if the VerboseLogging option is set.
-func (s *ServerContext) Debug(args ...interface{}) {
-	if s.VerboseLogging {
-		logrus.Debug(args...)
-	}
 }
 
 // PubSubMessageInner is the inner struct that holds the actual Pub/Sub

--- a/legacy/cli/audit.go
+++ b/legacy/cli/audit.go
@@ -49,13 +49,14 @@ func RunAuditCmd(opts *AuditOptions) error {
 		opts.RepoBranch,
 		opts.ManifestPath,
 		opts.UUID,
-		opts.Verbose,
 	)
 	if err != nil {
 		return errors.Wrap(err, "creating auditor context")
 	}
 
 	if opts.Verbose {
+		// Enable verbose logging.
+		logrus.SetLevel(logrus.DebugLevel)
 		// Initialize global counter to track the number of HTTP requests made to GCR.
 		reqcounter.Init()
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change fixes missing `logrus.Debug()` statements by explicitly setting the logging level. Now, when passing the `--verbose` flag, we should be able to actually see verbose & request counter logs.

Additionally, since the default logging level hides debug statement by default, we no longer need a serviceContext.Debug() wrapper. It's safe to define logrus.Debug, as only --verbose will trigger the log level change.

Supersedes #380 
#### Which issue(s) this PR fixes:
Partially satisfies #358
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Currently, when deploying the auditor with `--verbose`, we were unable to see any Debug logs. This PR should fix that problem.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix logging level when passing --verbose flag.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering