### PR TITLE
Lintlintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,12 @@ issues:
         - gocritic
         - golint
         - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - nolintlint
     - prealloc
     - predeclared
     - promlinter
@@ -82,7 +83,6 @@ linters:
     # - nilerr
     # - nlreturn
     # - noctx
-    # - nolintlint
     # - paralleltest
     # - scopelint
     # - tagliatelle
@@ -171,3 +171,16 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 1.41.1
+    version: 1.42.1
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.41.1
+VERSION=v1.42.1
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/legacy/audit/auditor.go
+++ b/legacy/audit/auditor.go
@@ -75,9 +75,7 @@ func (s *ServerContext) RunAuditor() {
 	logrus.Info("Starting Auditor")
 	logrus.Infoln(s)
 
-	// nolint[errcheck]
 	defer s.LoggingFacility.Close()
-	// nolint[errcheck]
 	defer s.ErrorReportingFacility.Close()
 
 	http.HandleFunc(
@@ -165,7 +163,6 @@ func ValidatePayload(gcrPayload *reg.GCRPubSubPayload) error {
 // parse the request body to understand the GCR state change, (2) update the Git
 // repo of the promoter manifests, and (3) reconcile these two against each
 // other.
-// nolint[funlen]
 func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 	logInfo := s.LoggingFacility.GetInfoLogger()
 	logError := s.LoggingFacility.GetErrorLogger()
@@ -173,8 +170,7 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 
 	defer func() {
 		if msg := recover(); msg != nil {
-			// TODO: Check result of type assertion
-			//nolint:errcheck
+			//nolint:errcheck // TODO: Check result of type assertion
 			panicStr := msg.(string)
 
 			stacktrace := debug.Stack()

--- a/legacy/audit/auditor_test.go
+++ b/legacy/audit/auditor_test.go
@@ -175,7 +175,6 @@ func TestValidatePayload(t *testing.T) {
 	}
 }
 
-// nolint[gocyclo]
 func TestAudit(t *testing.T) {
 	// Regression test case for
 	// https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/191.

--- a/legacy/audit/types.go
+++ b/legacy/audit/types.go
@@ -26,8 +26,6 @@ import (
 
 // GcrReadingFacility holds functions used to create streams for reading the
 // repository and manifest list.
-//
-// nolint[lll]
 type GcrReadingFacility struct {
 	ReadRepo         func(*reg.SyncContext, reg.RegistryContext) stream.Producer
 	ReadManifestList func(*reg.SyncContext, *reg.GCRManifestListContext) stream.Producer

--- a/legacy/cli/run.go
+++ b/legacy/cli/run.go
@@ -201,7 +201,6 @@ func RunPromoteCmd(opts *RunOptions) error {
 		// Print version to make Prow logs more self-explanatory.
 		printVersion()
 
-		
 		if opts.SeverityThreshold >= 0 {
 			logrus.Info("********** START (VULN CHECK) **********")
 			logrus.Info(
@@ -361,7 +360,6 @@ necessarily mean that a new version of the image layer is available.`,
 		}
 	}
 
-	
 	if opts.SeverityThreshold >= 0 {
 		logrus.Info("********** FINISHED (VULN CHECK) **********")
 	} else if opts.DryRun {
@@ -372,7 +370,6 @@ necessarily mean that a new version of the image layer is available.`,
 
 	return nil
 }
-
 
 func validateImageOptions(o *RunOptions) error {
 	// TODO: Validate options

--- a/legacy/cli/run.go
+++ b/legacy/cli/run.go
@@ -201,7 +201,7 @@ func RunPromoteCmd(opts *RunOptions) error {
 		// Print version to make Prow logs more self-explanatory.
 		printVersion()
 
-		// nolint: gocritic
+		
 		if opts.SeverityThreshold >= 0 {
 			logrus.Info("********** START (VULN CHECK) **********")
 			logrus.Info(
@@ -361,7 +361,7 @@ necessarily mean that a new version of the image layer is available.`,
 		}
 	}
 
-	// nolint: gocritic
+	
 	if opts.SeverityThreshold >= 0 {
 		logrus.Info("********** FINISHED (VULN CHECK) **********")
 	} else if opts.DryRun {
@@ -373,7 +373,7 @@ necessarily mean that a new version of the image layer is available.`,
 	return nil
 }
 
-// nolint: unused
+
 func validateImageOptions(o *RunOptions) error {
 	// TODO: Validate options
 	return nil

--- a/legacy/dockerregistry/checks.go
+++ b/legacy/dockerregistry/checks.go
@@ -275,7 +275,6 @@ func MKImageVulnCheck(
 
 // Run is a function of ImageVulnCheck and checks that none of the
 // images to be promoted have any severe vulnerabilities.
-// nolint[errcheck]
 func (check *ImageVulnCheck) Run() error {
 	var populateRequests PopulateRequests = func(
 		sc *SyncContext,
@@ -426,7 +425,6 @@ func parseImageProjectID(edge *PromotionEdge) (string, error) {
 // mkRealVulnProducer returns an ImageVulnProducer that gets all vulnerability
 // Occurrences associated with the image represented in the PromotionEdge
 // using the Container Analysis Service client library.
-// nolint[errcheck]
 func mkRealVulnProducer(client *containeranalysis.Client) ImageVulnProducer {
 	return func(
 		edge PromotionEdge,

--- a/legacy/dockerregistry/grow_manifest.go
+++ b/legacy/dockerregistry/grow_manifest.go
@@ -225,9 +225,9 @@ func ApplyFilters(o *GrowManifestOptions, rii RegInvImage) (RegInvImage, error) 
 	rii = ExcludeTags(rii, excludeTags)
 
 	if len(rii) == 0 {
-		// nolint[lll]
 		return RegInvImage{}, xerrors.New(
-			"no images survived filtering; double-check your --filter_* flag(s) for typos")
+			"no images survived filtering; double-check your --filter_* flag(s) for typos",
+		)
 	}
 
 	return rii, nil

--- a/legacy/dockerregistry/grow_manifest.go
+++ b/legacy/dockerregistry/grow_manifest.go
@@ -139,7 +139,7 @@ func WriteImages(manifest Manifest, rii RegInvImage) error {
 
 	// Write the file.
 	err := ioutil.WriteFile(
-		imagesPath, []byte(rii.ToYAML(YamlMarshalingOpts{})), 0644)
+		imagesPath, []byte(rii.ToYAML(YamlMarshalingOpts{})), 0o644)
 	return err
 }
 

--- a/legacy/dockerregistry/inventory.go
+++ b/legacy/dockerregistry/inventory.go
@@ -228,8 +228,6 @@ func (m *Manifest) Finalize() error {
 // ParseThinManifestsFromDir parses all thin Manifest files within a directory.
 // We effectively have to create a map of manifests, keyed by the source
 // registry (there can only be 1 source registry).
-//
-// nolint[funlen]
 func ParseThinManifestsFromDir(
 	dir string,
 ) ([]Manifest, error) {
@@ -303,8 +301,6 @@ func ParseThinManifestsFromDir(
 // structure for thin manifests. Most importantly, it requires that if a file
 // named "foo/manifests/bar/promoter-manifest.yaml" exists, that a corresponding
 // file named "foo/images/bar/promoter-manifest.yaml" must also exist.
-//
-// nolint[gocyclo]
 func ValidateThinManifestDirectoryStructure(
 	dir string,
 ) error {
@@ -461,8 +457,6 @@ func mkPromotionEdge(
 // This filters out those edges from ToPromotionEdges (found in []Manifest), to
 // only those PromotionEdges that makes sense to keep around. For example, we
 // want to remove all edges that have already been promoted.
-//
-// nolint[gocyclo]
 func (sc *SyncContext) GetPromotionCandidates(edges map[PromotionEdge]interface{}) (
 	map[PromotionEdge]interface{},
 	bool,
@@ -476,11 +470,16 @@ func (sc *SyncContext) GetPromotionCandidates(edges map[PromotionEdge]interface{
 	}
 
 	toPromote := make(map[PromotionEdge]interface{})
-	// nolint[lll]
 	for edge := range edges {
-		// If the edge should be ignored because of a bad read in sc.Inv, drop it
+		// If the edge should be ignored because of a bad read in sc.Inv,
+		// drop it.
 		if img, ok := ignoreMap[edge.SrcImageTag.ImageName]; ok {
-			logrus.Warnf("edge %v: ignoring because src image could not be read: %s\n", edge, img)
+			logrus.Warnf(
+				"edge %v: ignoring because src image could not be read: %s\n",
+				edge,
+				img,
+			)
+
 			continue
 		}
 
@@ -572,8 +571,6 @@ func (sc *SyncContext) getDigestForTag(inputTag Tag) *Digest {
 // different, because most likely this is at best just human error and at worst
 // a malicious attack (someone trying to push an image to an endpoint they
 // shouldn't own).
-//
-// nolint[gocyclo]
 func CheckOverlappingEdges(
 	edges map[PromotionEdge]interface{}) (map[PromotionEdge]interface{}, error) {
 	// Build up a "promotionIntent". This will be checked below.
@@ -820,7 +817,6 @@ func (m Manifest) srcRegistryName() RegistryName {
 	return RegistryName("")
 }
 
-// nolint[gocyclo]
 func validateRequiredComponents(m Manifest) error {
 	// TODO: Should we return []error here instead?
 	errs := make([]string, 0)
@@ -879,8 +875,6 @@ func validateRequiredComponents(m Manifest) error {
 }
 
 // PrettyValue creates a prettified string representation of MasterInventory.
-//
-// nolint[gocyclo]
 func (mi *MasterInventory) PrettyValue() string {
 	var b strings.Builder
 	regNames := []RegistryName{}
@@ -1020,7 +1014,6 @@ func getRegistryTagsFrom(req stream.ExternalRequest,
 		return nil, err
 	}
 
-	// nolint[errcheck]
 	defer req.StreamProducer.Close()
 
 	tags, err := extractRegistryTags(reader)
@@ -1071,7 +1064,6 @@ func getGCRManifestListFrom(req stream.ExternalRequest) (*ggcrV1.IndexManifest, 
 		return nil, err
 	}
 
-	// nolint[errcheck]
 	defer req.StreamProducer.Close()
 
 	gcrManifestList, err := extractGCRManifestList(reader)
@@ -1267,8 +1259,6 @@ func GetTokenKeyDomainRepoPath(registryName RegistryName) (key, domain, repoPath
 // NOTE: Repository names may overlap with image names. e.g., it may be in the
 // example above that there are images named gcr.io/google-containers/foo:2.0
 // and gcr.io/google-containers/foo/baz:2.0.
-//
-// nolint[gocyclo]
 func (sc *SyncContext) ReadRegistries(
 	toRead []RegistryContext,
 	recurse bool,
@@ -1426,8 +1416,6 @@ func (sc *SyncContext) ReadRegistries(
 // it is referenced by a parent DockerManifestList.
 //
 // TODO: Combine this function with ReadRegistries().
-//
-// nolint[gocyclo]
 func (sc *SyncContext) ReadGCRManifestLists(
 	mkProducer func(*SyncContext, *GCRManifestListContext) stream.Producer,
 ) {
@@ -1585,8 +1573,6 @@ func SplitByKnownRegistries(
 	for _, rc := range rcs {
 		if strings.HasPrefix(string(r), string(rc.Name)) {
 			trimmed := strings.TrimPrefix(string(r), string(rc.Name))
-
-			// nolint[gocritic]
 			if trimmed == "" {
 				// The unparsed full image path `r` and rc.Name is the same ---
 				// this happens for images pushed to the root directory. Just
@@ -1706,8 +1692,6 @@ func MkReadManifestListCmdReal(sc *SyncContext, gmlc *GCRManifestListContext) st
 
 // ExecRequests uses the Worker Pool pattern, where MaxConcurrentRequests
 // determines the number of workers to spawn.
-//
-// nolint[funlen]
 func (sc *SyncContext) ExecRequests(
 	populateRequests PopulateRequests,
 	processRequest ProcessRequest,
@@ -1877,8 +1861,6 @@ func (rii *RegInvImage) ToSorted() []ImageWithDigestSlice {
 
 // ToYAML displays a RegInvImage as YAML, but with the map items sorted
 // alphabetically.
-//
-// nolint[gocognit]
 func (rii *RegInvImage) ToYAML(o YamlMarshalingOpts) string {
 	images := rii.ToSorted()
 
@@ -1924,9 +1906,7 @@ func (rii *RegInvImage) ToYAML(o YamlMarshalingOpts) string {
 // format, it prints one image on each line as a CSV. If there is a tag pointing
 // to the image, then it is printed next to the image on the same line.
 //
-// E.g.
-//
-// nolint[lll]
+// Example:
 // a@sha256:0000000000000000000000000000000000000000000000000000000000000000,a:1.0
 // a@sha256:0000000000000000000000000000000000000000000000000000000000000000,a:latest
 // b@sha256:1111111111111111111111111111111111111111111111111111111111111111,-
@@ -2203,8 +2183,6 @@ func getRegistriesToRead(edges map[PromotionEdge]interface{}) []RegistryContext 
 
 // Promote performs container image promotion by realizing the intent in the
 // Manifest.
-//
-// nolint[gocyclo]
 func (sc *SyncContext) Promote(
 	edges map[PromotionEdge]interface{},
 	mkProducer func(
@@ -2416,7 +2394,6 @@ func MkRequestCapturer(captured *CapturedRequests) ProcessRequest {
 }
 
 // GarbageCollect deletes all images that are not referenced by Docker tags.
-// nolint[gocyclo]
 func (sc *SyncContext) GarbageCollect(
 	mfest Manifest,
 	mkProducer func(RegistryContext, ImageName, Digest) stream.Producer,
@@ -2531,7 +2508,6 @@ func supportedMediaType(v string) (ggcrV1Types.MediaType, error) {
 }
 
 // ClearRepository wipes out all Docker images from a registry! Use with caution.
-// nolint[gocyclo]
 //
 // TODO: Maybe split this into 2 parts, so that each part can be unit-tested
 // separately (deletion of manifest lists vs deletion of other media types).
@@ -2853,7 +2829,6 @@ func (payload *GCRPubSubPayload) PopulateExtraFields() error {
 	// Populate digest, if found.
 	if len(payload.FQIN) > 0 {
 		parsed := strings.Split(payload.FQIN, "@")
-		// nolint[gomnd]
 		if len(parsed) != 2 {
 			return fmt.Errorf("invalid FQIN: %v", payload.FQIN)
 		}
@@ -2864,7 +2839,6 @@ func (payload *GCRPubSubPayload) PopulateExtraFields() error {
 	// Populate tag, if found.
 	if len(payload.PQIN) > 0 {
 		parsed := strings.Split(payload.PQIN, ":")
-		// nolint[gomnd]
 		if len(parsed) != 2 {
 			return fmt.Errorf("invalid PQIN: %v", payload.PQIN)
 		}

--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -501,7 +501,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 			mfest.Filepath = filepath.Join(fixtureDir, mfest.Filepath)
 
 			// SA4010: this result of append is never used, except maybe in other appends
-			// nolint: staticcheck
+			
 			expectedModified = append(expectedModified, mfest)
 		}
 

--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -499,9 +499,6 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 		expectedModified := test.expectedOutput[:0]
 		for _, mfest := range test.expectedOutput {
 			mfest.Filepath = filepath.Join(fixtureDir, mfest.Filepath)
-
-			// SA4010: this result of append is never used, except maybe in other appends
-			
 			expectedModified = append(expectedModified, mfest)
 		}
 

--- a/legacy/dockerregistry/types.go
+++ b/legacy/dockerregistry/types.go
@@ -433,22 +433,30 @@ type digest struct {
 }
 
 // GCRPubSubPayload is the message payload sent to a Pub/Sub topic by a GCR.
-// nolint[lll]
 type GCRPubSubPayload struct {
 	Action string `json:"action"`
+
 	// The payload field is "digest", but really it is a FQIN like
-	//  "gcr.io/linusa/small@sha256:35f442d8d56cc7a2d4000f3417d71f44a730b900f3df440c09a9c40c42c40f86".
+	// "gcr.io/linusa/small@sha256:35f442d8d56cc7a2d4000f3417d71f44a730b900f3df440c09a9c40c42c40f86".
 	FQIN string `json:"digest,omitempty"`
-	// Similarly, the field "tag is always a PQIN. E.g.,
+
+	// Similarly, the field "tag is always a PQIN.
+	//
+	// Example:
 	// "gcr.io/linusa/small:a".
 	PQIN string `json:"tag,omitempty"`
 
-	// Everything leading up to either the tag or digest. E.g., given
-	// "us.gcr.io/k8s-artifacts-prod/foo/bar:1.0", this would be
+	// Everything leading up to either the tag or digest.
+	//
+	// Example:
+	// Given "us.gcr.io/k8s-artifacts-prod/foo/bar:1.0", this would be
 	// "us.gcr.io/k8s-artifacts-prod/foo/bar".
+
 	Path string
+
 	// Image digest, if any.
 	Digest Digest
+
 	// Tag, if any.
 	Tag Tag
 }

--- a/legacy/report/gcp.go
+++ b/legacy/report/gcp.go
@@ -32,8 +32,10 @@ func NewGcpErrorReportingClient(
 	erc, err := errorreporting.NewClient(ctx, projectID, errorreporting.Config{
 		ServiceName: serviceName,
 		OnError: func(err error) {
-			// nolint[lll]
-			logrus.Errorf("Could not log error to GCP Stackdriver Error Reporting: %v", err)
+			logrus.Errorf(
+				"could not log error to GCP Stackdriver Error Reporting: %v",
+				err,
+			)
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- golangci-lint: Update to 1.42.1
- golangci-lint: Enable all issues to display at once
- generated: Run `golangci-lint run --fix`
- golangci-lint: Enable `nolintlint` linter
- generated: Run `golangci-lint run --fix`
- lint(nolintlint): Drop or fix `nolint` directives

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Similar cleanup to https://github.com/kubernetes/release/pull/2228.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
