### PR TITLE
kpromo: Use gcr.io/google.com/cloudsdktool/cloud-sdk:slim

### DIFF
--- a/Dockerfile-kpromo
+++ b/Dockerfile-kpromo
@@ -15,8 +15,6 @@
 # Build the manager binary
 ARG GO_VERSION
 ARG OS_CODENAME
-# TODO(codename): Consider parameterizing in Makefile based on codename
-ARG DISTROLESS_IMAGE
 FROM golang:${GO_VERSION}-${OS_CODENAME} as builder
 
 WORKDIR /go/src/sigs.k8s.io/k8s-container-image-promoter
@@ -40,7 +38,7 @@ RUN go build -trimpath -ldflags '-s -w -buildid= -extldflags "-static"' \
     -o kpromo ${package}
 
 # Production image
-FROM gcr.io/distroless/${DISTROLESS_IMAGE}:latest
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
 LABEL maintainers="Kubernetes Authors"
 LABEL description="kpromo: The Kubernetes project artifact promoter"

--- a/Makefile-kpromo
+++ b/Makefile-kpromo
@@ -26,7 +26,6 @@ TAG ?= $(shell git describe --tags --always --dirty)
 # Build args
 GO_VERSION ?= 1.17
 OS_CODENAME ?= buster
-DISTROLESS_IMAGE ?= static-debian10
 
 # Configuration
 CONFIG = $(OS_CODENAME)
@@ -38,8 +37,7 @@ HOST_GOARCH ?= $(shell go env GOARCH)
 GO_BUILD ?= go build
 
 BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
-             --build-arg=OS_CODENAME=$(OS_CODENAME) \
-             --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE)
+             --build-arg=OS_CODENAME=$(OS_CODENAME)
 
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled

--- a/Makefile-kpromo
+++ b/Makefile-kpromo
@@ -17,7 +17,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = kpromo
-IMAGE_VERSION ?= v0.2.1-1
+IMAGE_VERSION ?= v0.2.1-2
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,7 +29,6 @@ steps:
   - IMAGE_VERSION=$_IMAGE_VERSION
   - GO_VERSION=$_GO_VERSION
   - OS_CODENAME=$_OS_CODENAME
-  - DISTROLESS_IMAGE=$_DISTROLESS_IMAGE
   args:
   - '-c'
   - |
@@ -45,7 +44,6 @@ substitutions:
   _IMAGE_VERSION: 'v0.2.1-1'
   _GO_VERSION: '1.17'
   _OS_CODENAME: 'buster'
-  _DISTROLESS_IMAGE: 'static-debian10'
 
 tags:
 - 'cip'
@@ -55,7 +53,6 @@ tags:
 - ${_IMAGE_VERSION}
 - ${_GO_VERSION}
 - ${_OS_CODENAME}
-- ${_DISTROLESS_IMAGE}
 
 images:
 # TODO: Temporarily disabling this check, which is currently failing in

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.2.1-1'
+  _IMAGE_VERSION: 'v0.2.1-2'
   _GO_VERSION: '1.17'
   _OS_CODENAME: 'buster'
 

--- a/cmd/kpromo/variants.yaml
+++ b/cmd/kpromo/variants.yaml
@@ -1,6 +1,0 @@
-variants:
-  default:
-    IMAGE_VERSION: 'v0.1.0-1'
-    GO_VERSION: '1.17'
-    OS_CODENAME: 'buster'
-    DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v0.2.1-1
+    version: v0.2.1-2
     refPaths:
     - path: cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,15 +24,6 @@ dependencies:
     - path: Makefile-kpromo
       match: OS_CODENAME\ \?=\ (bullseye|buster)
 
-  - name: "distroless"
-    version: static-debian10
-    refPaths:
-    # Must match distroless Debian version as well
-    - path: cloudbuild.yaml
-      match: "_DISTROLESS_IMAGE: 'static-debian[0-9]{2}'"
-    - path: Makefile-kpromo
-      match: DISTROLESS_IMAGE\ \?=\ static-debian[0-9]{2}
-
   # golangci-lint
   - name: "golangci-lint"
     version: 1.41.1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- kpromo: Use gcr.io/google.com/cloudsdktool/cloud-sdk:slim
  To support `gcloud` calls to retrieve access tokens
- kpromo: Build v0.2.1-2 image 

Needed to fix [CI failures](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-file-promo/1435127641098162176) for https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413, https://github.com/kubernetes/k8s.io/issues/2624:

```console
 ********** START **********
level=info msg="processing destination \"gs://k8s-artifacts-prod/binaries/kops/\""
level=info msg="listing files in bucket k8s-staging-kops with prefix \"kops/releases/\""
level=info msg="listing files in bucket k8s-artifacts-prod with prefix \"binaries/kops/\""
level=info msg="getting service-account-token for \"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\""
level=error msg="could not execute cmd gcloud auth --account=k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com print-access-token"
level=warning msg="failed to get service-account-token for \"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\": exec: \"gcloud\": executable file not found in $PATH"
level=fatal msg="run `kpromo run files`: error building operations: error building promotion operations for \"gs://k8s-artifacts-prod/binaries/kops/\": error listing objects in \"gs://k8s-artifacts-prod/binaries/kops/\": Get \"https://storage.googleapis.com/storage/v1/b/k8s-artifacts-prod/o?alt=json&delimiter=&endOffset=&pageToken=&prefix=binaries%2Fkops%2F&prettyPrint=false&projection=full&startOffset=&versions=false\": exec: \"gcloud\": executable file not found in $PATH" 
```

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- kpromo: Use gcr.io/google.com/cloudsdktool/cloud-sdk:slim
  To support `gcloud` calls to retrieve access tokens
- kpromo: Build v0.2.1-2 image 
```
