### PR TITLE
filepromoter: Warn on (but don't block) unauthenticated operations

### DIFF
--- a/Makefile-kpromo
+++ b/Makefile-kpromo
@@ -17,7 +17,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = kpromo
-IMAGE_VERSION ?= v0.2.1-2
+IMAGE_VERSION ?= v0.2.2-1
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.2.1-2'
+  _IMAGE_VERSION: 'v0.2.2-1'
   _GO_VERSION: '1.17'
   _OS_CODENAME: 'buster'
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v0.2.1-2
+    version: v0.2.2-1
     refPaths:
     - path: cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -72,16 +72,13 @@ func openFilestore(
 	}
 
 	var opts []option.ClientOption
-	if filestore.Src {
+	if filestore.ServiceAccount == "" {
+		logrus.Warnf("a service account was not specified for this filestore (%s), so all operations will run without authentication",
+			filestore.Base,
+		)
+
 		opts = append(opts, option.WithoutAuthentication())
 	} else {
-		if filestore.ServiceAccount == "" {
-			return nil, fmt.Errorf(
-				"service account must be specified for destination filestore %s",
-				filestore.Base,
-			)
-		}
-
 		ts := &gcloudTokenSource{ServiceAccount: filestore.ServiceAccount}
 		opts = append(opts, option.WithTokenSource(ts))
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

(Part of https://github.com/kubernetes/k8s.io/issues/2624, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.)

- filepromoter: Warn on (but don't block) unauthenticated operations
  This is a partial revert of a previous commit (https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/412) which enforced
  authentication for operations on destination filestores. Without
  this, presubmits will fail because they're running in an untrusted
  environment (without access to the prod file promotion svc acct).
- kpromo: Build v0.2.2-1 image

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Example presubmit [failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/k8s.io/2704/pull-k8sio-file-promo/1436440286698934272) from https://github.com/kubernetes/k8s.io/pull/2704 (also visible in https://github.com/kubernetes/k8s.io/pull/2663):

```console
level=warning msg="failed to get service-account-token for \"k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\": command /usr/bin/gcloud auth --account=k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com print-access-token did not succeed: ERROR: (gcloud.auth.print-access-token) Your current active account [k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com] does not have any valid credentials\nPlease run:\n\n  $ gcloud auth login\n\nto obtain new credentials.\n\nFor service account, please activate it first:\n\n  $ gcloud auth activate-service-account ACCOUNT\n"
level=fatal msg="run `kpromo run files`: error building operations: error building promotion operations for \"gs://k8s-artifacts-prod/binaries/kops/\": error listing objects in \"gs://k8s-artifacts-prod/binaries/kops/\": Get \"https://storage.googleapis.com/storage/v1/b/k8s-artifacts-prod/o?alt=json&delimiter=&endOffset=&pageToken=&prefix=binaries%2Fkops%2F&prettyPrint=false&projection=full&startOffset=&versions=false\": command /usr/bin/gcloud auth --account=k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com print-access-token did not succeed: ERROR: (gcloud.auth.print-access-token) Your current active account [k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com] does not have any valid credentials\nPlease run:\n\n  $ gcloud auth login\n\nto obtain new credentials.\n\nFor service account, please activate it first:\n\n  $ gcloud auth activate-service-account ACCOUNT\n" 
```

With this PR, we should see logs similar to this in presubmit:

<details>

```console
❯ time ~/go/bin/kpromo run files --manifests=artifacts
********** START (DRY RUN) **********
INFO processing destination "gs://k8s-artifacts-prod/binaries/kops/"
WARN a service account was not specified for this filestore (gs://k8s-staging-kops/kops/releases/), so all operations will run without authentication
WARN a service account was not specified for this filestore (gs://k8s-artifacts-prod/binaries/kops/), so all operations will run without authentication
INFO listing files in bucket k8s-staging-kops with prefix "kops/releases/"
INFO listing files in bucket k8s-artifacts-prod with prefix "binaries/kops/"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/darwin/amd64/kops"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/darwin/amd64/kops.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/dns-controller-amd64.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/dns-controller-amd64.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/dns-controller-arm64.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/dns-controller-arm64.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/images.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/images.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kops-controller-amd64.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kops-controller-amd64.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kops-controller-arm64.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kops-controller-arm64.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kube-apiserver-healthcheck-amd64.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kube-apiserver-healthcheck-arm64.tar.gz"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/channels"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/channels.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/kops"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/kops.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/nodeup"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/nodeup.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/protokube"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/amd64/protokube.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/channels"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/channels.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/kops"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/kops.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/nodeup"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/nodeup.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/protokube"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/linux/arm64/protokube.sha256"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/windows/amd64/kops.exe"
INFO metadata match for "gs://k8s-artifacts-prod/binaries/kops/1.21.1/windows/amd64/kops.exe.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/darwin/amd64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/darwin/amd64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/darwin/amd64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/darwin/amd64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/darwin/arm64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/darwin/arm64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/darwin/arm64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/darwin/arm64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/dns-controller-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/dns-controller-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/dns-controller-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/dns-controller-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/dns-controller-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/dns-controller-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/dns-controller-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/dns-controller-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/images.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/images.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/images.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/images.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kops-controller-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kops-controller-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kops-controller-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kops-controller-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kops-controller-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kops-controller-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kops-controller-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kops-controller-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kube-apiserver-healthcheck-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kube-apiserver-healthcheck-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kube-apiserver-healthcheck-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kube-apiserver-healthcheck-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/channels" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/channels"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/channels.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/channels.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/nodeup" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/nodeup"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/nodeup.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/nodeup.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/protokube" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/protokube"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/amd64/protokube.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/amd64/protokube.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/channels" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/channels"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/channels.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/channels.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/nodeup" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/nodeup"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/nodeup.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/nodeup.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/protokube" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/protokube"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/linux/arm64/protokube.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/linux/arm64/protokube.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/windows/amd64/kops.exe" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/windows/amd64/kops.exe"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-alpha.2/windows/amd64/kops.exe.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-alpha.2/windows/amd64/kops.exe.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/darwin/amd64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/darwin/amd64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/darwin/amd64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/darwin/amd64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/darwin/arm64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/darwin/arm64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/darwin/arm64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/darwin/arm64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/dns-controller-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/dns-controller-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/dns-controller-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/dns-controller-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/dns-controller-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/dns-controller-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/dns-controller-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/dns-controller-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/images.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/images.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/images.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/images.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kops-controller-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kops-controller-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kops-controller-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kops-controller-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kops-controller-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kops-controller-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kops-controller-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kops-controller-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kube-apiserver-healthcheck-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kube-apiserver-healthcheck-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kube-apiserver-healthcheck-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kube-apiserver-healthcheck-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/channels" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/channels"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/channels.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/channels.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/nodeup" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/nodeup"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/nodeup.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/nodeup.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/protokube" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/protokube"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/amd64/protokube.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/amd64/protokube.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/channels" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/channels"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/channels.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/channels.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/nodeup" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/nodeup"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/nodeup.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/nodeup.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/protokube" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/protokube"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/linux/arm64/protokube.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/linux/arm64/protokube.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/windows/amd64/kops.exe" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/windows/amd64/kops.exe"
COPY "gs://k8s-staging-kops/kops/releases/1.22.0-beta.1/windows/amd64/kops.exe.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.22.0-beta.1/windows/amd64/kops.exe.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/darwin/amd64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/darwin/amd64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/darwin/amd64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/darwin/amd64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/darwin/arm64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/darwin/arm64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/darwin/arm64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/darwin/arm64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/dns-controller-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/dns-controller-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/dns-controller-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/dns-controller-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/dns-controller-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/dns-controller-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/dns-controller-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/dns-controller-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/images.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/images.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/images.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/images.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kops-controller-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kops-controller-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kops-controller-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kops-controller-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kops-controller-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kops-controller-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kops-controller-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kops-controller-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kube-apiserver-healthcheck-amd64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kube-apiserver-healthcheck-amd64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kube-apiserver-healthcheck-amd64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kube-apiserver-healthcheck-arm64.tar.gz" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kube-apiserver-healthcheck-arm64.tar.gz"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/images/kube-apiserver-healthcheck-arm64.tar.gz.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/channels" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/channels"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/channels.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/channels.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/nodeup" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/nodeup"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/nodeup.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/nodeup.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/protokube" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/protokube"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/amd64/protokube.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/amd64/protokube.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/channels" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/channels"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/channels.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/channels.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/kops" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/kops"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/kops.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/kops.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/nodeup" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/nodeup"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/nodeup.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/nodeup.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/protokube" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/protokube"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/linux/arm64/protokube.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/linux/arm64/protokube.sha256"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/windows/amd64/kops.exe" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/windows/amd64/kops.exe"
COPY "gs://k8s-staging-kops/kops/releases/1.23.0-alpha.1/windows/amd64/kops.exe.sha256" to "gs://k8s-artifacts-prod/binaries/kops/1.23.0-alpha.1/windows/amd64/kops.exe.sha256"
********** FINISHED (DRY RUN) **********
```

</details>

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- filepromoter: Warn on (but don't block) unauthenticated operations
  This is a partial revert of a previous commit which enforced
  authentication for operations on destination filestores. Without
  this, presubmits will fail because they're running in an untrusted
  environment (without access to the prod file promotion svc acct).
- kpromo: Build v0.2.2-1 image
```
