### PR TITLE
golangci-lint: Bump to v2.4.0 and enable `hack/verify-golangci-lint.sh` on macOS

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 2.1.6
+    version: 2.4.0
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v2.1.6
+VERSION=v2.4.0
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=${URL_BASE}/${VERSION}/install.sh
 # If you update the version above you might need to update the checksum
@@ -27,7 +27,7 @@ URL=${URL_BASE}/${VERSION}/install.sh
 # To obtain the checksum, download the install script and run the following
 # command:
 # > sha256sum <path-to-install-script>
-INSTALL_CHECKSUM=9e99d38f3213411a1b6175e5b535c72e37c7ed42ccf251d331385a3f97b695e7
+INSTALL_CHECKSUM=8e7a5b7d112128d7a700755a9064b20bdc8d2834c4f6ad7614af2274aa51a20b
 
 if [[ ! -f .golangci.yml ]]; then
     echo 'ERROR: missing .golangci.yml in repo root' >&2
@@ -37,7 +37,14 @@ fi
 if ! command -v golangci-lint; then
     INSTALL_SCRIPT=$(mktemp -d)/install.sh
     curl -sfL "${URL}" >"${INSTALL_SCRIPT}"
-    if echo "${INSTALL_CHECKSUM} ${INSTALL_SCRIPT}" | sha256sum --check; then
+    # Cross-platform sha256sum/shasum check
+    system=$(uname)
+    if [[ "${system}" == "Darwin" ]]; then
+        CHECK_CMD="echo \"${INSTALL_CHECKSUM}  ${INSTALL_SCRIPT}\" | shasum -a 256 --check --status"
+    else
+        CHECK_CMD="echo \"${INSTALL_CHECKSUM}  ${INSTALL_SCRIPT}\" | sha256sum --check --status"
+    fi
+    if eval "${CHECK_CMD}"; then
         chmod 755 "${INSTALL_SCRIPT}"
         ${INSTALL_SCRIPT} -b /tmp "${VERSION}"
         export PATH=${PATH}:/tmp


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup




#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #1543



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
golangci-lint: Bump to v2.4.0 and enable `hack/verify-golangci-lint.sh` on macOS
```
