### PR TITLE
Watch OS signals when providing --verbose flag

### DIFF
--- a/legacy/cli/audit.go
+++ b/legacy/cli/audit.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/audit"
 	"sigs.k8s.io/k8s-container-image-promoter/legacy/reqcounter"
+	"sigs.k8s.io/k8s-container-image-promoter/legacy/signals"
 )
 
 type AuditOptions struct {
@@ -59,6 +60,8 @@ func RunAuditCmd(opts *AuditOptions) error {
 		logrus.SetLevel(logrus.DebugLevel)
 		// Initialize global counter to track the number of HTTP requests made to GCR.
 		reqcounter.Init()
+		// Watch for OS signals.
+		signals.Watch()
 	}
 
 	auditorContext.RunAuditor()

--- a/legacy/signals/signals.go
+++ b/legacy/signals/signals.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Watch concurrenlty logs debug statements when encountering interrupt signals from the OS.
+// This function relies on the os/signal package which may not capture SIGKILL and SIGSTOP.
+func Watch() {
+	c := make(chan os.Signal, 1)
+	// Observe all signals, excluding SIGKILL and SIGSTOP.
+	signal.Notify(c)
+	// Continuously watch for signals.
+	go func() {
+		logrus.Debug("Watching for OS Signals...")
+		for sig := range c {
+			logrus.Debug("Encoutered signal: ", sig.String())
+			// If the observed signal is a termination signal, we are
+			// expected to handle this by exiting the program. If we didn't
+			// exit, the program would only stop upon receiving a SIGKILL.
+			if sig == syscall.SIGHUP ||
+				sig == syscall.SIGINT ||
+				sig == syscall.SIGABRT ||
+				sig == syscall.SIGILL ||
+				sig == syscall.SIGQUIT ||
+				sig == syscall.SIGTERM ||
+				sig == syscall.SIGSEGV ||
+				sig == syscall.SIGTSTP {
+				logrus.Debug("Exiting from signal: ", sig.String())
+				os.Exit(0)
+			}
+		}
+	}()
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When providing the `--verbose` flag to the auditor, all OS signals are logged when encountered. The two exceptions are SIGKILL and SIGSTOP as the `os/signal` package [cannot catch these signals](https://pkg.go.dev/os/signal#hdr-Types_of_signals).

Capturing all OS signals may gain insight into how and why the auditor keeps restarting #353 

#### Which issue(s) this PR fixes:
Part of #353 

#### Special notes for your reviewer:
When observing OS signals, we are expected to\ handle them. This is why we must check for all "termination" signals and force the program to exit. If we did not do this, our program would only exit when given a SIGKILL. Realistically, when deployed in Cloud Run, the container will be stopped after sending a SIGINT, so this would not effect deployment situations. However, when running locally #388, the program would not terminate when given hitting (ctrl-c).

#### Does this PR introduce a user-facing change?
YES
When providing the auditor with the `--verbose`, debug messages will be logged like so:
```
DEBU Watching for OS Signals...                    file="signals/signals.go:50"
INFO Defaulting to port 8080                       file="audit/auditor.go:94"
INFO Listening on port 8080                        file="audit/auditor.go:97"
DEBU Encoutered signal: bus error                  file="signals/signals.go:52"
DEBU Encoutered signal: floating point exception   file="signals/signals.go:52"
DEBU Encoutered signal: urgent I/O condition       file="signals/signals.go:52"
DEBU Encoutered signal: signal 54                  file="signals/signals.go:52"
DEBU Encoutered signal: urgent I/O condition       file="signals/signals.go:52"
DEBU Encoutered signal: child exited               file="signals/signals.go:52"
DEBU Encoutered signal: trace/breakpoint trap      file="signals/signals.go:52"
DEBU Encoutered signal: window changed             file="signals/signals.go:52"
DEBU Encoutered signal: urgent I/O condition       file="signals/signals.go:52"
DEBU Encoutered signal: urgent I/O condition       file="signals/signals.go:52"
```

```release-note
Observe all OS signals directed to the auditor when passing the --verbose flag.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering