### PR TITLE
dependencies.yaml: Update verify tooling to latest versions (part 1)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,10 +8,10 @@ dependencies:
 
   # zeitgeist
   - name: "zeitgeist"
-    version: 0.0.17
+    version: 0.3.0
     refPaths:
     - path: hack/verify-dependencies.sh
-      match: VERSION=(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+      match: VERSION=v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
   # golangci-lint
   - name: "golangci-lint"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
   # repo infra
   - name: "repo-infra"
-    version: 0.1.1
+    version: 0.2.2
     refPaths:
     - path: hack/verify-boilerplate.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v0.1.1
+VERSION=v0.2.2
 URL_BASE=https://raw.githubusercontent.com/kubernetes/repo-infra
 URL=$URL_BASE/$VERSION/hack/verify_boilerplate.py
 BIN_DIR=bin

--- a/hack/verify-dependencies.sh
+++ b/hack/verify-dependencies.sh
@@ -18,21 +18,25 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=0.0.17
-OS="$(uname -s)"
-OS="${OS,,}"
-URL_BASE=https://github.com/kubernetes-sigs/zeitgeist/releases/download
-FILENAME="zeitgeist_${VERSION}_${OS}_amd64.tar.gz"
-URL="${URL_BASE}/v${VERSION}/${FILENAME}"
+VERSION=v0.3.0
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-mkdir -p ./bin ./zeitgeist
-PATH=$PATH:bin
-
-if ! command -v zeitgeist; then
-  curl -sfL "${URL}" -o "${FILENAME}"
-  tar -xzf "${FILENAME}" -C zeitgeist
-  mv ./zeitgeist/zeitgeist ./bin
-  rm -rf ./zeitgeist "${FILENAME}"
+# Ensure that we find the binaries we build before anything else.
+gobin=${GOBIN:-$(go env GOBIN)}
+if [[ -z $gobin ]]; then
+  gobin="$(go env GOPATH)/bin"
 fi
+PATH="${gobin}:${PATH}"
 
-zeitgeist validate
+# Install zeitgeist
+cd "${REPO_ROOT}/internal"
+GO111MODULE=on go install sigs.k8s.io/zeitgeist@"${VERSION}"
+cd -
+
+# Prefer full path for running zeitgeist
+ZEITGEIST_BIN="$(which zeitgeist)"
+
+"${ZEITGEIST_BIN}" validate \
+  --local-only \
+  --base-path "${REPO_ROOT}" \
+  --config "${REPO_ROOT}"/dependencies.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

dependencies.yaml: Update verify tooling to latest versions
- Update k/repo-infra to v0.2.2
- Update zeitgeist to v0.3.0

/assign @saschagrunert @cpanato @puerco 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Continued in https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/394.
Peeling these commits out, as the initial PR led to more linting than I initially expected.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
