### PR TITLE
filepromoter: Build unauthenticated client for source filestores

### DIFF
--- a/Makefile-kpromo
+++ b/Makefile-kpromo
@@ -17,7 +17,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = kpromo
-IMAGE_VERSION ?= v0.2.3-1
+IMAGE_VERSION ?= v0.2.4-1
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.2.3-1'
+  _IMAGE_VERSION: 'v0.2.4-1'
   _GO_VERSION: '1.17'
   _OS_CODENAME: 'buster'
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v0.2.3-1
+    version: v0.2.4-1
     refPaths:
     - path: cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -86,12 +86,18 @@ func openFilestore(
 
 	var opts []option.ClientOption
 	if withAuth {
-		logrus.Infof("requesting an authenticated storage client")
+		logrus.Infof(
+			"requesting an authenticated storage client for %s",
+			filestore.Base,
+		)
 
 		ts := &gcloudTokenSource{ServiceAccount: filestore.ServiceAccount}
 		opts = append(opts, option.WithTokenSource(ts))
 	} else {
-		logrus.Warnf("requesting an UNAUTHENTICATED storage client")
+		logrus.Warnf(
+			"requesting an UNAUTHENTICATED storage client for %s",
+			filestore.Base,
+		)
 
 		opts = append(opts, option.WithoutAuthentication())
 	}
@@ -122,6 +128,13 @@ func useStorageClientAuth(
 	useServiceAccount, dryRun bool,
 ) (bool, error) {
 	withAuth := false
+
+	// Source filestores should be world-readable, so authentication should
+	// not be required.
+	if filestore.Src {
+		return withAuth, nil
+	}
+
 	if !dryRun {
 		if filestore.ServiceAccount == "" {
 			return withAuth, fmt.Errorf("cannot execute a production file promotion without a service account")

--- a/filepromoter/filestore_test.go
+++ b/filepromoter/filestore_test.go
@@ -57,6 +57,17 @@ func Test_useStorageClientAuth(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "production source filestore without service account",
+			args: args{
+				filestore: &api.Filestore{
+					Src: true,
+				},
+				dryRun: false,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
 			name: "non-production",
 			args: args{
 				filestore: &api.Filestore{},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

(Part of https://github.com/kubernetes/k8s.io/issues/2624, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.)

- filepromoter: Build unauthenticated client for source filestores
  
  Source filestores are (supposed to be) world-readable, so there is
  no need to require an authenticated client for them.

  This is a workaround for the fact that service accounts are stored
  as part of `filestore`, when ergonomically, they should probably be
  at the top-level of a root promotion manifest. To be fixed in a
  future commit.

- kpromo: Build v0.2.4-1 image

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @ameukam @cpanato @Verolop
cc: @kubernetes-sigs/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Discovered in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-file-promo/1437091170512539648, following the merge of https://github.com/kubernetes/k8s.io/pull/2704:

```console
********** START **********
level=info msg="processing destination \"gs://k8s-artifacts-prod/binaries/kops/\""
level=fatal msg="run `kpromo run files`: error building operations: error building promotion operations for \"gs://k8s-artifacts-prod/binaries/kops/\": cannot execute a production file promotion without a service account" 
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- filepromoter: Build unauthenticated client for source filestores
  
  Source filestores are (supposed to be) world-readable, so there is
  no need to require an authenticated client for them.

  This is a workaround for the fact that service accounts are stored
  as part of `filestore`, when ergonomically, they should probably be
  at the top-level of a root promotion manifest. To be fixed in a
  future commit.

- kpromo: Build v0.2.4-1 image
```
