### PR TITLE
go_with_version.sh: Shellcheck and drop `return` statement

### DIFF
--- a/go_with_version.sh
+++ b/go_with_version.sh
@@ -28,7 +28,7 @@ printUsage() {
     >&2 echo "Usage: $0 (build | run) path/to/code.go [args...]"
 }
 
-if [[ $# < 2 ]]; then
+if [[ $# -lt 2 ]]; then
     >&2 echo "ERROR: Invalid number of arguments!"
     printUsage
     exit 1
@@ -46,12 +46,11 @@ if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${g
 git_tree_state=clean
 fi
 
-go $1 -v -ldflags "-s -w \
+go "$1" -v -ldflags "-s -w \
     -X $pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
     -X $pkg.gitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) \
     -X $pkg.gitTreeState=$git_tree_state \
     -X $pkg.gitVersion=$(git describe --tags --abbrev=0 || echo unknown)" \
-    "${@:2}" \
-    || return 1
+    "${@:2}"
 
 echo "Finished running $tool"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

(Peeled off of https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/285.)

go_with_version.sh: Shellcheck and drop `return` statement

`return` only works within the context of a function. 
Given we `set -o errexit`, a command failure will cause the script to fail anyway, so this line is extraneous.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @puerco @cpanato 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
