### PR TITLE
Add unit tests to signals package

### DIFF
--- a/legacy/signals/signals.go
+++ b/legacy/signals/signals.go
@@ -24,31 +24,68 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	// ExitSignals are used to determine if an incoming os.Signal should cause termination.
+	ExitSignals map[os.Signal]bool = map[os.Signal]bool{
+		syscall.SIGHUP:  true,
+		syscall.SIGINT:  true,
+		syscall.SIGABRT: true,
+		syscall.SIGILL:  true,
+		syscall.SIGQUIT: true,
+		syscall.SIGTERM: true,
+		syscall.SIGSEGV: true,
+		syscall.SIGTSTP: true,
+	}
+	// ExitChannel is for gracefully terminating the LogSignals() function.
+	ExitChannel chan bool = make(chan bool, 1)
+	// SignalChannel is for listening to OS signals.
+	SignalChannel chan os.Signal = make(chan os.Signal, 1)
+	// Debug is defined globally for mocking logrus.Debug statements.
+	Debug func(args ...interface{}) = logrus.Debug
+)
+
 // Watch concurrenlty logs debug statements when encountering interrupt signals from the OS.
 // This function relies on the os/signal package which may not capture SIGKILL and SIGSTOP.
 func Watch() {
-	c := make(chan os.Signal, 1)
+	Debug("Watching for OS Signals...")
 	// Observe all signals, excluding SIGKILL and SIGSTOP.
-	signal.Notify(c)
-	// Continuously watch for signals.
-	go func() {
-		logrus.Debug("Watching for OS Signals...")
-		for sig := range c {
-			logrus.Debug("Encoutered signal: ", sig.String())
-			// If the observed signal is a termination signal, we are
-			// expected to handle this by exiting the program. If we didn't
-			// exit, the program would only stop upon receiving a SIGKILL.
-			if sig == syscall.SIGHUP ||
-				sig == syscall.SIGINT ||
-				sig == syscall.SIGABRT ||
-				sig == syscall.SIGILL ||
-				sig == syscall.SIGQUIT ||
-				sig == syscall.SIGTERM ||
-				sig == syscall.SIGSEGV ||
-				sig == syscall.SIGTSTP {
-				logrus.Debug("Exiting from signal: ", sig.String())
-				os.Exit(0)
-			}
+	signal.Notify(SignalChannel)
+	// Continuously log signals.
+	go LogSignals()
+}
+
+// Stop gracefully terminates the concurrent signal logging.
+// TODO: @tylerferrara Currently we don't gracefully exit, since the Auditor is designed
+// to run indefinitely. In the future, we should enable graceful termination to allow
+// this to be called from a Shutdown() function.
+func Stop() {
+	ExitChannel <- true
+}
+
+// LogSignals continuously prints logging statements for each signal it observes,
+// exiting only when observing an exit signal.
+func LogSignals() {
+	for {
+		select {
+		case sig := <-SignalChannel:
+			LogSignal(sig)
+		case <-ExitChannel:
+			// Gracefully terminate.
+			return
 		}
-	}()
+	}
+}
+
+// LogSignal prints a logging statements for the given signal,
+// exiting only when observing an exit signal.
+func LogSignal(sig os.Signal) {
+	Debug("Encoutered signal: ", sig.String())
+	// Handle exit signals.
+	if _, found := ExitSignals[sig]; found {
+		Debug("Exiting from signal: ", sig.String())
+		// If we get here, an exit signal was seen. We must handle this by forcing
+		// the program to exit. Without this, the program would ignore all exit signals
+		// except SIGKILL.
+		Stop()
+	}
 }

--- a/legacy/signals/signals_test.go
+++ b/legacy/signals/signals_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package signals_test
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/k8s-container-image-promoter/legacy/signals"
+)
+
+func TestLogSignal(t *testing.T) {
+	// Define what a test looks like.
+	type sigTest struct {
+		signal    os.Signal // Incoming signal to observe.
+		expected  []string  // Expected logs to be produced.
+		terminate bool      // Determine if signals.LogSignals() should return.
+	}
+	// Create multiple tests.
+	// NOTE: We are unable to observe SIGKILL or SIGSTOP, therefore we will not
+	// test with these syscalls.
+	sigTests := []sigTest{
+		{
+			signal: syscall.SIGIO,
+			expected: []string{
+				fmt.Sprintf("Encoutered signal: %s", syscall.SIGIO.String()),
+			},
+			terminate: false,
+		},
+		{
+			signal: syscall.SIGALRM,
+			expected: []string{
+				fmt.Sprintf("Encoutered signal: %s", syscall.SIGALRM.String()),
+			},
+			terminate: false,
+		},
+		{
+			signal: syscall.SIGALRM,
+			expected: []string{
+				fmt.Sprintf("Encoutered signal: %s", syscall.SIGALRM.String()),
+			},
+			terminate: false,
+		},
+		{
+			signal: syscall.SIGQUIT,
+			expected: []string{
+				fmt.Sprintf("Encoutered signal: %s", syscall.SIGQUIT.String()),
+				fmt.Sprintf("Exiting from signal: %s", syscall.SIGQUIT.String()),
+			},
+			terminate: true,
+		},
+		{
+			signal: syscall.SIGINT,
+			expected: []string{
+				fmt.Sprintf("Encoutered signal: %s", syscall.SIGINT.String()),
+				fmt.Sprintf("Exiting from signal: %s", syscall.SIGINT.String()),
+			},
+			terminate: true,
+		},
+		{
+			signal: syscall.SIGABRT,
+			expected: []string{
+				fmt.Sprintf("Encoutered signal: %s", syscall.SIGABRT.String()),
+				fmt.Sprintf("Exiting from signal: %s", syscall.SIGABRT.String()),
+			},
+			terminate: true,
+		},
+	}
+	// Capture all logs.
+	logs := []string{}
+	// Mock logrus.Debug statements.
+	signals.Debug = func(args ...interface{}) {
+		logs = append(logs, fmt.Sprint(args...))
+	}
+	// Determine if LogSignal invoked Stop().
+	terminated := func() bool {
+		return <-signals.ExitChannel
+	}
+	// Used for enforcing defaults before each test.
+	reset := func() {
+		logs = []string{}
+	}
+	// Run through all tests.
+	for _, st := range sigTests {
+		reset()
+		// Log the test signal.
+		signals.LogSignal(st.signal)
+		// Ensure the logs are correct.
+		require.EqualValues(t, st.expected, logs, "Unexpected signal observation logs.")
+		if st.terminate {
+			// Ensure Stop() was invoked if the test specifies.
+			require.True(t, terminated(), "LogSignal did not terminate on exit signal.")
+		}
+	}
+}
+
+// TestLogSignals ensures LogSignals() can handle multiple incoming signals and terminates either by
+// receiving an exit signal or explicit call to Stop().
+func TestLogSignals(t *testing.T) {
+	// Capture concurrent function termination.
+	wg := sync.WaitGroup{}
+	terminated := false
+	// Ensure the test waits for logSignals to finish executing.
+	logSignals := func() {
+		signals.LogSignals()
+		terminated = true
+		wg.Done()
+	}
+	// Start logging.
+	wg.Add(1)
+	go logSignals()
+	// Pass multiple non-exit signals, ensuring LogSignals is consuming each. Otherwise,
+	// the SignalChannel will block and the test will fail.
+	signals.SignalChannel <- syscall.SIGBUS
+	signals.SignalChannel <- syscall.SIGALRM
+	signals.SignalChannel <- syscall.SIGSYS
+	signals.SignalChannel <- syscall.SIGIO
+	// Force exit.
+	signals.Stop()
+	wg.Wait()
+	// Ensure termination happened.
+	require.True(t, terminated, "LogSignals() did not terminate on call to Stop()")
+
+	// Reset termination bool for new test.
+	terminated = false
+	// Start logging.
+	wg.Add(1)
+	go logSignals()
+	// Pass multiple non-exit signals, ensuring LogSignals is consuming each. Otherwise,
+	// the SignalChannel will block and the test will fail.
+	signals.SignalChannel <- syscall.SIGTTOU
+	signals.SignalChannel <- syscall.SIGCHLD
+	signals.SignalChannel <- syscall.SIGPIPE
+	// Pass an exit signal.
+	signals.SignalChannel <- syscall.SIGINT
+	wg.Wait()
+	// Ensure termination happened.
+	require.True(t, terminated, "LogSignals() did not terminate when given an exit signal")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR introduces unit tests to the `signals` package. It also re-factors much of `signals.go` to allow for easier testing.

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Since the Auditor is designed to run indefinitely, like a server, it does not support graceful termination. Therefore, to stop it, we must send a signal like `SIGINT` (ctrl-c) or `SIGQUIT`. These signals are captured by the `signals` package, but simply call `os.Exit(0)`. In the future, this package may be able to enable graceful termination for the auditor. This would probably mean defining a shutdown function that is called upon exit.

However, let it be known that we cannot capture `SIGKILL` and `SIGSTOP` signals. Meaning, if the Auditor is are given either of these signals, it will be unable to observe them within `signals` and not trigger a graceful termination. As of now, there is no getting around this, since the [os/signal](https://pkg.go.dev/os/signal#hdr-Types_of_signals) package doesn't support this. 

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add unit tests to signals package.
```
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering