### PR TITLE
Dockerfile: Use an explicit go version (go1.16.7) for image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # Determine final build variant [prod | test].
 ARG variant
 
-FROM golang:latest AS base
+FROM golang:1.16.7 AS base
 # Transfer all project files to container.
 WORKDIR /go/src/app
 COPY . .

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,3 +19,23 @@ dependencies:
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+
+  # Golang
+  - name: "golang"
+    version: 1.16.7
+    refPaths:
+    - path: Dockerfile
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) AS base
+
+  # Golang pre-releases are denoted as `1.y<pre-release stage>.z`
+  # Example: go1.16rc1
+  #
+  # This entry is a stub of the major and minor version to allow dependency
+  # checks to pass when building using a pre-release of Golang.
+  - name: "golang: <major>.<minor>"
+    version: 1.16
+    refPaths:
+    - path: Dockerfile
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) AS base
+    - path: go.mod
+      match: go \d+.\d+(alpha|beta|rc)?\.?(\d+)?


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency

#### What this PR does / why we need it:

- Dockerfile: Use an explicit go version (go1.16.7) for image building
  
  Using a `latest` tag in general, but specifically for Golang-based
  images will eventually lead to unexpected variance in our image builds.
  
  Here we pull an explicit go version and add an entry for it in
  `dependencies.yaml`.
  
  This commit also adds a dependency entry for the go major version in
  `go.mod`, to ensure it stays in sync with image builds.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Dockerfile: Use an explicit go version (go1.16.7) for image building
  
  Using a `latest` tag in general, but specifically for Golang-based
  images will eventually lead to unexpected variance in our image builds.
  
  Here we pull an explicit go version and add an entry for it in
  `dependencies.yaml`.
  
  This commit also adds a dependency entry for the go major version in
  `go.mod`, to ensure it stays in sync with image builds.
```
