### PR TITLE
Module rename: sigs.k8s.io/k8s-container-image-promoter --> sigs.k8s.io/promo-tools

### DIFF
--- a/Dockerfile-kpromo
+++ b/Dockerfile-kpromo
@@ -17,7 +17,7 @@ ARG GO_VERSION
 ARG OS_CODENAME
 FROM golang:${GO_VERSION}-${OS_CODENAME} as builder
 
-WORKDIR /go/src/sigs.k8s.io/k8s-container-image-promoter
+WORKDIR /go/src/sigs.k8s.io/promo-tools
 
 # Copy the sources
 ENV package="./cmd/kpromo"
@@ -44,6 +44,6 @@ LABEL maintainers="Kubernetes Authors"
 LABEL description="kpromo: The Kubernetes project artifact promoter"
 
 WORKDIR /
-COPY --from=builder /go/src/sigs.k8s.io/k8s-container-image-promoter/kpromo .
+COPY --from=builder /go/src/sigs.k8s.io/promo-tools/kpromo .
 
 ENTRYPOINT ["/kpromo"]

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Currently only Google Container Registry (GCR) is supported.
 2. Run the steps below:
 
 ```console
-go get sigs.k8s.io/k8s-container-image-promoter
-cd $GOPATH/src/sigs.k8s.io/k8s-container-image-promoter
+go get sigs.k8s.io/promo-tools
+cd $GOPATH/src/sigs.k8s.io/promo-tools
 
 # Install the "cip" binary into $GOPATH/bin
 make install
@@ -384,7 +384,7 @@ the VERSION file often as the Docker images will always get a unique identifier.
 
 ## Checks Interface
 
-Read more [here](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/checks_interface.md).
+Read more [here](https://github.com/kubernetes-sigs/promo-tools/blob/master/checks_interface.md).
 
 The addition of the checks interface to the Container Image Promoter is meant
 to make it easy to add checks against pull requests affecting the promoter

--- a/api/files/manifest_test.go
+++ b/api/files/manifest_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	"sigs.k8s.io/promo-tools/v3/api/files"
 )
 
 func TestValidateFilestores(t *testing.T) {

--- a/checks_interface.md
+++ b/checks_interface.md
@@ -9,7 +9,7 @@ check requirements in the future.
 
 ## Interface Explanation
 The `PreCheck` interface is implemented like so in the 
-[types.go](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/lib/dockerregistry/types.go) 
+[types.go](https://github.com/kubernetes-sigs/promo-tools/blob/master/lib/dockerregistry/types.go)
 file. The `Run` function is the method used in order to actually execute the 
 check that implements this interface.
 
@@ -54,7 +54,7 @@ func (f *foo) Run() error
 ```
 Then add that check type you've created to the input list of PreChecks for 
 the RunChecks method, which is called in the 
-[cip.go](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/cip.go) 
+[cip.go](https://github.com/kubernetes-sigs/promo-tools/blob/master/cip.go)
 file.
 
 Note that the `Run` method of the precheck interface does not accept any 

--- a/cmd/cip-mm/main.go
+++ b/cmd/cip-mm/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
 	"sigs.k8s.io/release-utils/log"
 )
 

--- a/cmd/cip/cmd/audit.go
+++ b/cmd/cip/cmd/audit.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/cli"
+	"sigs.k8s.io/promo-tools/v3/legacy/cli"
 )
 
 // auditCmd represents the base command when called without any subcommands

--- a/cmd/cip/cmd/root.go
+++ b/cmd/cip/cmd/root.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/cli"
+	"sigs.k8s.io/promo-tools/v3/legacy/cli"
 	"sigs.k8s.io/release-utils/log"
 )
 

--- a/cmd/cip/cmd/run.go
+++ b/cmd/cip/cmd/run.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/cli"
+	"sigs.k8s.io/promo-tools/v3/legacy/cli"
 )
 
 // runCmd represents the base command when called without any subcommands

--- a/cmd/cip/cmd/version.go
+++ b/cmd/cip/cmd/version.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/cli"
+	"sigs.k8s.io/promo-tools/v3/legacy/cli"
 )
 
 var versionOpts = &cli.VersionOptions{}

--- a/cmd/cip/main.go
+++ b/cmd/cip/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "sigs.k8s.io/k8s-container-image-promoter/v3/cmd/cip/cmd"
+import "sigs.k8s.io/promo-tools/v3/cmd/cip/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/gh2gcs/cmd/root.go
+++ b/cmd/gh2gcs/cmd/root.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/gh2gcs"
+	"sigs.k8s.io/promo-tools/v3/gh2gcs"
 	"sigs.k8s.io/release-sdk/gcli"
 	"sigs.k8s.io/release-sdk/github"
 	"sigs.k8s.io/release-utils/log"

--- a/cmd/gh2gcs/main.go
+++ b/cmd/gh2gcs/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "sigs.k8s.io/k8s-container-image-promoter/v3/cmd/gh2gcs/cmd"
+import "sigs.k8s.io/promo-tools/v3/cmd/gh2gcs/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/kpromo/cmd/manifest/files.go
+++ b/cmd/kpromo/cmd/manifest/files.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/promobot"
+	"sigs.k8s.io/promo-tools/v3/promobot"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/kpromo/cmd/root.go
+++ b/cmd/kpromo/cmd/root.go
@@ -22,8 +22,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/cmd/kpromo/cmd/manifest"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/cmd/kpromo/cmd/run"
+	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/manifest"
+	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/run"
 	"sigs.k8s.io/release-utils/log"
 )
 

--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/promobot"
+	"sigs.k8s.io/promo-tools/v3/promobot"
 )
 
 // filesCmd represents the subcommand for `kpromo run files`

--- a/cmd/kpromo/main.go
+++ b/cmd/kpromo/main.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package main
 
-import "sigs.k8s.io/k8s-container-image-promoter/v3/cmd/kpromo/cmd"
+import "sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd"
 
 func main() {
 	cmd.Execute()

--- a/filepromoter/file.go
+++ b/filepromoter/file.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
 	"sigs.k8s.io/release-utils/hash"
 )
 

--- a/filepromoter/filepromoterfakes/fake_sync_file_op.go
+++ b/filepromoter/filepromoterfakes/fake_sync_file_op.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"sync"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/filepromoter"
+	"sigs.k8s.io/promo-tools/v3/filepromoter"
 )
 
 type FakeSyncFileOp struct {

--- a/filepromoter/filepromoterfakes/fake_sync_filestore.go
+++ b/filepromoter/filepromoterfakes/fake_sync_filestore.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"sync"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/filepromoter"
+	"sigs.k8s.io/promo-tools/v3/filepromoter"
 )
 
 type FakeSyncFilestore struct {

--- a/filepromoter/filestore.go
+++ b/filepromoter/filestore.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
 	"sigs.k8s.io/release-sdk/object"
 )
 

--- a/filepromoter/filestore_test.go
+++ b/filepromoter/filestore_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
 )
 
 func Test_useStorageClientAuth(t *testing.T) {

--- a/filepromoter/gcs.go
+++ b/filepromoter/gcs.go
@@ -29,7 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
 	"sigs.k8s.io/release-sdk/object"
 )
 

--- a/filepromoter/manifest.go
+++ b/filepromoter/manifest.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
 )
 
 // ManifestPromoter promotes files as described in Manifest.

--- a/filepromoter/token.go
+++ b/filepromoter/token.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/gcloud"
+	"sigs.k8s.io/promo-tools/v3/legacy/gcloud"
 )
 
 // gcloudTokenSource implements oauth2.TokenSource.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/k8s-container-image-promoter/v3
+module sigs.k8s.io/promo-tools/v3
 
 go 1.17
 

--- a/go_with_version.sh
+++ b/go_with_version.sh
@@ -40,7 +40,7 @@ fi
 
 tool="$2"
 git_tree_state=dirty
-pkg=sigs.k8s.io/k8s-container-image-promoter/internal/version
+pkg=sigs.k8s.io/promo-tools/internal/version
 
 if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${git_status}" ]]; then
 git_tree_state=clean

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -57,7 +57,7 @@ go_test_flags=(
 )
 
 packages=()
-mapfile -t packages < <(go list ./... | grep -v 'sigs.k8s.io/k8s-container-image-promoter/cmd\|test-e2e')
+mapfile -t packages < <(go list ./... | grep -v 'sigs.k8s.io/promo-tools/cmd\|test-e2e')
 
 export GO111MODULE=on
 

--- a/legacy/audit/auditor.go
+++ b/legacy/audit/auditor.go
@@ -28,10 +28,10 @@ import (
 	"cloud.google.com/go/errorreporting"
 	"github.com/sirupsen/logrus"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/logclient"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/remotemanifest"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/report"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/logclient"
+	"sigs.k8s.io/promo-tools/v3/legacy/remotemanifest"
+	"sigs.k8s.io/promo-tools/v3/legacy/report"
 )
 
 // InitRealServerContext creates a ServerContext with facilities that are meant

--- a/legacy/audit/auditor_test.go
+++ b/legacy/audit/auditor_test.go
@@ -27,12 +27,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/audit"
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/logclient"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/remotemanifest"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/report"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/legacy/audit"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/logclient"
+	"sigs.k8s.io/promo-tools/v3/legacy/remotemanifest"
+	"sigs.k8s.io/promo-tools/v3/legacy/report"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 func TestParsePubSubMessageBody(t *testing.T) {
@@ -177,7 +177,7 @@ func TestValidatePayload(t *testing.T) {
 
 func TestAudit(t *testing.T) {
 	// Regression test case for
-	// https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/191.
+	// https://github.com/kubernetes-sigs/promo-tools/issues/191.
 	manifests1 := []reg.Manifest{
 		{
 			Registries: []reg.RegistryContext{

--- a/legacy/audit/types.go
+++ b/legacy/audit/types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package audit
 
 import (
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/logclient"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/remotemanifest"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/report"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/logclient"
+	"sigs.k8s.io/promo-tools/v3/legacy/remotemanifest"
+	"sigs.k8s.io/promo-tools/v3/legacy/report"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 // GcrReadingFacility holds functions used to create streams for reading the

--- a/legacy/cli/audit.go
+++ b/legacy/cli/audit.go
@@ -23,9 +23,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/audit"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/reqcounter"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/signals"
+	"sigs.k8s.io/promo-tools/v3/legacy/audit"
+	"sigs.k8s.io/promo-tools/v3/legacy/reqcounter"
+	"sigs.k8s.io/promo-tools/v3/legacy/signals"
 )
 
 type AuditOptions struct {

--- a/legacy/cli/root.go
+++ b/legacy/cli/root.go
@@ -19,7 +19,7 @@ package cli
 import (
 	"fmt"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/internal/version"
+	"sigs.k8s.io/promo-tools/v3/internal/version"
 )
 
 type RootOptions struct {

--- a/legacy/cli/run.go
+++ b/legacy/cli/run.go
@@ -23,9 +23,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/gcloud"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/gcloud"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 type RunOptions struct {

--- a/legacy/cli/version.go
+++ b/legacy/cli/version.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/internal/version"
+	"sigs.k8s.io/promo-tools/v3/internal/version"
 )
 
 type VersionOptions struct {

--- a/legacy/dockerregistry/checks.go
+++ b/legacy/dockerregistry/checks.go
@@ -34,7 +34,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 // MBToBytes converts a value from MiB to Bytes.

--- a/legacy/dockerregistry/checks_test.go
+++ b/legacy/dockerregistry/checks_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
 )
 
 func TestImageRemovalCheck(t *testing.T) {

--- a/legacy/dockerregistry/grow_manifest_test.go
+++ b/legacy/dockerregistry/grow_manifest_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
 )
 
 func TestFindManifest(t *testing.T) {

--- a/legacy/dockerregistry/inventory.go
+++ b/legacy/dockerregistry/inventory.go
@@ -38,10 +38,10 @@ import (
 	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/gcloud"
-	cipJson "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/json"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/reqcounter"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/legacy/gcloud"
+	cipJson "sigs.k8s.io/promo-tools/v3/legacy/json"
+	"sigs.k8s.io/promo-tools/v3/legacy/reqcounter"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 // GetSrcRegistry gets the source registry.

--- a/legacy/dockerregistry/inventory_test.go
+++ b/legacy/dockerregistry/inventory_test.go
@@ -27,9 +27,9 @@ import (
 	cr "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/json"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/json"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 type ParseJSONStreamResult struct {
@@ -790,7 +790,7 @@ func TestSplitRegistryImagePath(t *testing.T) {
 func TestSplitByKnownRegistries(t *testing.T) {
 	knownRegistryNames := []reg.RegistryName{
 		// See
-		// https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/188.
+		// https://github.com/kubernetes-sigs/promo-tools/issues/188.
 		`us.gcr.io/k8s-artifacts-prod/kube-state-metrics`,
 		`us.gcr.io/k8s-artifacts-prod/metrics-server`,
 		`us.gcr.io/k8s-artifacts-prod`,

--- a/legacy/dockerregistry/set.go
+++ b/legacy/dockerregistry/set.go
@@ -17,7 +17,7 @@ limitations under the License.
 package inventory
 
 import (
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/container"
+	"sigs.k8s.io/promo-tools/v3/legacy/container"
 )
 
 // Various set manipulation operations. Some set operations are missing,

--- a/legacy/dockerregistry/types.go
+++ b/legacy/dockerregistry/types.go
@@ -23,8 +23,8 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/gcloud"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/legacy/gcloud"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 )
 
 // RequestResult contains information about the result of running a request

--- a/legacy/remotemanifest/fake.go
+++ b/legacy/remotemanifest/fake.go
@@ -17,7 +17,7 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
 )
 
 // Fake is a fake remote manifest. It is fake in the sense that it

--- a/legacy/remotemanifest/git.go
+++ b/legacy/remotemanifest/git.go
@@ -27,7 +27,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
 )
 
 const (

--- a/legacy/remotemanifest/types.go
+++ b/legacy/remotemanifest/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
 )
 
 // Facility requires a single method, called Fetch(), which corresponds to

--- a/legacy/reqcounter/reqcounter.go
+++ b/legacy/reqcounter/reqcounter.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	tw "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/timewrapper"
+	tw "sigs.k8s.io/promo-tools/v3/legacy/timewrapper"
 )
 
 // RequestCounter records the number of HTTP requests to GCR.

--- a/legacy/reqcounter/reqcounter_test.go
+++ b/legacy/reqcounter/reqcounter_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	rc "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/reqcounter"
-	tw "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/timewrapper"
+	rc "sigs.k8s.io/promo-tools/v3/legacy/reqcounter"
+	tw "sigs.k8s.io/promo-tools/v3/legacy/timewrapper"
 )
 
 // defaultThreshold should be used as a default request counter threshold.

--- a/legacy/signals/signals_test.go
+++ b/legacy/signals/signals_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/signals"
+	"sigs.k8s.io/promo-tools/v3/legacy/signals"
 )
 
 func TestLogSignal(t *testing.T) {

--- a/promobot/hash.go
+++ b/promobot/hash.go
@@ -24,7 +24,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
 	"sigs.k8s.io/release-utils/hash"
 )
 

--- a/promobot/hash_test.go
+++ b/promobot/hash_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/utils/diff"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/promobot"
+	"sigs.k8s.io/promo-tools/v3/promobot"
 	"sigs.k8s.io/yaml"
 )
 

--- a/promobot/promotefiles.go
+++ b/promobot/promotefiles.go
@@ -27,8 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 
-	api "sigs.k8s.io/k8s-container-image-promoter/v3/api/files"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/filepromoter"
+	api "sigs.k8s.io/promo-tools/v3/api/files"
+	"sigs.k8s.io/promo-tools/v3/filepromoter"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/promobot/readmanifest_test.go
+++ b/promobot/readmanifest_test.go
@@ -19,7 +19,7 @@ package promobot_test
 import (
 	"testing"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/promobot"
+	"sigs.k8s.io/promo-tools/v3/promobot"
 	"sigs.k8s.io/yaml"
 )
 

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -28,11 +28,11 @@ import (
 	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/internal/version"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/audit"
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/gcloud"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/internal/version"
+	"sigs.k8s.io/promo-tools/v3/legacy/audit"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/gcloud"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 	"sigs.k8s.io/release-utils/command"
 )
 

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -30,10 +30,10 @@ import (
 	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
-	"sigs.k8s.io/k8s-container-image-promoter/v3/internal/version"
-	reg "sigs.k8s.io/k8s-container-image-promoter/v3/legacy/dockerregistry"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/gcloud"
-	"sigs.k8s.io/k8s-container-image-promoter/v3/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/internal/version"
+	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/legacy/gcloud"
+	"sigs.k8s.io/promo-tools/v3/legacy/stream"
 	"sigs.k8s.io/release-utils/command"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:

Module rename: sigs.k8s.io/k8s-container-image-promoter --> sigs.k8s.io/promo-tools
This will happen today in coordination with the repo rename AND branch rename to `main`.

We'll lock in the renames first and sweep "non-code" references in a follow-up.
PR has been opened to update test-infra job references: https://github.com/kubernetes/test-infra/pull/23605

Tracking issue: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/424

/assign @puerco @cpanato @ameukam @Verolop 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Module rename: sigs.k8s.io/k8s-container-image-promoter --> sigs.k8s.io/promo-tools
```
