### PR TITLE
OWNERS cleanup

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,11 +3,9 @@
 approvers:
 - sig-release-leads
 - release-engineering-approvers
-- wg-k8s-infra-leads
 - cip-approvers
 reviewers:
 - release-engineering-reviewers
-- cip-approvers
 - cip-reviewers
 
 labels:

--- a/OWNERS
+++ b/OWNERS
@@ -3,10 +3,10 @@
 approvers:
 - sig-release-leads
 - release-engineering-approvers
-- cip-approvers
+- promo-tools-approvers
 reviewers:
 - release-engineering-reviewers
-- cip-reviewers
+- promo-tools-reviewers
 
 labels:
 - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,10 +23,6 @@ aliases:
     - thejoycekung # Release Manager Associate
     - verolop # Release Manager Associate
     - wilsonehusin # Release Manager Associate
-  wg-k8s-infra-leads:
-    - ameukam
-    - dims
-    - spiffxp
   cip-approvers:
     - justaugustus
     - justinsb

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,20 +2,17 @@
 
 aliases:
   sig-release-leads:
-    - hasheddan # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
-    - hasheddan # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # Release Manager
-    - hasheddan # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,11 +23,17 @@ aliases:
     - thejoycekung # Release Manager Associate
     - verolop # Release Manager Associate
     - wilsonehusin # Release Manager Associate
-  cip-approvers:
+  promo-tools-approvers:
+    - cpanato
+    - jeremyrickard
     - justaugustus
-    - justinsb
     - listx
-  cip-reviewers:
+    - puerco
+    - saschagrunert
+  promo-tools-reviewers:
+    - cpanato
+    - jeremyrickard
     - justaugustus
-    - justinsb
     - listx
+    - puerco
+    - saschagrunert

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,21 +2,27 @@
 
 aliases:
   sig-release-leads:
+    - cpanato # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
-    - justaugustus # subproject owner / Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
     - xmudrii # Release Manager
   release-engineering-reviewers:
-    - cpanato # Release Manager
-    - justaugustus # subproject owner / Release Manager
-    - puerco # Release Manager
-    - saschagrunert # subproject owner / Release Manager
-    - xmudrii # Release Manager
+    - ameukam # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - mkorbi # Release Manager Associate
+    - palnabarun # Release Manager Associate
+    - onlydole # Release Manager Associate
+    - sethmccombs # Release Manager Associate
+    - thejoycekung # Release Manager Associate
+    - verolop # Release Manager Associate
+    - wilsonehusin # Release Manager Associate
   wg-k8s-infra-leads:
     - ameukam
     - dims

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,16 +1,18 @@
 # Defined below are the security contacts for this repo.
 #
-# They are the contact point for the Product Security Team to reach out
+# They are the contact points for the Security Response Committee to reach out
 # to for triaging and handling of incoming issues.
 #
 # The below names agree to abide by the
-# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
 # and will be removed and replaced if they violate that agreement.
 #
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-dims
-hh
+cpanato
+jeremyrickard
+justaugustus
 listx
-tpepper
+puerco
+saschagrunert


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- @hasheddan is now Emeritus: https://github.com/kubernetes/sig-release/issues/1667
- Sync RelEng aliases and security contacts from k/release: https://github.com/kubernetes/release/pull/2214
- Drop default approver privileges for WG K8s Infra leads
  WG K8s Infra is transitioning to a SIG: https://github.com/kubernetes/community/pull/5928
  As part of that, we refine approvals down to maintainers and
  Release Engineering subproject owners.
- Sync promotion tool approvers/reviewers with k/org: https://github.com/kubernetes/org/pull/2906

/assign @cpanato @saschagrunert @puerco @jeremyrickard 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
