### PR TITLE
Rewrite rate limiter with budget allocation and adaptive backoff

### DIFF
--- a/internal/legacy/dockerregistry/types.go
+++ b/internal/legacy/dockerregistry/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package inventory
 
 import (
+	"net/http"
 	"sync"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -83,6 +84,11 @@ type SyncContext struct { //nolint: gocritic
 	DigestMediaType   DigestMediaType
 	ParentDigest      ParentDigest
 	Logs              CollectedLogs
+
+	// PromotionTransport is the HTTP transport to use for image copy
+	// operations. If nil, falls back to ratelimit.Limiter for backwards
+	// compatibility.
+	PromotionTransport http.RoundTripper
 }
 
 // PreCheck represents a check function to run against a pull request that

--- a/internal/legacy/stream/http.go
+++ b/internal/legacy/stream/http.go
@@ -42,6 +42,7 @@ const (
 // stderr). In this case we equate the http.Respose "Body" with stdout.
 func (h *HTTP) Produce() (stdOut, stdErr io.Reader, err error) {
 	client := http.Client{
+		//nolint:staticcheck // Legacy fallback during transition to BudgetAllocator.
 		Transport: ratelimit.Limiter,
 		Timeout:   time.Second * requestTimeoutSeconds,
 	}

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -51,7 +51,7 @@ func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (
 
 // MakeSyncContext takes a slice of manifests and creates a sync context
 // object based on them and the promoter options.
-func (di DefaultPromoterImplementation) MakeSyncContext(
+func (di *DefaultPromoterImplementation) MakeSyncContext(
 	opts *options.Options, mfests []schema.Manifest,
 ) (*reg.SyncContext, error) {
 	sc, err := reg.MakeSyncContext(
@@ -60,6 +60,14 @@ func (di DefaultPromoterImplementation) MakeSyncContext(
 	if err != nil {
 		return nil, fmt.Errorf("creating sync context: %w", err)
 	}
+
+	// Propagate the promotion transport to the SyncContext so that
+	// Promote() uses the dedicated rate-limited transport instead of
+	// the global singleton.
+	if di.promotionTransport != nil {
+		sc.PromotionTransport = di.promotionTransport
+	}
+
 	return sc, err
 }
 

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -38,7 +38,6 @@ import (
 	reg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry"
 	"sigs.k8s.io/promo-tools/v4/internal/legacy/gcloud"
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
-	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
@@ -253,7 +252,7 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *reg.Promotion
 	craneOpts := []crane.Option{
 		crane.WithAuthFromKeychain(gcrane.Keychain),
 		crane.WithUserAgent(image.UserAgent),
-		crane.WithTransport(ratelimit.Limiter),
+		crane.WithTransport(di.getSigningTransport()),
 	}
 
 	if err := crane.Copy(srcRef.String(), dstRef.String(), craneOpts...); err != nil {
@@ -315,7 +314,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 		opts := []crane.Option{
 			crane.WithAuthFromKeychain(gcrane.Keychain),
 			crane.WithUserAgent(image.UserAgent),
-			crane.WithTransport(ratelimit.Limiter),
+			crane.WithTransport(di.getSigningTransport()),
 		}
 		if err := crane.Copy(srcRef.String(), dstRef.reference.String(), opts...); err != nil {
 			return fmt.Errorf(

--- a/promoter/image/ratelimit/budget.go
+++ b/promoter/image/ratelimit/budget.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+)
+
+// BudgetAllocator partitions a total requests-per-second budget into named
+// sub-budgets. Each sub-budget gets its own RoundTripper with a fraction of
+// the total rate. Budgets can be rebalanced at runtime, e.g., when promotion
+// finishes and signing should get the full budget.
+type BudgetAllocator struct {
+	mu          sync.Mutex
+	total       rate.Limit
+	allocations map[string]*allocation
+}
+
+type allocation struct {
+	limiter  *RoundTripper
+	fraction float64
+}
+
+// NewBudgetAllocator creates a new allocator with the given total
+// requests-per-second budget.
+func NewBudgetAllocator(totalEventsPerSecond rate.Limit) *BudgetAllocator {
+	return &BudgetAllocator{
+		total:       totalEventsPerSecond,
+		allocations: make(map[string]*allocation),
+	}
+}
+
+// Allocate creates a named rate limiter with the given fraction of the total
+// budget. The fraction must be between 0 and 1. The sum of all fractions
+// should not exceed 1.0.
+func (b *BudgetAllocator) Allocate(name string, fraction float64) *RoundTripper {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	limit := rate.Limit(float64(b.total) * fraction)
+	rt := NewNamedRoundTripper(name, limit, DefaultBurst)
+
+	b.allocations[name] = &allocation{
+		limiter:  rt,
+		fraction: fraction,
+	}
+
+	logrus.WithField("allocator", "budget").Infof(
+		"Allocated %q: %.1f req/sec (%.0f%% of %.1f total)",
+		name, float64(limit), fraction*100, float64(b.total),
+	)
+
+	return rt
+}
+
+// Get returns the rate limiter for the given name, or an error if it doesn't
+// exist.
+func (b *BudgetAllocator) Get(name string) (*RoundTripper, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	alloc, ok := b.allocations[name]
+	if !ok {
+		return nil, fmt.Errorf("no rate limiter allocated with name %q", name)
+	}
+	return alloc.limiter, nil
+}
+
+// Rebalance shifts budget from one allocation to another. The amount is
+// specified as a fraction of the total budget (0 to 1). The source
+// allocation's rate is reduced and the destination's is increased.
+func (b *BudgetAllocator) Rebalance(from, to string, fraction float64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	fromAlloc, ok := b.allocations[from]
+	if !ok {
+		return fmt.Errorf("source allocation %q not found", from)
+	}
+	toAlloc, ok := b.allocations[to]
+	if !ok {
+		return fmt.Errorf("destination allocation %q not found", to)
+	}
+
+	fromAlloc.fraction -= fraction
+	if fromAlloc.fraction < 0 {
+		fromAlloc.fraction = 0
+	}
+	toAlloc.fraction += fraction
+
+	fromAlloc.limiter.SetLimit(rate.Limit(float64(b.total) * fromAlloc.fraction))
+	toAlloc.limiter.SetLimit(rate.Limit(float64(b.total) * toAlloc.fraction))
+
+	logrus.WithField("allocator", "budget").Infof(
+		"Rebalanced: %q=%.0f%%, %q=%.0f%%",
+		from, fromAlloc.fraction*100, to, toAlloc.fraction*100,
+	)
+
+	return nil
+}
+
+// GiveAll transfers the entire budget to a single allocation. All other
+// allocations are set to zero. This is useful when a phase completes and
+// the remaining phase should get full throughput.
+func (b *BudgetAllocator) GiveAll(name string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	target, ok := b.allocations[name]
+	if !ok {
+		return fmt.Errorf("allocation %q not found", name)
+	}
+
+	for n, alloc := range b.allocations {
+		if n == name {
+			alloc.fraction = 1.0
+			alloc.limiter.SetLimit(b.total)
+		} else {
+			alloc.fraction = 0
+			alloc.limiter.SetLimit(0)
+		}
+	}
+
+	logrus.WithField("allocator", "budget").Infof(
+		"Gave full budget to %q: %.1f req/sec",
+		name, float64(target.limiter.rateLimiter.Limit()),
+	)
+
+	return nil
+}
+
+// Stats returns the total requests and wait time for all allocations.
+func (b *BudgetAllocator) Stats() map[string]struct {
+	Requests int64
+	Waited   string
+} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	stats := make(map[string]struct {
+		Requests int64
+		Waited   string
+	})
+	for name, alloc := range b.allocations {
+		reqs, waited := alloc.limiter.Stats()
+		stats[name] = struct {
+			Requests int64
+			Waited   string
+		}{reqs, waited.String()}
+	}
+	return stats
+}

--- a/promoter/image/ratelimit/budget_test.go
+++ b/promoter/image/ratelimit/budget_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"math"
+	"testing"
+
+	"golang.org/x/time/rate"
+)
+
+func TestBudgetAllocatorAllocate(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+
+	promo := ba.Allocate("promotion", 0.7)
+	sign := ba.Allocate("signing", 0.3)
+
+	if promo == nil || sign == nil {
+		t.Fatal("Allocate returned nil")
+	}
+
+	// Verify rates are correctly partitioned.
+	promoLimit := promo.rateLimiter.Limit()
+	signLimit := sign.rateLimiter.Limit()
+
+	if math.Abs(float64(promoLimit)-70.0) > 0.1 {
+		t.Errorf("expected promotion limit ~70, got %v", promoLimit)
+	}
+	if math.Abs(float64(signLimit)-30.0) > 0.1 {
+		t.Errorf("expected signing limit ~30, got %v", signLimit)
+	}
+}
+
+func TestBudgetAllocatorGet(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	ba.Allocate("test", 0.5)
+
+	rt, err := ba.Get("test")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if rt.Name() != "test" {
+		t.Errorf("expected name 'test', got %q", rt.Name())
+	}
+
+	_, err = ba.Get("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent allocation")
+	}
+}
+
+func TestBudgetAllocatorRebalance(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	promo := ba.Allocate("promotion", 0.7)
+	sign := ba.Allocate("signing", 0.3)
+
+	// Rebalance: move 20% from promotion to signing.
+	if err := ba.Rebalance("promotion", "signing", 0.2); err != nil {
+		t.Fatalf("Rebalance failed: %v", err)
+	}
+
+	promoLimit := promo.rateLimiter.Limit()
+	signLimit := sign.rateLimiter.Limit()
+
+	if math.Abs(float64(promoLimit)-50.0) > 0.1 {
+		t.Errorf("after rebalance, expected promotion limit ~50, got %v", promoLimit)
+	}
+	if math.Abs(float64(signLimit)-50.0) > 0.1 {
+		t.Errorf("after rebalance, expected signing limit ~50, got %v", signLimit)
+	}
+}
+
+func TestBudgetAllocatorRebalanceErrors(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	ba.Allocate("a", 0.5)
+
+	if err := ba.Rebalance("nonexistent", "a", 0.1); err == nil {
+		t.Error("expected error for nonexistent source")
+	}
+	if err := ba.Rebalance("a", "nonexistent", 0.1); err == nil {
+		t.Error("expected error for nonexistent destination")
+	}
+}
+
+func TestBudgetAllocatorGiveAll(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	promo := ba.Allocate("promotion", 0.7)
+	sign := ba.Allocate("signing", 0.3)
+
+	if err := ba.GiveAll("signing"); err != nil {
+		t.Fatalf("GiveAll failed: %v", err)
+	}
+
+	promoLimit := promo.rateLimiter.Limit()
+	signLimit := sign.rateLimiter.Limit()
+
+	if promoLimit != rate.Limit(0) {
+		t.Errorf("expected promotion limit 0 after GiveAll, got %v", promoLimit)
+	}
+	if math.Abs(float64(signLimit)-100.0) > 0.1 {
+		t.Errorf("expected signing limit ~100 after GiveAll, got %v", signLimit)
+	}
+}
+
+func TestBudgetAllocatorGiveAllError(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	if err := ba.GiveAll("nonexistent"); err == nil {
+		t.Error("expected error for nonexistent allocation")
+	}
+}
+
+func TestBudgetAllocatorRebalanceClampToZero(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	ba.Allocate("a", 0.3)
+	ba.Allocate("b", 0.7)
+
+	// Rebalance more than what 'a' has — should clamp to 0.
+	if err := ba.Rebalance("a", "b", 0.5); err != nil {
+		t.Fatalf("Rebalance failed: %v", err)
+	}
+
+	a, err := ba.Get("a")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if a.rateLimiter.Limit() != 0 {
+		t.Errorf("expected clamped limit 0, got %v", a.rateLimiter.Limit())
+	}
+}
+
+func TestBudgetAllocatorStats(t *testing.T) {
+	ba := NewBudgetAllocator(100)
+	ba.Allocate("a", 0.5)
+	ba.Allocate("b", 0.5)
+
+	stats := ba.Stats()
+	if len(stats) != 2 {
+		t.Errorf("expected 2 stats entries, got %d", len(stats))
+	}
+	if _, ok := stats["a"]; !ok {
+		t.Error("expected stats for 'a'")
+	}
+	if _, ok := stats["b"]; !ok {
+		t.Error("expected stats for 'b'")
+	}
+}

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -19,30 +19,53 @@ package ratelimit
 import (
 	"context"
 	"net/http"
+	"sync"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
 
 const (
-	burst = 1
+	// DefaultBurst allows small bursts while still respecting the per-second
+	// limit. Increased from 1 to reduce starvation under concurrent load.
+	DefaultBurst = 5
 
-	// Number of events to pass to the crane rate limiter to match the
-	// AR api limits:
+	// MaxEvents is the target request rate for Artifact Registry.
 	// https://github.com/kubernetes/registry.k8s.io/issues/153#issuecomment-1460913153
-	// bentheelder: (83*60=4980)
-	// Temp: We are temporarily dropping this from the max of 83 to
-	// two thirds while the rate limiter is instrumented everywhere.
-	MaxEvents = 50
+	// AR limit is ~83 req/sec (83*60=4980/min). We use 50 as a conservative
+	// target to leave headroom for retries and other API consumers.
+	MaxEvents rate.Limit = 50
+
+	// backoffDuration is how long to pause after receiving a 429 response.
+	backoffDuration = 10 * time.Second
+
+	// backoffCooldown is the minimum interval between backoff events to
+	// prevent repeated 429s from causing excessive pausing.
+	backoffCooldown = 15 * time.Second
 )
 
-// RoundTripper wraps an http.RoundTripper with rate limiting.
+// RoundTripper wraps an http.RoundTripper with rate limiting and adaptive
+// backoff on 429 responses.
 type RoundTripper struct {
+	name         string
 	rateLimiter  *rate.Limiter
 	roundTripper http.RoundTripper
+
+	mu            sync.Mutex
+	lastBackoff   time.Time
+	backoffUntil  time.Time
+	totalWaited   time.Duration
+	totalRequests int64
 }
 
 var _ http.RoundTripper = &RoundTripper{}
 
+// Limiter is the global default rate limiter, kept for backwards compatibility.
+//
+// Deprecated: Use NewRoundTripper or a BudgetAllocator instead of the global
+// singleton. The global singleton causes promotion and signing to compete for
+// the same rate budget, leading to 429 errors under load.
 var Limiter *RoundTripper
 
 func init() {
@@ -51,21 +74,116 @@ func init() {
 	}
 }
 
+// NewRoundTripper creates a rate-limited HTTP transport with the given
+// requests-per-second limit.
 func NewRoundTripper(limit rate.Limit) *RoundTripper {
+	return NewNamedRoundTripper("default", limit, DefaultBurst)
+}
+
+// NewNamedRoundTripper creates a named rate-limited HTTP transport for
+// observability.
+func NewNamedRoundTripper(name string, limit rate.Limit, burst int) *RoundTripper {
 	return &RoundTripper{
+		name:         name,
 		rateLimiter:  rate.NewLimiter(limit, burst),
 		roundTripper: http.DefaultTransport,
 	}
 }
 
+// RoundTrip executes the HTTP request with rate limiting. All HTTP methods are
+// rate-limited because Artifact Registry quotas apply to both reads and writes.
+// If a 429 response is received, an adaptive backoff pauses future requests.
 func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	// only rate limit read type calls, not writes
-	if r.Method == http.MethodGet || r.Method == http.MethodHead {
-		err := rt.rateLimiter.Wait(context.Background())
-		if err != nil {
-			return nil, err
-		}
+	ctx := r.Context()
+
+	// Wait for any active backoff to expire.
+	rt.waitForBackoff(ctx)
+
+	// Wait for rate limiter token.
+	if err := rt.rateLimiter.Wait(ctx); err != nil {
+		return nil, err
 	}
 
-	return rt.roundTripper.RoundTrip(r)
+	rt.mu.Lock()
+	rt.totalRequests++
+	rt.mu.Unlock()
+
+	resp, err := rt.roundTripper.RoundTrip(r)
+	if err != nil {
+		return resp, err
+	}
+
+	// Adaptive backoff: if we get a 429, temporarily pause all requests
+	// through this limiter to let the quota recover.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		rt.triggerBackoff()
+	}
+
+	return resp, nil
+}
+
+// SetLimit changes the rate limit dynamically. This is used by BudgetAllocator
+// to rebalance budgets between phases.
+func (rt *RoundTripper) SetLimit(newLimit rate.Limit) {
+	rt.rateLimiter.SetLimit(newLimit)
+	logrus.WithField("limiter", rt.name).Infof(
+		"Rate limit adjusted to %.1f req/sec", float64(newLimit),
+	)
+}
+
+// SetBurst changes the burst limit dynamically.
+func (rt *RoundTripper) SetBurst(newBurst int) {
+	rt.rateLimiter.SetBurst(newBurst)
+}
+
+// Stats returns observability data about this rate limiter.
+func (rt *RoundTripper) Stats() (totalRequests int64, totalWaited time.Duration) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.totalRequests, rt.totalWaited
+}
+
+// Name returns the name of this rate limiter.
+func (rt *RoundTripper) Name() string {
+	return rt.name
+}
+
+func (rt *RoundTripper) waitForBackoff(ctx context.Context) {
+	rt.mu.Lock()
+	until := rt.backoffUntil
+	rt.mu.Unlock()
+
+	if until.IsZero() || time.Now().After(until) {
+		return
+	}
+
+	wait := time.Until(until)
+	logrus.WithField("limiter", rt.name).Warnf(
+		"Backoff active, waiting %s before next request", wait.Round(time.Millisecond),
+	)
+
+	select {
+	case <-time.After(wait):
+	case <-ctx.Done():
+	}
+
+	rt.mu.Lock()
+	rt.totalWaited += wait
+	rt.mu.Unlock()
+}
+
+func (rt *RoundTripper) triggerBackoff() {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	now := time.Now()
+	if now.Sub(rt.lastBackoff) < backoffCooldown {
+		return
+	}
+
+	rt.lastBackoff = now
+	rt.backoffUntil = now.Add(backoffDuration)
+	logrus.WithField("limiter", rt.name).Warnf(
+		"Received 429 Too Many Requests, backing off for %s", backoffDuration,
+	)
 }

--- a/promoter/image/ratelimit/roundtripper_test.go
+++ b/promoter/image/ratelimit/roundtripper_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func TestNewRoundTripper(t *testing.T) {
+	rt := NewRoundTripper(50)
+	if rt == nil {
+		t.Fatal("NewRoundTripper returned nil")
+	}
+	if rt.name != "default" {
+		t.Errorf("expected name 'default', got %q", rt.name)
+	}
+}
+
+func TestNewNamedRoundTripper(t *testing.T) {
+	rt := NewNamedRoundTripper("test", 100, 10)
+	if rt.Name() != "test" {
+		t.Errorf("expected name 'test', got %q", rt.Name())
+	}
+}
+
+func TestRoundTripRateLimitsAllMethods(t *testing.T) {
+	// Verify that all HTTP methods are rate-limited, not just GET/HEAD.
+	var requestCount atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Use a very low rate to make timing measurable.
+	rt := NewNamedRoundTripper("test", 5, 5)
+	client := &http.Client{Transport: rt}
+
+	methods := []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost, http.MethodPatch}
+	for _, method := range methods {
+		req, err := http.NewRequest(method, server.URL, http.NoBody)
+		if err != nil {
+			t.Fatalf("creating %s request: %v", method, err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%s request failed: %v", method, err)
+		}
+		resp.Body.Close()
+	}
+
+	if requestCount.Load() != int64(len(methods)) {
+		t.Errorf("expected %d requests, got %d", len(methods), requestCount.Load())
+	}
+}
+
+func TestAdaptiveBackoffOn429(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt := NewNamedRoundTripper("test", rate.Inf, 1)
+
+	client := &http.Client{Transport: rt}
+
+	// First request triggers 429 and backoff.
+	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	resp, reqErr := client.Do(req)
+	if reqErr != nil {
+		t.Fatalf("first request failed: %v", reqErr)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", resp.StatusCode)
+	}
+
+	// Verify backoff was triggered.
+	rt.mu.Lock()
+	hasBackoff := !rt.backoffUntil.IsZero()
+	rt.mu.Unlock()
+	if !hasBackoff {
+		t.Error("expected backoff to be triggered after 429")
+	}
+}
+
+func TestStatsTracking(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt := NewNamedRoundTripper("test", rate.Inf, 100)
+	client := &http.Client{Transport: rt}
+
+	for range 5 {
+		req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+		if err != nil {
+			t.Fatalf("creating request: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		resp.Body.Close()
+	}
+
+	reqs, _ := rt.Stats()
+	if reqs != 5 {
+		t.Errorf("expected 5 total requests, got %d", reqs)
+	}
+}
+
+func TestSetLimit(t *testing.T) {
+	rt := NewNamedRoundTripper("test", 10, 5)
+	rt.SetLimit(100)
+
+	if rt.rateLimiter.Limit() != 100 {
+		t.Errorf("expected limit 100, got %v", rt.rateLimiter.Limit())
+	}
+}
+
+func TestBackoffCooldown(t *testing.T) {
+	rt := NewNamedRoundTripper("test", rate.Inf, 1)
+
+	// Trigger first backoff.
+	rt.triggerBackoff()
+	rt.mu.Lock()
+	firstBackoff := rt.lastBackoff
+	rt.mu.Unlock()
+
+	// Immediate second trigger should be ignored (cooldown).
+	rt.triggerBackoff()
+	rt.mu.Lock()
+	secondBackoff := rt.lastBackoff
+	rt.mu.Unlock()
+
+	if !firstBackoff.Equal(secondBackoff) {
+		t.Error("expected second backoff to be ignored due to cooldown")
+	}
+}
+
+func TestGlobalLimiterBackwardsCompat(t *testing.T) {
+	// Verify the global Limiter is initialized.
+	if Limiter == nil {
+		t.Fatal("global Limiter should be initialized via init()")
+	}
+	if Limiter.rateLimiter.Limit() != MaxEvents {
+		t.Errorf("expected global limiter rate %v, got %v", MaxEvents, Limiter.rateLimiter.Limit())
+	}
+}
+
+func TestWaitForBackoffRespectsContext(t *testing.T) {
+	rt := NewNamedRoundTripper("test", rate.Inf, 1)
+
+	// Set a backoff far in the future.
+	rt.mu.Lock()
+	rt.backoffUntil = time.Now().Add(1 * time.Hour)
+	rt.mu.Unlock()
+
+	// Create a server that accepts requests.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Use a context with a short timeout.
+	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		rt.waitForBackoff(req.Context())
+		close(done)
+	}()
+
+	// The waitForBackoff should respect the context deadline.
+	// Since we didn't set a deadline, it would wait forever.
+	// Just verify it doesn't panic. The real protection is via
+	// request context deadlines in production.
+	select {
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still waiting because no context cancellation.
+	case <-done:
+		t.Error("waitForBackoff returned without context cancellation")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Rewrites the image promoter rate limiter to fix the root cause of frequent 429 failures in K8s core image promotion jobs (33min+, frequently failing).

- Rate-limit ALL HTTP methods, not just GET/HEAD
- Add adaptive backoff on 429 responses (10s backoff, 15s cooldown)
- Increase default burst from 1 to 5
- Add `BudgetAllocator` to partition rate limits between promotion (70%) and signing (30%), with runtime rebalancing after promotion completes
- Wire dedicated transports through `DefaultPromoterImplementation` instead of using the global singleton

#### Which issue(s) this PR fixes:

Part of #1701

#### Special notes for your reviewer:

Phase 1 of the promoter rewrite. This is the foundation that later phases build on. The deprecated global `Limiter` is kept for backwards compatibility and removed in a later phase.

#### Does this PR introduce a user-facing change?

```release-note
Rewrite image promoter rate limiter with per-operation budget allocation and adaptive 429 backoff.
```