### PR TITLE
abort promoter if we detect an attempt to perform a tag move in the destination (in production)

### DIFF
--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -2713,9 +2713,7 @@ func TestExecRequests(t *testing.T) {
 		return nil
 	}
 
-	// TODO: Why are we not checking errors here?
-	// nolint: errcheck
-	edges, _ := reg.ToPromotionEdges(
+	edges, err := reg.ToPromotionEdges(
 		[]reg.Manifest{
 			{
 				Registries: registries,
@@ -2731,6 +2729,7 @@ func TestExecRequests(t *testing.T) {
 			},
 		},
 	)
+	require.Nil(t, err)
 
 	populateRequests := reg.MKPopulateRequestsForPromotionEdges(
 		edges,
@@ -2932,9 +2931,8 @@ func TestGarbageCollection(t *testing.T) {
 		mutex *sync.Mutex,
 	) {
 		for req := range reqs {
-			// TODO: Why are we not checking errors here?
-			// nolint: errcheck
-			pr := req.RequestParams.(reg.PromotionRequest)
+			pr, ok := req.RequestParams.(reg.PromotionRequest)
+			require.True(t, ok)
 			mutex.Lock()
 			captured[pr]++
 			mutex.Unlock()
@@ -3092,9 +3090,8 @@ func TestGarbageCollectionMulti(t *testing.T) {
 		mutex *sync.Mutex,
 	) {
 		for req := range reqs {
-			// TODO: Why are we not checking errors here?
-			// nolint: errcheck
-			pr := req.RequestParams.(reg.PromotionRequest)
+			pr, ok := req.RequestParams.(reg.PromotionRequest)
+			require.True(t, ok)
 			mutex.Lock()
 			captured[pr]++
 			mutex.Unlock()

--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -2789,6 +2789,140 @@ func TestExecRequests(t *testing.T) {
 	}
 }
 
+func TestValidateEdges(t *testing.T) {
+	srcRegName := reg.RegistryName("gcr.io/src")
+	dstRegName := reg.RegistryName("gcr.io/dst")
+	srcRegistry := reg.RegistryContext{
+		Name:           srcRegName,
+		ServiceAccount: "robot",
+		Src:            true,
+	}
+	dstRegistry := reg.RegistryContext{
+		Name:           dstRegName,
+		ServiceAccount: "robot",
+	}
+
+	registries := []reg.RegistryContext{
+		srcRegistry,
+		dstRegistry,
+	}
+
+	tests := []struct {
+		name     string
+		inputM   reg.Manifest
+		inputSc  reg.SyncContext
+		expected error
+	}{
+		{
+			"No problems (nothing to promote)",
+			reg.Manifest{
+				SrcRegistry: &srcRegistry,
+				Registries:  registries,
+				Images: []reg.Image{
+					{
+						ImageName: "a",
+						Dmap: reg.DigestTags{
+							"sha256:000": {"0.0"},
+						},
+					},
+				},
+			},
+			reg.SyncContext{
+				Inv: reg.MasterInventory{
+					"gcr.io/src": {
+						"a": {
+							"sha256:000": {"0.0"},
+						},
+					},
+					"gcr.io/dst": {
+						"a": {
+							"sha256:000": {"0.0"},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"Promotion edges OK",
+			reg.Manifest{
+				SrcRegistry: &srcRegistry,
+				Registries:  registries,
+				Images: []reg.Image{
+					{
+						ImageName: "a",
+						Dmap: reg.DigestTags{
+							"sha256:000": {"0.0"},
+							// This is an image we want to promote. There are no
+							// tag moves involved here, so it's OK.
+							"sha256:111": {"1.0"},
+						},
+					},
+				},
+			},
+			reg.SyncContext{
+				Inv: reg.MasterInventory{
+					"gcr.io/src": {
+						"a": {
+							"sha256:000": {},
+							"sha256:111": {},
+						},
+					},
+					"gcr.io/dst": {
+						"a": {
+							"sha256:000": {"0.0"},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"Tag move detected in promotion edge",
+			reg.Manifest{
+				SrcRegistry: &srcRegistry,
+				Registries:  registries,
+				Images: []reg.Image{
+					{
+						ImageName: "a",
+						Dmap: reg.DigestTags{
+							// The idea here is that we've already promoted
+							// sha256:111 as tag 1.0, but we want to try to
+							// retag 1.0 to the sha256:222 image instead. This
+							// intent should result in an error.
+							"sha256:222": {"1.0"},
+						},
+					},
+				},
+			},
+			reg.SyncContext{
+				Inv: reg.MasterInventory{
+					"gcr.io/src": {
+						"a": {
+							"sha256:000": {},
+							"sha256:111": {},
+						},
+					},
+					"gcr.io/dst": {
+						"a": {
+							"sha256:000": {"0.0"},
+							"sha256:111": {"1.0"},
+						},
+					},
+				},
+			},
+			fmt.Errorf("[edge &{{gcr.io/src robot  true} {a 1.0} sha256:222 {gcr.io/dst robot  false} {a 1.0}}: tag '1.0' in dest points to sha256:111, not sha256:222 (as per the manifest), but tag moves are not supported; skipping]"),
+		},
+	}
+
+	for _, test := range tests {
+		edges, err := reg.ToPromotionEdges([]reg.Manifest{test.inputM})
+		require.Nil(t, err)
+		got := test.inputSc.ValidateEdges(edges)
+		require.Equal(t, test.expected, got)
+	}
+}
+
 func TestGarbageCollection(t *testing.T) {
 	srcRegName := reg.RegistryName("gcr.io/foo")
 	destRegName := reg.RegistryName("gcr.io/bar")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Implements #375

#### Which issue(s) this PR fixes:

Fixes #375

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The promoter now exits with an error if a tag move is attempted. Previously we merely gave a warning, but exited without an error. This change in behavior will result in a presubmit (and postsubmit) failure if we have malformed manifests that try to retag existing images in production.
```

/cc @spiffxp @tylerferrara 
/hold