### PR TITLE
gcloud/token: Ensure access token is not printed in logs

### DIFF
--- a/legacy/gcloud/token.go
+++ b/legacy/gcloud/token.go
@@ -42,7 +42,10 @@ func GetServiceAccountToken(
 	args = MaybeUseServiceAccount(serviceAccount, useServiceAccount, args)
 
 	cmd := command.New("gcloud", args...)
-	std, err := cmd.RunSuccessOutput()
+
+	// We use RunSilentSuccessOutput() to ensure the access token is captured,
+	// but not displayed in logs.
+	std, err := cmd.RunSilentSuccessOutput()
 	// Do not log the token (stdout) on error, because it could
 	// be that the token was valid, but that Run() failed for
 	// other reasons. NEVER print the token as part of an error message!


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area security
/priority critical-urgent

#### What this PR does / why we need it:

gcloud/token: Ensure access token is not printed in logs

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @justinsb @puerco @saschagrunert @cpanato 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Noticed while looking into file promotion on https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gcloud/token: Ensure access token is not printed in logs
```
