### PR TITLE
filepromoter: Allow authenticated clients in non-production runs

### DIFF
--- a/Makefile-kpromo
+++ b/Makefile-kpromo
@@ -17,7 +17,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = kpromo
-IMAGE_VERSION ?= v0.2.2-1
+IMAGE_VERSION ?= v0.2.3-1
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.2.2-1'
+  _IMAGE_VERSION: 'v0.2.3-1'
   _GO_VERSION: '1.17'
   _OS_CODENAME: 'buster'
 

--- a/cmd/kpromo/README.md
+++ b/cmd/kpromo/README.md
@@ -75,6 +75,7 @@ Flags:
       --filestores filestores   path to the filestores promoter manifest
   -h, --help                    help for files
       --manifests string        path to manifests for multiple projects
+      --use-service-account     allow service account usage with gcloud calls
 
 Global Flags:
       --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warning', 'info', 'debug', 'trace' (default "info")

--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -71,6 +71,13 @@ func init() {
 		"test run promotion without modifying any filestore",
 	)
 
+	filesCmd.PersistentFlags().BoolVar(
+		&filesOpts.UseServiceAccount,
+		"use-service-account",
+		filesOpts.UseServiceAccount,
+		"allow service account usage with gcloud calls",
+	)
+
 	// TODO(kpromo): Consider marking manifest flags as required
 
 	RunCmd.AddCommand(filesCmd)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v0.2.2-1
+    version: v0.2.3-1
     refPaths:
     - path: cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -37,6 +37,10 @@ type FilestorePromoter struct {
 	Dest   *api.Filestore
 
 	Files []api.File
+
+	// UseServiceAccount must be true, for service accounts to be used
+	// This gives some protection against a hostile manifest.
+	UseServiceAccount bool
 }
 
 //counterfeiter:generate . syncFilestore
@@ -54,6 +58,7 @@ type syncFilestore interface {
 func openFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,
+	useServiceAccount bool,
 ) (syncFilestore, error) {
 	u, err := url.Parse(filestore.Base)
 	if err != nil {
@@ -186,11 +191,11 @@ func joinFilepath(filestore *api.Filestore, relativePath string) string {
 // Source Filestore to the Dest Filestore.
 func (p *FilestorePromoter) BuildOperations(
 	ctx context.Context) ([]SyncFileOp, error) {
-	sourceFilestore, err := openFilestore(ctx, p.Source)
+	sourceFilestore, err := openFilestore(ctx, p.Source, p.UseServiceAccount)
 	if err != nil {
 		return nil, err
 	}
-	destFilestore, err := openFilestore(ctx, p.Dest)
+	destFilestore, err := openFilestore(ctx, p.Dest, p.UseServiceAccount)
 	if err != nil {
 		return nil, err
 	}

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -38,6 +38,8 @@ type FilestorePromoter struct {
 
 	Files []api.File
 
+	DryRun bool
+
 	// UseServiceAccount must be true, for service accounts to be used
 	// This gives some protection against a hostile manifest.
 	UseServiceAccount bool
@@ -58,7 +60,7 @@ type syncFilestore interface {
 func openFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,
-	useServiceAccount bool,
+	useServiceAccount, dryRun bool,
 ) (syncFilestore, error) {
 	u, err := url.Parse(filestore.Base)
 	if err != nil {
@@ -77,16 +79,21 @@ func openFilestore(
 		)
 	}
 
-	var opts []option.ClientOption
-	if filestore.ServiceAccount == "" {
-		logrus.Warnf("a service account was not specified for this filestore (%s), so all operations will run without authentication",
-			filestore.Base,
-		)
+	withAuth, err := useStorageClientAuth(filestore, useServiceAccount, dryRun)
+	if err != nil {
+		return nil, err
+	}
 
-		opts = append(opts, option.WithoutAuthentication())
-	} else {
+	var opts []option.ClientOption
+	if withAuth {
+		logrus.Infof("requesting an authenticated storage client")
+
 		ts := &gcloudTokenSource{ServiceAccount: filestore.ServiceAccount}
 		opts = append(opts, option.WithTokenSource(ts))
+	} else {
+		logrus.Warnf("requesting an UNAUTHENTICATED storage client")
+
+		opts = append(opts, option.WithoutAuthentication())
 	}
 
 	client, err := storage.NewClient(ctx, opts...)
@@ -108,6 +115,28 @@ func openFilestore(
 		prefix:    prefix,
 	}
 	return s, nil
+}
+
+func useStorageClientAuth(
+	filestore *api.Filestore,
+	useServiceAccount, dryRun bool,
+) (bool, error) {
+	withAuth := false
+	if !dryRun {
+		if filestore.ServiceAccount == "" {
+			return withAuth, fmt.Errorf("cannot execute a production file promotion without a service account")
+		}
+
+		withAuth = true
+	} else if useServiceAccount {
+		if filestore.ServiceAccount == "" {
+			return withAuth, fmt.Errorf("requested an authenticated file promotion, but a service account was not specified")
+		}
+
+		withAuth = true
+	}
+
+	return withAuth, nil
 }
 
 // computeNeededOperations determines the list of files that need to be copied
@@ -191,13 +220,30 @@ func joinFilepath(filestore *api.Filestore, relativePath string) string {
 // Source Filestore to the Dest Filestore.
 func (p *FilestorePromoter) BuildOperations(
 	ctx context.Context) ([]SyncFileOp, error) {
-	sourceFilestore, err := openFilestore(ctx, p.Source, p.UseServiceAccount)
+	sourceFilestore, err := openFilestore(
+		ctx,
+		p.Source,
+		p.UseServiceAccount,
+		p.DryRun,
+	)
 	if err != nil {
 		return nil, err
 	}
-	destFilestore, err := openFilestore(ctx, p.Dest, p.UseServiceAccount)
+	if sourceFilestore == nil {
+		return nil, fmt.Errorf("source filestore cannot be nil")
+	}
+
+	destFilestore, err := openFilestore(
+		ctx,
+		p.Dest,
+		p.UseServiceAccount,
+		p.DryRun,
+	)
 	if err != nil {
 		return nil, err
+	}
+	if destFilestore == nil {
+		return nil, fmt.Errorf("destination filestore cannot be nil")
 	}
 
 	sourceFiles, err := sourceFilestore.ListFiles(ctx)

--- a/filepromoter/filestore_test.go
+++ b/filepromoter/filestore_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filepromoter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	api "sigs.k8s.io/k8s-container-image-promoter/api/files"
+)
+
+func Test_useStorageClientAuth(t *testing.T) {
+	type args struct {
+		filestore         *api.Filestore
+		useServiceAccount bool
+		dryRun            bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "production",
+			args: args{
+				filestore: &api.Filestore{
+					ServiceAccount: "good@service.account",
+				},
+				dryRun: false,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "production without service account",
+			args: args{
+				filestore: &api.Filestore{},
+				dryRun:    false,
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "non-production",
+			args: args{
+				filestore: &api.Filestore{},
+				dryRun:    true,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "non-production with service account failure",
+			args: args{
+				filestore:         &api.Filestore{},
+				dryRun:            true,
+				useServiceAccount: true,
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "non-production with service account success",
+			args: args{
+				filestore: &api.Filestore{
+					ServiceAccount: "good@service.account",
+				},
+				dryRun:            true,
+				useServiceAccount: true,
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := useStorageClientAuth(
+				tt.args.filestore,
+				tt.args.useServiceAccount,
+				tt.args.dryRun,
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			}
+
+			require.Equal(t, tt.want, got)
+		},
+		)
+	}
+}

--- a/filepromoter/manifest.go
+++ b/filepromoter/manifest.go
@@ -28,6 +28,10 @@ import (
 // ManifestPromoter promotes files as described in Manifest.
 type ManifestPromoter struct {
 	Manifest *api.Manifest
+
+	// UseServiceAccount must be true, for service accounts to be used
+	// This gives some protection against a hostile manifest.
+	UseServiceAccount bool
 }
 
 // BuildOperations builds the required operations to sync from the
@@ -48,9 +52,10 @@ func (p *ManifestPromoter) BuildOperations(
 		}
 		logrus.Infof("processing destination %q", filestore.Base)
 		fp := &FilestorePromoter{
-			Source: source,
-			Dest:   filestore,
-			Files:  p.Manifest.Files,
+			Source:            source,
+			Dest:              filestore,
+			Files:             p.Manifest.Files,
+			UseServiceAccount: p.UseServiceAccount,
 		}
 		ops, err := fp.BuildOperations(ctx)
 		if err != nil {

--- a/filepromoter/manifest.go
+++ b/filepromoter/manifest.go
@@ -29,6 +29,8 @@ import (
 type ManifestPromoter struct {
 	Manifest *api.Manifest
 
+	DryRun bool
+
 	// UseServiceAccount must be true, for service accounts to be used
 	// This gives some protection against a hostile manifest.
 	UseServiceAccount bool
@@ -55,6 +57,7 @@ func (p *ManifestPromoter) BuildOperations(
 			Source:            source,
 			Dest:              filestore,
 			Files:             p.Manifest.Files,
+			DryRun:            p.DryRun,
 			UseServiceAccount: p.UseServiceAccount,
 		}
 		ops, err := fp.BuildOperations(ctx)

--- a/promobot/promotefiles.go
+++ b/promobot/promotefiles.go
@@ -65,6 +65,10 @@ type PromoteFilesOptions struct {
 	// DryRun (if set) will not perform operations, but print them instead
 	DryRun bool
 
+	// UseServiceAccount must be true, for service accounts to be used
+	// This gives some protection against a hostile manifest.
+	UseServiceAccount bool
+
 	// Out is the destination for "normal" output (such as dry-run)
 	Out io.Writer
 }
@@ -72,6 +76,7 @@ type PromoteFilesOptions struct {
 // PopulateDefaults sets the default values for PromoteFilesOptions
 func (o *PromoteFilesOptions) PopulateDefaults() {
 	o.DryRun = true
+	o.UseServiceAccount = false
 	o.Out = os.Stdout
 }
 
@@ -95,7 +100,8 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	var ops []filepromoter.SyncFileOp
 	for _, manifest := range manifests {
 		promoter := &filepromoter.ManifestPromoter{
-			Manifest: manifest,
+			Manifest:          manifest,
+			UseServiceAccount: options.UseServiceAccount,
 		}
 
 		o, err := promoter.BuildOperations(ctx)
@@ -201,10 +207,11 @@ func ReadManifests(options PromoteFilesOptions) ([]*api.Manifest, error) {
 		)
 
 		prjOpts := &PromoteFilesOptions{
-			FilestoresPath: filestores,
-			FilesPath:      files,
-			DryRun:         options.DryRun,
-			Out:            options.Out,
+			FilestoresPath:    filestores,
+			FilesPath:         files,
+			DryRun:            options.DryRun,
+			UseServiceAccount: options.UseServiceAccount,
+			Out:               options.Out,
 		}
 
 		m, err := ReadManifest(*prjOpts)

--- a/promobot/promotefiles.go
+++ b/promobot/promotefiles.go
@@ -101,6 +101,7 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	for _, manifest := range manifests {
 		promoter := &filepromoter.ManifestPromoter{
 			Manifest:          manifest,
+			DryRun:            options.DryRun,
 			UseServiceAccount: options.UseServiceAccount,
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

(Part of https://github.com/kubernetes/k8s.io/issues/2624, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.)

- Revert "kpromo: Drop unused UseServiceAccount code paths"
  This reverts commit 120a02f7242454b51554f91d7ee3d4dbfe33d38e.
- filepromoter: Allow authenticated clients in non-production runs

  This facilitates presubmit testing by allowing non-production runs
  to bypass (or enforce) service account usage.

  Production runs (`--dry-run=false`) will expect (and fail) without
  a service account specified.

  Non-production runs support the following operation modes:
  - `[--dry-run]`: unauthenticated
  - `[--dry-run] --use-service-account`: authenticated (fails without
  a service account specified)

  We've added unit tests for this behavior (as a treat).

- kpromo: Build v0.2.3-1 image

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Should fix presubmit failures blocking https://github.com/kubernetes/k8s.io/pull/2704 and https://github.com/kubernetes/k8s.io/pull/2663.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Revert "kpromo: Drop unused UseServiceAccount code paths"
  This reverts commit 120a02f7242454b51554f91d7ee3d4dbfe33d38e.
- filepromoter: Allow authenticated clients in non-production runs

  This facilitates presubmit testing by allowing non-production runs
  to bypass (or enforce) service account usage.

  Production runs (`--dry-run=false`) will expect (and fail) without
  a service account specified.

  Non-production runs support the following operation modes:
  - `[--dry-run]`: unauthenticated
  - `[--dry-run] --use-service-account`: authenticated (fails without
  a service account specified)

  We've added unit tests for this behavior (as a treat).

- kpromo: Build v0.2.3-1 image
```
