### PR TITLE
kpromo: Improve service account usage/retrieval

### DIFF
--- a/Makefile-kpromo
+++ b/Makefile-kpromo
@@ -17,7 +17,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = kpromo
-IMAGE_VERSION ?= v0.2.0-1
+IMAGE_VERSION ?= v0.2.1-1
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,7 +42,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.2.0-1'
+  _IMAGE_VERSION: 'v0.2.1-1'
   _GO_VERSION: '1.17'
   _OS_CODENAME: 'buster'
   _DISTROLESS_IMAGE: 'static-debian10'

--- a/cmd/kpromo/README.md
+++ b/cmd/kpromo/README.md
@@ -74,7 +74,7 @@ Flags:
       --files files             path to the files manifest
       --filestores filestores   path to the filestores promoter manifest
   -h, --help                    help for files
-      --use-service-account     allow service account usage with gcloud calls
+      --manifests string        path to manifests for multiple projects
 
 Global Flags:
       --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warning', 'info', 'debug', 'trace' (default "info")

--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -71,13 +71,6 @@ func init() {
 		"test run promotion without modifying any filestore",
 	)
 
-	filesCmd.PersistentFlags().BoolVar(
-		&filesOpts.UseServiceAccount,
-		"use-service-account",
-		filesOpts.UseServiceAccount,
-		"allow service account usage with gcloud calls",
-	)
-
 	// TODO(kpromo): Consider marking manifest flags as required
 
 	RunCmd.AddCommand(filesCmd)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -69,7 +69,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v0.2.0-1
+    version: v0.2.1-1
     refPaths:
     - path: cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -73,11 +73,18 @@ func openFilestore(
 	}
 
 	var opts []option.ClientOption
-	if useServiceAccount && filestore.ServiceAccount != "" {
+	if filestore.Src {
+		opts = append(opts, option.WithoutAuthentication())
+	} else {
+		if filestore.ServiceAccount == "" {
+			return nil, fmt.Errorf(
+				"service account must be specified for destination filestore %s",
+				filestore.Base,
+			)
+		}
+
 		ts := &gcloudTokenSource{ServiceAccount: filestore.ServiceAccount}
 		opts = append(opts, option.WithTokenSource(ts))
-	} else {
-		opts = append(opts, option.WithoutAuthentication())
 	}
 
 	client, err := storage.NewClient(ctx, opts...)

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -37,10 +37,6 @@ type FilestorePromoter struct {
 	Dest   *api.Filestore
 
 	Files []api.File
-
-	// UseServiceAccount must be true, for service accounts to be used
-	// This gives some protection against a hostile manifest.
-	UseServiceAccount bool
 }
 
 type syncFilestore interface {
@@ -57,18 +53,21 @@ type syncFilestore interface {
 func openFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,
-	useServiceAccount bool) (syncFilestore, error) {
+) (syncFilestore, error) {
 	u, err := url.Parse(filestore.Base)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error parsing filestore base %q: %v",
-			filestore.Base, err)
+			filestore.Base,
+			err,
+		)
 	}
 
 	if u.Scheme != "gs" {
 		return nil, fmt.Errorf(
 			"unrecognized scheme %q (supported schemes: %s)",
-			object.GcsPrefix, filestore.Base,
+			filestore.Base,
+			object.GcsPrefix,
 		)
 	}
 
@@ -189,11 +188,11 @@ func joinFilepath(filestore *api.Filestore, relativePath string) string {
 // Source Filestore to the Dest Filestore.
 func (p *FilestorePromoter) BuildOperations(
 	ctx context.Context) ([]SyncFileOp, error) {
-	sourceFilestore, err := openFilestore(ctx, p.Source, p.UseServiceAccount)
+	sourceFilestore, err := openFilestore(ctx, p.Source)
 	if err != nil {
 		return nil, err
 	}
-	destFilestore, err := openFilestore(ctx, p.Dest, p.UseServiceAccount)
+	destFilestore, err := openFilestore(ctx, p.Dest)
 	if err != nil {
 		return nil, err
 	}

--- a/filepromoter/manifest.go
+++ b/filepromoter/manifest.go
@@ -28,10 +28,6 @@ import (
 // ManifestPromoter promotes files as described in Manifest.
 type ManifestPromoter struct {
 	Manifest *api.Manifest
-
-	// UseServiceAccount must be true, for service accounts to be used
-	// This gives some protection against a hostile manifest.
-	UseServiceAccount bool
 }
 
 // BuildOperations builds the required operations to sync from the
@@ -52,10 +48,9 @@ func (p *ManifestPromoter) BuildOperations(
 		}
 		logrus.Infof("processing destination %q", filestore.Base)
 		fp := &FilestorePromoter{
-			Source:            source,
-			Dest:              filestore,
-			Files:             p.Manifest.Files,
-			UseServiceAccount: p.UseServiceAccount,
+			Source: source,
+			Dest:   filestore,
+			Files:  p.Manifest.Files,
 		}
 		ops, err := fp.BuildOperations(ctx)
 		if err != nil {

--- a/promobot/promotefiles.go
+++ b/promobot/promotefiles.go
@@ -63,10 +63,6 @@ type PromoteFilesOptions struct {
 	// DryRun (if set) will not perform operations, but print them instead
 	DryRun bool
 
-	// UseServiceAccount must be true, for service accounts to be used
-	// This gives some protection against a hostile manifest.
-	UseServiceAccount bool
-
 	// Out is the destination for "normal" output (such as dry-run)
 	Out io.Writer
 }
@@ -74,7 +70,6 @@ type PromoteFilesOptions struct {
 // PopulateDefaults sets the default values for PromoteFilesOptions
 func (o *PromoteFilesOptions) PopulateDefaults() {
 	o.DryRun = true
-	o.UseServiceAccount = false
 	o.Out = os.Stdout
 }
 
@@ -98,8 +93,7 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	var ops []filepromoter.SyncFileOp
 	for _, manifest := range manifests {
 		promoter := &filepromoter.ManifestPromoter{
-			Manifest:          manifest,
-			UseServiceAccount: options.UseServiceAccount,
+			Manifest: manifest,
 		}
 
 		o, err := promoter.BuildOperations(ctx)
@@ -205,11 +199,10 @@ func ReadManifests(options PromoteFilesOptions) ([]*api.Manifest, error) {
 		)
 
 		prjOpts := &PromoteFilesOptions{
-			FilestoresPath:    filestores,
-			FilesPath:         files,
-			DryRun:            options.DryRun,
-			UseServiceAccount: options.UseServiceAccount,
-			Out:               options.Out,
+			FilestoresPath: filestores,
+			FilesPath:      files,
+			DryRun:         options.DryRun,
+			Out:            options.Out,
 		}
 
 		m, err := ReadManifest(*prjOpts)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

(Part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413, https://github.com/kubernetes/k8s.io/issues/2624.)

- filepromoter: Enforce service account for ops on GCS destinations
- kpromo: Drop unused `UseServiceAccount` code paths
  Service account usage is now enforced for operations on destination
  GCS buckets, so the `UseServiceAccount` code paths are no longer
  used (or required).
- kpromo: Build v0.2.1-1 image

ref: https://github.com/kubernetes/test-infra/pull/23496, https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/409#discussion_r702940261, https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/414

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- filepromoter: Enforce service account for ops on GCS destinations
- kpromo: Drop unused `UseServiceAccount` code paths
  Service account usage is now enforced for operations on destination
  GCS buckets, so the `UseServiceAccount` code paths are no longer
  used (or required).
- kpromo: Build v0.2.1-1 image
```
