### PR TITLE
Create multiple request counters

### DIFF
--- a/legacy/reqcounter/reqcounter_test.go
+++ b/legacy/reqcounter/reqcounter_test.go
@@ -49,15 +49,17 @@ func TestInit(t *testing.T) {
 	require.True(t, rc.EnableCounting, "Init did not enable counting.")
 	// Ensure request counters are created.
 	require.Greater(t, len(rc.NetMonitor.RequestCounters), 0, "Init did not create any request counters within the global Monitor.")
-	// Ensure at least one request counter uses the MeasurementWindow.
-	found := false
+	// Ensure at least one request counter uses the QuotaWindowShort.
+	foundQuotaWindowShort, foundQuotaWindowLong := false, false
 	for _, requestCounter := range rc.NetMonitor.RequestCounters {
-		if requestCounter.Interval == rc.MeasurementWindow {
-			found = true
-			break
+		if requestCounter.Interval == rc.QuotaWindowShort {
+			foundQuotaWindowShort = true
+		} else if requestCounter.Interval == rc.QuotaWindowLong {
+			foundQuotaWindowLong = true
 		}
 	}
-	require.True(t, found, "No request counters are using the Interval: MeasurementWindow.")
+	require.True(t, foundQuotaWindowShort, "No request counters are using the Interval: QuotaWindowShort.")
+	require.True(t, foundQuotaWindowLong, "No request counters are using the Interval: QuotaWindowLong.")
 }
 
 func TestIncrement(t *testing.T) {
@@ -146,8 +148,13 @@ func TestCycle(t *testing.T) {
 	// Define all tests.
 	cycleTests := []cycleTest{
 		{
-			interval:   rc.MeasurementWindow,
+			interval:   rc.QuotaWindowShort,
 			requests:   []int{3, 7, 50, 1},
+			resettable: true,
+		},
+		{
+			interval:   rc.QuotaWindowLong,
+			requests:   []int{2, 622, 5, 8},
 			resettable: true,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change adds two additional request counters for logging HTTP traffic. Now we can measure network traffic that closely relates to the [actual GCR quotas](https://cloud.google.com/container-registry/quotas). Overall, this helps us determine how expensive image verification are, in terms of network cost.

#### Which issue(s) this PR fixes:
Part of #358 #353 #259

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Create multiple request counters that record network traffic similar to GCR quotas.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering