### PR TITLE
Update verify tooling and fixup lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -43,6 +42,7 @@ linters:
     - prealloc
     - predeclared
     - promlinter
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
@@ -78,7 +78,6 @@ linters:
     # - noctx
     # - nolintlint
     # - paralleltest
-    # - revive
     # - scopelint
     # - tagliatelle
     # - testpackage

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,10 +8,10 @@ dependencies:
 
   # zeitgeist
   - name: "zeitgeist"
-    version: 0.0.17
+    version: 0.3.0
     refPaths:
     - path: hack/verify-dependencies.sh
-      match: VERSION=(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+      match: VERSION=v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
   # golangci-lint
   - name: "golangci-lint"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
   # repo infra
   - name: "repo-infra"
-    version: 0.1.1
+    version: 0.2.2
     refPaths:
     - path: hack/verify-boilerplate.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -15,7 +15,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 1.40.1
+    version: 1.41.1
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v0.1.1
+VERSION=v0.2.2
 URL_BASE=https://raw.githubusercontent.com/kubernetes/repo-infra
 URL=$URL_BASE/$VERSION/hack/verify_boilerplate.py
 BIN_DIR=bin

--- a/hack/verify-dependencies.sh
+++ b/hack/verify-dependencies.sh
@@ -18,21 +18,25 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=0.0.17
-OS="$(uname -s)"
-OS="${OS,,}"
-URL_BASE=https://github.com/kubernetes-sigs/zeitgeist/releases/download
-FILENAME="zeitgeist_${VERSION}_${OS}_amd64.tar.gz"
-URL="${URL_BASE}/v${VERSION}/${FILENAME}"
+VERSION=v0.3.0
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-mkdir -p ./bin ./zeitgeist
-PATH=$PATH:bin
-
-if ! command -v zeitgeist; then
-  curl -sfL "${URL}" -o "${FILENAME}"
-  tar -xzf "${FILENAME}" -C zeitgeist
-  mv ./zeitgeist/zeitgeist ./bin
-  rm -rf ./zeitgeist "${FILENAME}"
+# Ensure that we find the binaries we build before anything else.
+gobin=${GOBIN:-$(go env GOBIN)}
+if [[ -z $gobin ]]; then
+  gobin="$(go env GOPATH)/bin"
 fi
+PATH="${gobin}:${PATH}"
 
-zeitgeist validate
+# Install zeitgeist
+cd "${REPO_ROOT}/internal"
+GO111MODULE=on go install sigs.k8s.io/zeitgeist@"${VERSION}"
+cd -
+
+# Prefer full path for running zeitgeist
+ZEITGEIST_BIN="$(which zeitgeist)"
+
+"${ZEITGEIST_BIN}" validate \
+  --local-only \
+  --base-path "${REPO_ROOT}" \
+  --config "${REPO_ROOT}"/dependencies.yaml

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.40.1
+VERSION=v1.41.1
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/legacy/audit/auditor.go
+++ b/legacy/audit/auditor.go
@@ -173,6 +173,8 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 
 	defer func() {
 		if msg := recover(); msg != nil {
+			// TODO: Check result of type assertion
+			//nolint:errcheck
 			panicStr := msg.(string)
 
 			stacktrace := debug.Stack()
@@ -196,8 +198,12 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 		// notifies us of any changes in how the messages are created in the
 		// first place.
 		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: parse failure: %v", s.ID, err)
+
+		// TODO: Properly catch write errors
+		//nolint:errcheck
 		_, _ = w.Write([]byte(msg))
 
+		// TODO(panic): Don't panic!
 		panic(msg)
 	}
 
@@ -206,8 +212,12 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	// deletions are prohibited.
 	if err := ValidatePayload(gcrPayload); err != nil {
 		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: validation failure: %v", s.ID, err)
+
+		// TODO: Properly catch write errors
+		//nolint:errcheck
 		_, _ = w.Write([]byte(msg))
 
+		// TODO(panic): Don't panic!
 		panic(msg)
 	}
 
@@ -245,6 +255,9 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 
 			logInfo.Println(msg)
 			logrus.Infoln(msg)
+
+			// TODO: Properly catch write errors
+			//nolint:errcheck
 			_, _ = w.Write([]byte(msg))
 			return
 		}
@@ -293,7 +306,12 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	srcRegistries, err := GetMatchingSourceRegistries(&manifests, gcrPayload)
 	if err != nil {
 		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: %v", s.ID, err)
+
+		// TODO: Properly catch write errors
+		//nolint:errcheck
 		_, _ = w.Write([]byte(msg))
+
+		// TODO(panic): Don't panic!
 		panic(msg)
 	}
 
@@ -309,7 +327,12 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	sc.ReadGCRManifestLists(s.GcrReadingFacility.ReadManifestList)
 	if gcrPayload.Digest == "" {
 		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: digest missing from payload --- cannot check parent digest: %v", s.ID, gcrPayload.Digest)
+
+		// TODO: Properly catch write errors
+		//nolint:errcheck
 		_, _ = w.Write([]byte(msg))
+
+		// TODO(panic): Don't panic!
 		panic(msg)
 	}
 
@@ -319,6 +342,9 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 			"(%s) TRANSACTION VERIFIED: %v: agrees with manifest (parent digest %v)\n", s.ID, gcrPayload, parentDigest)
 		logInfo.Println(msg)
 		logrus.Infoln(msg)
+
+		// TODO: Properly catch write errors
+		//nolint:errcheck
 		_, _ = w.Write([]byte(msg))
 
 		return
@@ -331,7 +357,12 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	// Return 200 OK, because we don't want to re-process this transaction.
 	// "Terminating" the auditing here simplifies debugging as well, because the
 	// same message is not repeated over and over again in the logs.
+
+	// TODO: Properly catch write errors
+	//nolint:errcheck
 	_, _ = w.Write([]byte(msg))
+
+	// TODO(panic): Don't panic!
 	panic(msg)
 }
 

--- a/legacy/audit/auditor.go
+++ b/legacy/audit/auditor.go
@@ -287,10 +287,10 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	// is so that we can query the subproject to figure out all digests that
 	// belong there, so that we can validate the child manifest in the
 	// GCRPubSubPayload.
-	srcRegistries, err := GetMatchingSourceRegistries(&manifests, gcrPayload)
-
+	//
 	// If we can't find any source registry for this image, then reject the
 	// transaction.
+	srcRegistries, err := GetMatchingSourceRegistries(&manifests, gcrPayload)
 	if err != nil {
 		msg := fmt.Sprintf("(%s) TRANSACTION REJECTED: %v", s.ID, err)
 		_, _ = w.Write([]byte(msg))

--- a/legacy/audit/auditor_test.go
+++ b/legacy/audit/auditor_test.go
@@ -639,7 +639,7 @@ func TestAudit(t *testing.T) {
 		alert  []string
 	}
 
-	var shouldBeValid = []struct {
+	shouldBeValid := []struct {
 		name             string
 		manifests        []reg.Manifest
 		payload          reg.GCRPubSubPayload
@@ -820,7 +820,6 @@ func TestAudit(t *testing.T) {
 	}
 
 	for _, test := range shouldBeValid {
-
 		// Create a new ResponseRecorder to record the response from Audit().
 		w := httptest.NewRecorder()
 
@@ -832,8 +831,11 @@ func TestAudit(t *testing.T) {
 		psm := audit.PubSubMessage{
 			Message: audit.PubSubMessageInner{
 				Data: payload,
-				ID:   "1"},
-			Subscription: "2"}
+				ID:   "1",
+			},
+			Subscription: "2",
+		}
+
 		b, err := json.Marshal(psm)
 		require.Nil(t, err)
 

--- a/legacy/cli/run.go
+++ b/legacy/cli/run.go
@@ -344,7 +344,7 @@ necessarily mean that a new version of the image layer is available.`,
 		err = sc.RunChecks(
 			[]reg.PreCheck{
 				reg.MKImageVulnCheck(
-					sc,
+					&sc,
 					promotionEdges,
 					opts.SeverityThreshold,
 					nil,

--- a/legacy/dockerregistry/checks.go
+++ b/legacy/dockerregistry/checks.go
@@ -323,16 +323,21 @@ func (check *ImageVulnCheck) Run() error {
 		reqs chan stream.ExternalRequest,
 		requestResults chan<- RequestResult,
 		wg *sync.WaitGroup,
-		mutex *sync.Mutex) {
+		mutex *sync.Mutex,
+	) {
 		for req := range reqs {
 			reqRes := RequestResult{Context: req}
 			errors := make(Errors, 0)
 			edge := req.RequestParams.(PromotionEdge)
 			occurrences, err := vulnProducer(edge)
 			if err != nil {
-				errors = append(errors, Error{
-					Context: "error getting vulnerabilities",
-					Error:   err})
+				errors = append(
+					errors,
+					Error{
+						Context: "error getting vulnerabilities",
+						Error:   err,
+					},
+				)
 			}
 
 			fixableSevereOccurrences := 0

--- a/legacy/dockerregistry/checks_test.go
+++ b/legacy/dockerregistry/checks_test.go
@@ -562,7 +562,7 @@ func TestImageVulnCheck(t *testing.T) {
 	for _, test := range tests {
 		sc := reg.SyncContext{}
 		check := reg.MKImageVulnCheck(
-			sc,
+			&sc,
 			test.edges,
 			test.severityThreshold,
 			mkVulnProducerFake(test.vulnerabilities),

--- a/legacy/dockerregistry/inventory.go
+++ b/legacy/dockerregistry/inventory.go
@@ -620,6 +620,9 @@ func CheckOverlappingEdges(
 					checked[edgeList[0]] = nil
 				default:
 					logrus.Infof("redundant promotion: multiple edges want to promote the same digest to the same destination endpoint %v:", pqin)
+
+					// TODO(lint): rangeValCopy: each iteration copies 192 bytes (consider pointers or indexing)
+					//nolint:gocritic
 					for _, edge := range edgeList {
 						logrus.Infof("%v", edge)
 					}
@@ -631,6 +634,9 @@ func CheckOverlappingEdges(
 			logrus.Errorf("multiple edges want to promote *different* images (digests) to the same destination endpoint %v:", pqin)
 			for digest, edgeList := range digestToEdges {
 				logrus.Errorf("  for digest %v:\n", digest)
+
+				// TODO(lint): rangeValCopy: each iteration copies 192 bytes (consider pointers or indexing)
+				//nolint:gocritic
 				for _, edge := range edgeList {
 					logrus.Errorf("%v\n", edge)
 				}
@@ -844,6 +850,8 @@ func validateRequiredComponents(m Manifest) error {
 			)
 		}
 
+		// TODO(lint): SA4010: this result of append is never used, except maybe in other appends
+		//nolint:staticcheck
 		knownRegistries = append(knownRegistries, registry.Name)
 	}
 
@@ -1370,6 +1378,8 @@ func (sc *SyncContext) ReadRegistries(
 			// Process child repos.
 			if recurse {
 				for _, childRepoName := range tagsStruct.Children {
+					// TODO: Check result of type assertion
+					//nolint:errcheck
 					parentRC, _ := req.RequestParams.(RegistryContext)
 
 					childRc := RegistryContext{
@@ -1405,6 +1415,8 @@ func (sc *SyncContext) ReadRegistries(
 		}
 	}
 
+	// TODO(lint): Check error return value
+	//nolint:errcheck
 	sc.ExecRequests(populateRequests, processRequest)
 }
 
@@ -1492,6 +1504,8 @@ func (sc *SyncContext) ReadGCRManifestLists(
 				continue
 			}
 
+			// TODO: Check result of type assertion
+			//nolint:errcheck
 			gmlc := req.RequestParams.(GCRManifestListContext)
 
 			for _, gManifest := range gcrManifestList.Manifests {
@@ -1505,6 +1519,8 @@ func (sc *SyncContext) ReadGCRManifestLists(
 		}
 	}
 
+	// TODO(lint): Check error return value
+	//nolint:errcheck
 	sc.ExecRequests(populateRequests, processRequest)
 }
 
@@ -2239,6 +2255,8 @@ func (sc *SyncContext) Promote(
 				// overwriting), do not bother shelling out to gcloud. Instead just
 				// use the gcrane.doCopy() method directly.
 
+				// TODO: Check result of type assertion
+				//nolint:errcheck
 				rpr := req.RequestParams.(PromotionRequest)
 				switch rpr.TagOp {
 				case Add:

--- a/legacy/dockerregistry/inventory.go
+++ b/legacy/dockerregistry/inventory.go
@@ -1158,9 +1158,11 @@ func (sc *SyncContext) IgnoreFromPromotion(regName RegistryName) {
 // user to provide these delineations for us.
 //
 // TODO: Can we simplify this to not use switch/case/goto?
-// TODO(nolint): Enable gocyclo
-// nolint[gocyclo]
-func ParseContainerParts(s string) (string, string, error) {
+func ParseContainerParts(s string) (
+	registry string,
+	repo string,
+	parseErr error,
+) {
 	parts := strings.Split(s, "/")
 	if len(parts) <= 1 {
 		goto InvalidString
@@ -1175,22 +1177,16 @@ func ParseContainerParts(s string) (string, string, error) {
 	}
 
 	switch parts[0] {
-	case "gcr.io":
-		fallthrough
-	case "asia.gcr.io":
-		fallthrough
-	case "eu.gcr.io":
-		fallthrough
-	case "us.gcr.io":
+	case "gcr.io", "asia.gcr.io", "eu.gcr.io", "us.gcr.io":
 		if len(parts) == 2 {
 			goto InvalidString
 		}
 		return strings.Join(parts[0:2], "/"), strings.Join(parts[2:], "/"), nil
-	case "k8s.gcr.io":
-		fallthrough
-	case "staging-k8s.gcr.io":
-		fallthrough
 	default:
+		if parts[0] != "k8s.gcr.io" && parts[0] != "staging-k8s.gcr.io" {
+			goto InvalidString
+		}
+
 		return parts[0], strings.Join(parts[1:], "/"), nil
 	}
 

--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -2779,7 +2779,9 @@ func TestExecRequests(t *testing.T) {
 		{
 			"Error tracking for promotion with errors",
 			processRequestError,
-			fmt.Errorf("Encountered an error while executing requests"),
+			// TODO: We should have a better check here. Checking the exact
+			//       message will throw errors any time we change the copy.
+			fmt.Errorf("encountered an error while executing requests"),
 		},
 	}
 

--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -1787,8 +1787,8 @@ func TestToPromotionEdges(t *testing.T) {
 	for _, test := range tests {
 		// Finalize Manifests.
 		for i := range test.input {
-			// Skip errors.
-			// nolint[errcheck]
+			// TODO(lint): Check error return value
+			//nolint:errcheck
 			_ = test.input[i].Finalize()
 		}
 

--- a/legacy/signals/signals.go
+++ b/legacy/signals/signals.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// ExitSignals are used to determine if an incoming os.Signal should cause termination.
-	ExitSignals map[os.Signal]bool = map[os.Signal]bool{
+	ExitSignals = map[os.Signal]bool{
 		syscall.SIGHUP:  true,
 		syscall.SIGINT:  true,
 		syscall.SIGABRT: true,
@@ -37,14 +37,14 @@ var (
 		syscall.SIGTSTP: true,
 	}
 	// ExitChannel is for gracefully terminating the LogSignals() function.
-	ExitChannel chan bool = make(chan bool, 1)
+	ExitChannel = make(chan bool, 1)
 	// SignalChannel is for listening to OS signals.
-	SignalChannel chan os.Signal = make(chan os.Signal, 1)
+	SignalChannel = make(chan os.Signal, 1)
 	// Debug is defined globally for mocking logrus.Debug statements.
 	Debug func(args ...interface{}) = logrus.Debug
 )
 
-// Watch concurrenlty logs debug statements when encountering interrupt signals from the OS.
+// Watch concurrently logs debug statements when encountering interrupt signals from the OS.
 // This function relies on the os/signal package which may not capture SIGKILL and SIGSTOP.
 func Watch() {
 	Debug("Watching for OS Signals...")

--- a/legacy/stream/http.go
+++ b/legacy/stream/http.go
@@ -43,8 +43,9 @@ func (h *HTTP) Produce() (stdOut, stdErr io.Reader, err error) {
 		Timeout: time.Second * requestTimeoutSeconds,
 	}
 
+	// TODO: Does Close() need to be handled in a separate method?
 	// We close the response body in Close().
-	// nolint[bodyclose]
+	//nolint:bodyclose
 	h.Res, err = client.Do(h.Req)
 
 	if err != nil {

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/release-utils/command"
 )
 
-// nolint[lll]
 func main() {
 	// NOTE: We can't run the tests in parallel because we only have 1 pair of
 	// staging/prod GCRs.
@@ -80,7 +79,6 @@ func main() {
 	runE2ETests(*testsPtr, *repoRootPtr)
 }
 
-// nolint[funlen]
 func runE2ETests(testsFile, repoRoot string) {
 	// Start tests
 	ts, err := readE2ETests(testsFile)
@@ -250,9 +248,7 @@ func runE2ETests(testsFile, repoRoot string) {
 // the regions to behave as the staging registry.
 //
 // [1]: https://cloud.google.com/pubsub/docs/admin#pubsub-delete-topic-gcloud
-//
-// nolint[funlen]
-func testSetup(repoRoot, projectID string, t E2ETest) error {
+func testSetup(repoRoot, projectID string, t *E2ETest) error {
 	// Clear GCR state.
 	if err := t.clearRepositories(); err != nil {
 		return err
@@ -284,7 +280,6 @@ func testSetup(repoRoot, projectID string, t E2ETest) error {
 	return populateGoldenImages(repoRoot)
 }
 
-// nolint[funlen]
 func populateGoldenImages(repoRoot string) error {
 	goldenPush := fmt.Sprintf("%s/test-e2e/golden-images/push-golden.sh", repoRoot)
 	cmd := command.NewWithWorkDir(
@@ -375,7 +370,6 @@ func getCmdListLogs(projectID string) []string {
 	}
 }
 
-// nolint[lll]
 func getCmdDeleteLogs(projectID string) []string {
 	return []string{
 		"gcloud",
@@ -483,7 +477,6 @@ func getCmdCreateTopic(projectID, topic string) []string {
 	}
 }
 
-// nolint[lll]
 func getCmdEnablePubSubTokenCreation(
 	projectNumber,
 	projectID string,
@@ -562,7 +555,6 @@ func getCmdCreatePubSubSubscription(
 	}
 }
 
-// nolint[lll]
 func getCmdShowLogs(projectID, uuid, pattern string) []string {
 	fullLogName := fmt.Sprintf("projects/%s/logs/%s", projectID, auditLogName)
 	uuidAndPattern := fmt.Sprintf("(%s) %s", uuid, pattern)
@@ -583,7 +575,6 @@ const (
 	maxLogMatchAttempts = 10
 )
 
-// nolint[lll]
 func getCmdsDeployCloudRun(
 	pushRepo,
 	projectID,
@@ -973,7 +964,7 @@ type E2ETest struct {
 }
 
 // E2ETests is an array of E2ETest.
-type E2ETests []E2ETest
+type E2ETests []*E2ETest
 
 func readE2ETests(filePath string) (E2ETests, error) {
 	var ts E2ETests

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -82,7 +82,6 @@ func main() {
 
 // nolint[funlen]
 func runE2ETests(testsFile, repoRoot string) {
-
 	// Start tests
 	ts, err := readE2ETests(testsFile)
 	if err != nil {
@@ -161,7 +160,7 @@ func runE2ETests(testsFile, repoRoot string) {
 		uuid := guuid.New().String()
 
 		fmt.Printf("\n===> Running e2e test '%s' (%s)...\n", t.Name, uuid)
-		err := testSetup(repoRoot, pushRepo, projectNumber, projectID, t)
+		err := testSetup(repoRoot, projectID, t)
 		if err != nil {
 			klog.Fatal("error with test setup stage:", err)
 		}
@@ -253,11 +252,7 @@ func runE2ETests(testsFile, repoRoot string) {
 // [1]: https://cloud.google.com/pubsub/docs/admin#pubsub-delete-topic-gcloud
 //
 // nolint[funlen]
-func testSetup(
-	repoRoot, pushRepo, projectNumber, projectID string,
-	t E2ETest,
-) error {
-
+func testSetup(repoRoot, projectID string, t E2ETest) error {
 	// Clear GCR state.
 	if err := t.clearRepositories(); err != nil {
 		return err

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/release-utils/command"
 )
 
-// nolint[lll]
 func main() {
 	// NOTE: We can't run the tests in parallel because we only have 1 pair of
 	// staging/prod GCRs.
@@ -85,7 +84,7 @@ func main() {
 	// Loop through each e2e test case.
 	for _, t := range ts {
 		fmt.Printf("\n===> Running e2e test '%s'...\n", t.Name)
-		err := testSetup(*repoRootPtr, t)
+		err := testSetup(*repoRootPtr, &t)
 		if err != nil {
 			klog.Fatal("error with test setup:", err)
 		}
@@ -128,8 +127,7 @@ func checkSnapshot(
 	}
 }
 
-// nolint[funlen]
-func testSetup(repoRoot string, t E2ETest) error {
+func testSetup(repoRoot string, t *E2ETest) error {
 	if err := t.clearRepositories(); err != nil {
 		return err
 	}

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -148,7 +148,6 @@ func testSetup(repoRoot string, t E2ETest) error {
 	fmt.Println(std.Error())
 
 	return err
-
 }
 
 func runPromotion(repoRoot string, t *E2ETest) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- dependencies.yaml: Update verify tooling to latest versions
  - Update k/repo-infra to v0.2.2
  - Update zeitgeist to v0.3.0
  - Update golangci-lint to v1.41.1
- .golangci.yml: Replace `golint` (archived) with `revive`
- golangci-lint: Fixup warnings (first pass)
- stream/http.go: nolint:bodyclose for Produce()
- inventory: Minor simplification of ParseContainerParts logic
- test-e2e: Fixup lint warnings
- audit: nolint:errcheck for write errors
- checks: Fixup lint warnings
- inventory: Fixup lint warnings

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold as golangci-lint is throwing a few failures locally

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
