### PR TITLE
cloudbuild.yaml: Re-enable image checks for CIP + auditor

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,12 +55,10 @@ tags:
 - ${_OS_CODENAME}
 
 images:
-# TODO: Temporarily disabling this check, which is currently failing in
-#       postsubmit: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/312
-#  - 'gcr.io/$PROJECT_ID/cip:$_GIT_TAG'
-#  - 'gcr.io/$PROJECT_ID/cip:latest'
-#  - 'gcr.io/$PROJECT_ID/cip-auditor:$_GIT_TAG'
-#  - 'gcr.io/$PROJECT_ID/cip-auditor:latest'
+- 'gcr.io/$PROJECT_ID/cip:$_GIT_TAG'
+- 'gcr.io/$PROJECT_ID/cip:latest'
+- 'gcr.io/$PROJECT_ID/cip-auditor:$_GIT_TAG'
+- 'gcr.io/$PROJECT_ID/cip-auditor:latest'
 - 'gcr.io/$PROJECT_ID/kpromo-amd64:$_IMAGE_VERSION'
 - 'gcr.io/$PROJECT_ID/kpromo-amd64:$_GIT_TAG'
 - 'gcr.io/$PROJECT_ID/kpromo-amd64:latest'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

...these should pass now that bazel has been removed from the repo.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Fixes: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/312

/hold for testing + maybe adding some other cleanups to this PR

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
cloudbuild.yaml: Re-enable image checks for CIP + auditor
```
