### PR TITLE
Abstract registry and auth operations behind interfaces

### DIFF
--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -17,6 +17,7 @@ limitations under the License.
 package imagepromoter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -30,8 +31,10 @@ import (
 	"sigs.k8s.io/promo-tools/v4/internal/legacy/gcloud"
 	"sigs.k8s.io/promo-tools/v4/internal/legacy/stream"
 	"sigs.k8s.io/promo-tools/v4/internal/version"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/auth"
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
+	imgregistry "sigs.k8s.io/promo-tools/v4/promoter/image/registry"
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
@@ -59,6 +62,18 @@ type DefaultPromoterImplementation struct {
 	// signingTransport is the HTTP transport used for signature copy and
 	// replication. If nil, falls back to the global ratelimit.Limiter.
 	signingTransport *ratelimit.RoundTripper
+
+	// registryProvider abstracts registry operations (read inventory, copy images).
+	// If nil, the legacy SyncContext-based code path is used.
+	registryProvider imgregistry.Provider
+
+	// identityTokenProvider abstracts OIDC token generation for signing.
+	// If nil, falls back to direct GCP IAM API calls.
+	identityTokenProvider auth.IdentityTokenProvider
+
+	// serviceActivator abstracts service account activation.
+	// If nil, falls back to gcloud CLI calls.
+	serviceActivator auth.ServiceActivator
 }
 
 // NewDefaultPromoterImplementation creates a new DefaultPromoterImplementation instance.
@@ -86,6 +101,21 @@ func (di *DefaultPromoterImplementation) getSigningTransport() *ratelimit.RoundT
 	}
 	//nolint:staticcheck // Legacy fallback during transition to BudgetAllocator.
 	return ratelimit.Limiter
+}
+
+// SetRegistryProvider sets the registry provider for image operations.
+func (di *DefaultPromoterImplementation) SetRegistryProvider(p imgregistry.Provider) {
+	di.registryProvider = p
+}
+
+// SetIdentityTokenProvider sets the OIDC token provider for signing.
+func (di *DefaultPromoterImplementation) SetIdentityTokenProvider(p auth.IdentityTokenProvider) {
+	di.identityTokenProvider = p
+}
+
+// SetServiceActivator sets the service account activator.
+func (di *DefaultPromoterImplementation) SetServiceActivator(a auth.ServiceActivator) {
+	di.serviceActivator = a
 }
 
 // defaultSignerOptions returns a new *sign.Options with default values applied.
@@ -128,10 +158,14 @@ func (di *DefaultPromoterImplementation) ActivateServiceAccounts(opts *options.O
 	if !opts.UseServiceAcct {
 		logrus.Warn("Not setting a service account")
 	}
+	if di.serviceActivator != nil {
+		return di.serviceActivator.ActivateServiceAccounts(
+			context.Background(), opts.KeyFiles,
+		)
+	}
 	if err := gcloud.ActivateServiceAccounts(opts.KeyFiles); err != nil {
 		return fmt.Errorf("activating service accounts: %w", err)
 	}
-	// TODO: Output to log the accout used
 	return nil
 }
 

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -341,27 +341,31 @@ func (di *DefaultPromoterImplementation) WriteSBOMs(
 func (di *DefaultPromoterImplementation) GetIdentityToken(
 	opts *options.Options, serviceAccount string,
 ) (tok string, err error) {
-	credOptions := []gopts.ClientOption{}
 	// If the test signer file is found switch to test credentials
 	if os.Getenv("CIP_E2E_KEY_FILE") != "" {
 		logrus.Info("Test keyfile set using e2e test credentials")
-		// ... and also use the e2e signing identity
 		serviceAccount = TestSigningAccount
+	}
+
+	// Use the identity token provider interface when available.
+	if di.identityTokenProvider != nil {
+		return di.identityTokenProvider.GetIdentityToken(
+			context.Background(), serviceAccount, oidcTokenAudience,
+		)
+	}
+
+	// Legacy path: direct GCP IAM API calls.
+	credOptions := []gopts.ClientOption{}
+	if os.Getenv("CIP_E2E_KEY_FILE") != "" {
 		credOptions = []gopts.ClientOption{
 			//nolint:staticcheck // These are the credentials for the e2e tests.
 			gopts.WithCredentialsFile(os.Getenv("CIP_E2E_KEY_FILE")),
 		}
 	}
 
-	// If SignerInitCredentials, initialize the iam client using
-	// the identityu in that file instead of Default Application Credentials
 	if opts.SignerInitCredentials != "" {
 		logrus.Infof("Using credentials from %s", opts.SignerInitCredentials)
 		credOptions = []gopts.ClientOption{
-			// This next line is throwing warnings in the staticcheck linter.
-			// We should handle this entirely with token exchanges from the
-			// workload identity. But, for now, we'll leave this as is as
-			// the promoter is supposed to be getting a revamp soon.
 			//nolint:staticcheck
 			gopts.WithCredentialsFile(opts.SignerInitCredentials),
 		}
@@ -383,7 +387,7 @@ func (di *DefaultPromoterImplementation) GetIdentityToken(
 
 	resp, err := c.GenerateIdToken(ctx, req)
 	if err != nil {
-		return tok, fmt.Errorf("getting error account: %w", err)
+		return tok, fmt.Errorf("generating identity token: %w", err)
 	}
 
 	return resp.GetToken(), nil

--- a/promoter/image/auth/auth.go
+++ b/promoter/image/auth/auth.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+)
+
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+// IdentityTokenProvider returns OIDC identity tokens for image signing.
+//
+//counterfeiter:generate . IdentityTokenProvider
+type IdentityTokenProvider interface {
+	// GetIdentityToken returns an OIDC identity token for the given
+	// service account and audience (e.g., "sigstore").
+	GetIdentityToken(ctx context.Context, serviceAccount, audience string) (string, error)
+}
+
+// ServiceActivator activates service accounts for subsequent operations.
+//
+//counterfeiter:generate . ServiceActivator
+type ServiceActivator interface {
+	// ActivateServiceAccounts activates the service accounts specified
+	// by the given key file paths (comma-separated).
+	ActivateServiceAccounts(ctx context.Context, keyFilePaths string) error
+}

--- a/promoter/image/auth/auth_test.go
+++ b/promoter/image/auth/auth_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestStaticIdentityTokenProvider(t *testing.T) {
+	p := &StaticIdentityTokenProvider{Token: "oidc-token"}
+
+	tok, err := p.GetIdentityToken(context.Background(), "sa@proj.iam", "sigstore")
+	if err != nil {
+		t.Fatalf("GetIdentityToken() error = %v", err)
+	}
+	if tok != "oidc-token" {
+		t.Errorf("GetIdentityToken() = %q, want %q", tok, "oidc-token")
+	}
+}
+
+func TestStaticIdentityTokenProviderError(t *testing.T) {
+	p := &StaticIdentityTokenProvider{Err: errors.New("expired")}
+
+	_, err := p.GetIdentityToken(context.Background(), "sa", "aud")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNoopServiceActivator(t *testing.T) {
+	a := &NoopServiceActivator{}
+
+	err := a.ActivateServiceAccounts(context.Background(), "/path/to/key.json")
+	if err != nil {
+		t.Fatalf("ActivateServiceAccounts() error = %v", err)
+	}
+}
+
+func TestNoopServiceActivatorError(t *testing.T) {
+	a := &NoopServiceActivator{Err: errors.New("denied")}
+
+	err := a.ActivateServiceAccounts(context.Background(), "/path/to/key.json")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ IdentityTokenProvider = &StaticIdentityTokenProvider{}
+	_ ServiceActivator      = &NoopServiceActivator{}
+)

--- a/promoter/image/auth/gcp.go
+++ b/promoter/image/auth/gcp.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	credentials "cloud.google.com/go/iam/credentials/apiv1"
+	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
+	"github.com/sirupsen/logrus"
+	gopts "google.golang.org/api/option"
+
+	"sigs.k8s.io/promo-tools/v4/internal/legacy/gcloud"
+)
+
+// GCPIdentityTokenProvider implements IdentityTokenProvider using the
+// GCP IAM Credentials API.
+type GCPIdentityTokenProvider struct {
+	// CredentialsFile is an optional path to a credentials JSON file.
+	// If empty, Application Default Credentials are used.
+	CredentialsFile string
+}
+
+// GetIdentityToken generates an OIDC identity token for the given service
+// account using the GCP IAM Credentials API.
+func (g *GCPIdentityTokenProvider) GetIdentityToken(
+	ctx context.Context, serviceAccount, audience string,
+) (string, error) {
+	var clientOpts []gopts.ClientOption
+	if g.CredentialsFile != "" {
+		logrus.Infof("Using credentials from %s", g.CredentialsFile)
+		//nolint:staticcheck // Credentials file is user-provided for service account impersonation.
+		clientOpts = append(clientOpts, gopts.WithCredentialsFile(g.CredentialsFile))
+	}
+
+	c, err := credentials.NewIamCredentialsClient(ctx, clientOpts...)
+	if err != nil {
+		return "", fmt.Errorf("creating IAM credentials client: %w", err)
+	}
+	defer c.Close()
+
+	logrus.Infof("Signing identity for images will be %s", serviceAccount)
+
+	name := serviceAccount
+	if !strings.HasPrefix(name, "projects/") {
+		name = "projects/-/serviceAccounts/" + serviceAccount
+	}
+
+	resp, err := c.GenerateIdToken(ctx, &credentialspb.GenerateIdTokenRequest{
+		Name:         name,
+		Audience:     audience,
+		IncludeEmail: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("generating identity token: %w", err)
+	}
+
+	return resp.GetToken(), nil
+}
+
+// GCPServiceActivator implements ServiceActivator using gcloud CLI.
+type GCPServiceActivator struct{}
+
+// ActivateServiceAccounts activates service accounts via gcloud.
+func (g *GCPServiceActivator) ActivateServiceAccounts(_ context.Context, keyFilePaths string) error {
+	return gcloud.ActivateServiceAccounts(keyFilePaths)
+}

--- a/promoter/image/auth/static.go
+++ b/promoter/image/auth/static.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+)
+
+// StaticIdentityTokenProvider implements IdentityTokenProvider with a fixed token.
+type StaticIdentityTokenProvider struct {
+	// Token is returned for all GetIdentityToken calls.
+	Token string
+
+	// Err is returned for all GetIdentityToken calls if non-nil.
+	Err error
+}
+
+// GetIdentityToken returns the static identity token.
+func (s *StaticIdentityTokenProvider) GetIdentityToken(_ context.Context, _, _ string) (string, error) {
+	if s.Err != nil {
+		return "", fmt.Errorf("static identity token error: %w", s.Err)
+	}
+	return s.Token, nil
+}
+
+// NoopServiceActivator implements ServiceActivator as a no-op.
+// Useful for testing or environments that don't need service account activation.
+type NoopServiceActivator struct {
+	// Err is returned for all ActivateServiceAccounts calls if non-nil.
+	Err error
+}
+
+// ActivateServiceAccounts is a no-op.
+func (n *NoopServiceActivator) ActivateServiceAccounts(_ context.Context, _ string) error {
+	if n.Err != nil {
+		return fmt.Errorf("noop activator error: %w", n.Err)
+	}
+	return nil
+}

--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/google/go-containerregistry/pkg/name"
+	ggcrV1Google "github.com/google/go-containerregistry/pkg/v1/google"
+	cr "github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sirupsen/logrus"
+
+	legacyreg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+// CraneProvider implements Provider using go-containerregistry/crane and the
+// Google-specific extensions for optimized registry walking.
+type CraneProvider struct {
+	transport http.RoundTripper
+}
+
+// CraneOption configures a CraneProvider.
+type CraneOption func(*CraneProvider)
+
+// WithTransport sets the HTTP transport for registry operations.
+func WithTransport(rt http.RoundTripper) CraneOption {
+	return func(p *CraneProvider) {
+		p.transport = rt
+	}
+}
+
+// NewCraneProvider creates a new CraneProvider with the given options.
+func NewCraneProvider(opts ...CraneOption) *CraneProvider {
+	p := &CraneProvider{}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// ReadRegistries reads the image inventory from one or more registries using
+// google.Walk (recursive) or google.List (non-recursive).
+func (p *CraneProvider) ReadRegistries(
+	ctx context.Context, registries []RegistryConfig, recurse bool,
+) (*Inventory, error) {
+	logrus.Infof("Reading %d registries (recursive: %v)", len(registries), recurse)
+
+	inv := NewInventory()
+	var mu sync.Mutex
+
+	walkOpts := []ggcrV1Google.Option{
+		ggcrV1Google.WithAuthFromKeychain(gcrane.Keychain),
+		ggcrV1Google.WithContext(ctx),
+	}
+
+	for _, r := range registries {
+		repo, err := name.NewRepository(string(r.Name))
+		if err != nil {
+			return nil, fmt.Errorf("parsing repo name %s: %w", r.Name, err)
+		}
+
+		recordTags := makeTagRecorder(inv, &mu, registries)
+
+		if recurse {
+			if err := ggcrV1Google.Walk(repo, recordTags, walkOpts...); err != nil {
+				return nil, fmt.Errorf("walking repo %s: %w", r.Name, err)
+			}
+		} else {
+			tags, err := ggcrV1Google.List(repo, walkOpts...)
+			if err != nil {
+				return nil, fmt.Errorf("listing repo %s: %w", r.Name, err)
+			}
+			if err := recordTags(repo, tags, nil); err != nil {
+				return nil, fmt.Errorf("recording tags for %s: %w", r.Name, err)
+			}
+		}
+	}
+	return inv, nil
+}
+
+// CopyImage copies a container image from src to dst using crane.
+func (p *CraneProvider) CopyImage(_ context.Context, src, dst string) error {
+	opts := []crane.Option{
+		crane.WithAuthFromKeychain(gcrane.Keychain),
+		crane.WithUserAgent(image.UserAgent),
+	}
+	if p.transport != nil {
+		opts = append(opts, crane.WithTransport(p.transport))
+	}
+	return crane.Copy(src, dst, opts...)
+}
+
+// makeTagRecorder creates a callback function for google.Walk that records
+// found tags into the inventory.
+func makeTagRecorder(
+	inv *Inventory, mu *sync.Mutex, registries []RegistryConfig,
+) func(name.Repository, *ggcrV1Google.Tags, error) error {
+	return func(repo name.Repository, tags *ggcrV1Google.Tags, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walking registry: %w", walkErr)
+		}
+
+		regName, imageName, err := splitByKnownRegistries(
+			image.Registry(repo.Name()), registries,
+		)
+		if err != nil {
+			return fmt.Errorf("splitting repo and image name: %w", err)
+		}
+
+		logrus.Debugf("Registry: %s Image: %s Got: %s", regName, imageName, repo.Name())
+
+		digestTags := make(legacyreg.DigestTags)
+		if tags != nil && tags.Manifests != nil {
+			for digest, manifest := range tags.Manifests {
+				tagSlice := legacyreg.TagSlice{}
+				for _, tag := range manifest.Tags {
+					tagSlice = append(tagSlice, image.Tag(tag))
+				}
+				digestTags[image.Digest(digest)] = tagSlice
+
+				mediaType, err := supportedMediaType(manifest.MediaType)
+				if err != nil {
+					logrus.Errorf("Processing digest %s: %v", digest, err)
+				}
+
+				mu.Lock()
+				inv.MediaTypes[image.Digest(digest)] = mediaType
+				mu.Unlock()
+			}
+		}
+
+		logrus.Debugf("%d tags found", len(digestTags))
+
+		mu.Lock()
+		if _, ok := inv.Images[regName]; !ok {
+			inv.Images[regName] = make(legacyreg.RegInvImage)
+		}
+		if len(digestTags) > 0 {
+			inv.Images[regName][imageName] = digestTags
+		}
+		mu.Unlock()
+
+		return nil
+	}
+}
+
+// splitByKnownRegistries splits a full image path into the registry name
+// and image name components based on known registries.
+func splitByKnownRegistries(
+	fullName image.Registry, registries []RegistryConfig,
+) (image.Registry, image.Name, error) {
+	for _, r := range registries {
+		rn := string(r.Name)
+		fn := string(fullName)
+		if len(fn) > len(rn) && fn[:len(rn)] == rn && fn[len(rn)] == '/' {
+			return r.Name, image.Name(fn[len(rn)+1:]), nil
+		}
+		if fn == rn {
+			return r.Name, "", nil
+		}
+	}
+	return "", "", fmt.Errorf("could not determine registry for %s", fullName)
+}
+
+// supportedMediaType returns the appropriate MediaType, or an error if
+// the media type is not supported.
+func supportedMediaType(mediaType string) (cr.MediaType, error) {
+	switch cr.MediaType(mediaType) {
+	case cr.DockerManifestSchema2:
+		return cr.DockerManifestSchema2, nil
+	case cr.DockerManifestList:
+		return cr.DockerManifestList, nil
+	case cr.OCIManifestSchema1:
+		return cr.OCIManifestSchema1, nil
+	case cr.OCIImageIndex:
+		return cr.OCIImageIndex, nil
+	default:
+		// Default to DockerManifestSchema2 for backwards compatibility.
+		if mediaType == "" {
+			return cr.DockerManifestSchema2, nil
+		}
+		return cr.MediaType(mediaType),
+			fmt.Errorf("unsupported media type %q", mediaType)
+	}
+}

--- a/promoter/image/registry/fake.go
+++ b/promoter/image/registry/fake.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	legacyreg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+// FakeProvider is an in-memory implementation of Provider for testing.
+type FakeProvider struct {
+	mu sync.Mutex
+
+	// Inventory is the pre-populated inventory returned by ReadRegistries.
+	Inventory *Inventory
+
+	// CopiedImages records all src->dst copy calls.
+	CopiedImages []CopyRecord
+
+	// ReadRegistriesErr forces ReadRegistries to return this error.
+	ReadRegistriesErr error
+
+	// CopyImageErr forces CopyImage to return this error.
+	CopyImageErr error
+}
+
+// CopyRecord records the arguments to a CopyImage call.
+type CopyRecord struct {
+	Src, Dst string
+}
+
+// NewFakeProvider creates a FakeProvider with an empty inventory.
+func NewFakeProvider() *FakeProvider {
+	return &FakeProvider{
+		Inventory: NewInventory(),
+	}
+}
+
+// AddImage adds an image to the fake inventory.
+func (f *FakeProvider) AddImage(
+	reg image.Registry, name image.Name,
+	digest image.Digest, tags ...image.Tag,
+) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if _, ok := f.Inventory.Images[reg]; !ok {
+		f.Inventory.Images[reg] = make(legacyreg.RegInvImage)
+	}
+	if _, ok := f.Inventory.Images[reg][name]; !ok {
+		f.Inventory.Images[reg][name] = make(legacyreg.DigestTags)
+	}
+	f.Inventory.Images[reg][name][digest] = tags
+}
+
+// ReadRegistries returns the pre-populated inventory.
+func (f *FakeProvider) ReadRegistries(
+	_ context.Context, _ []RegistryConfig, _ bool,
+) (*Inventory, error) {
+	if f.ReadRegistriesErr != nil {
+		return nil, f.ReadRegistriesErr
+	}
+	return f.Inventory, nil
+}
+
+// CopyImage records the copy and returns the configured error.
+func (f *FakeProvider) CopyImage(_ context.Context, src, dst string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.CopiedImages = append(f.CopiedImages, CopyRecord{Src: src, Dst: dst})
+	if f.CopyImageErr != nil {
+		return fmt.Errorf("fake copy error: %w", f.CopyImageErr)
+	}
+	return nil
+}

--- a/promoter/image/registry/provider.go
+++ b/promoter/image/registry/provider.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+
+	cr "github.com/google/go-containerregistry/pkg/v1/types"
+
+	legacyreg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+// Provider defines operations for interacting with container image registries.
+//
+//counterfeiter:generate . Provider
+type Provider interface {
+	// ReadRegistries reads the image inventory from one or more registries.
+	// If recurse is true, child repositories are walked recursively.
+	ReadRegistries(ctx context.Context, registries []RegistryConfig, recurse bool) (*Inventory, error)
+
+	// CopyImage copies a container image from the source reference to the
+	// destination reference. References can be by digest (FQIN) or tag (PQIN).
+	CopyImage(ctx context.Context, src, dst string) error
+}
+
+// RegistryConfig describes a container image registry endpoint.
+type RegistryConfig struct {
+	// Name is the registry URL (e.g., "us-docker.pkg.dev/k8s-artifacts-prod/images").
+	Name image.Registry
+
+	// ServiceAccount is the service account used for authentication.
+	ServiceAccount string
+
+	// Src marks this registry as a source (staging) registry.
+	Src bool
+}
+
+// RegistryConfigFromContext converts a legacy registry.Context to a RegistryConfig.
+func RegistryConfigFromContext(rc legacyreg.Context) RegistryConfig {
+	return RegistryConfig{
+		Name:           rc.Name,
+		ServiceAccount: rc.ServiceAccount,
+		Src:            rc.Src,
+	}
+}
+
+// RegistryConfigsFromContexts converts a slice of legacy registry.Context to RegistryConfigs.
+func RegistryConfigsFromContexts(rcs []legacyreg.Context) []RegistryConfig {
+	configs := make([]RegistryConfig, len(rcs))
+	for i, rc := range rcs {
+		configs[i] = RegistryConfigFromContext(rc)
+	}
+	return configs
+}
+
+// Inventory holds the results of reading registry inventories.
+type Inventory struct {
+	// Images maps registry names to their image inventories.
+	Images map[image.Registry]legacyreg.RegInvImage
+
+	// MediaTypes maps digests to their OCI media types.
+	MediaTypes map[image.Digest]cr.MediaType
+}
+
+// NewInventory creates an empty Inventory.
+func NewInventory() *Inventory {
+	return &Inventory{
+		Images:     make(map[image.Registry]legacyreg.RegInvImage),
+		MediaTypes: make(map[image.Digest]cr.MediaType),
+	}
+}

--- a/promoter/image/registry/provider_test.go
+++ b/promoter/image/registry/provider_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	legacyreg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+func TestRegistryConfigFromContext(t *testing.T) {
+	rc := legacyreg.Context{
+		Name:           "gcr.io/k8s-staging-foo",
+		ServiceAccount: "sa@project.iam.gserviceaccount.com",
+		Src:            true,
+	}
+
+	config := RegistryConfigFromContext(rc)
+
+	if config.Name != rc.Name {
+		t.Errorf("Name = %q, want %q", config.Name, rc.Name)
+	}
+	if config.ServiceAccount != rc.ServiceAccount {
+		t.Errorf("ServiceAccount = %q, want %q", config.ServiceAccount, rc.ServiceAccount)
+	}
+	if config.Src != rc.Src {
+		t.Errorf("Src = %v, want %v", config.Src, rc.Src)
+	}
+}
+
+func TestRegistryConfigsFromContexts(t *testing.T) {
+	rcs := []legacyreg.Context{
+		{Name: "gcr.io/staging", Src: true},
+		{Name: "us-docker.pkg.dev/prod/images", Src: false},
+	}
+
+	configs := RegistryConfigsFromContexts(rcs)
+
+	if len(configs) != 2 {
+		t.Fatalf("len(configs) = %d, want 2", len(configs))
+	}
+	if configs[0].Name != "gcr.io/staging" {
+		t.Errorf("configs[0].Name = %q, want %q", configs[0].Name, "gcr.io/staging")
+	}
+	if !configs[0].Src {
+		t.Error("configs[0].Src = false, want true")
+	}
+	if configs[1].Name != "us-docker.pkg.dev/prod/images" {
+		t.Errorf("configs[1].Name = %q", configs[1].Name)
+	}
+}
+
+func TestNewInventory(t *testing.T) {
+	inv := NewInventory()
+
+	if inv.Images == nil {
+		t.Error("Images map is nil")
+	}
+	if inv.MediaTypes == nil {
+		t.Error("MediaTypes map is nil")
+	}
+}
+
+func TestFakeProviderAddImage(t *testing.T) {
+	f := NewFakeProvider()
+
+	reg := image.Registry("gcr.io/test")
+	name := image.Name("myimage")
+	digest := image.Digest("sha256:abc123")
+	tags := []image.Tag{"v1.0", "latest"}
+
+	f.AddImage(reg, name, digest, tags...)
+
+	if _, ok := f.Inventory.Images[reg]; !ok {
+		t.Fatal("registry not found in inventory")
+	}
+	if _, ok := f.Inventory.Images[reg][name]; !ok {
+		t.Fatal("image not found in inventory")
+	}
+	storedTags := f.Inventory.Images[reg][name][digest]
+	if len(storedTags) != 2 {
+		t.Fatalf("len(tags) = %d, want 2", len(storedTags))
+	}
+}
+
+func TestFakeProviderReadRegistries(t *testing.T) {
+	f := NewFakeProvider()
+	f.AddImage("gcr.io/test", "img", "sha256:abc", "v1")
+
+	inv, err := f.ReadRegistries(context.Background(), nil, false)
+	if err != nil {
+		t.Fatalf("ReadRegistries() error = %v", err)
+	}
+	if len(inv.Images) != 1 {
+		t.Errorf("len(Images) = %d, want 1", len(inv.Images))
+	}
+}
+
+func TestFakeProviderReadRegistriesError(t *testing.T) {
+	f := NewFakeProvider()
+	f.ReadRegistriesErr = errors.New("boom")
+
+	_, err := f.ReadRegistries(context.Background(), nil, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFakeProviderCopyImage(t *testing.T) {
+	f := NewFakeProvider()
+
+	err := f.CopyImage(context.Background(), "src:tag", "dst:tag")
+	if err != nil {
+		t.Fatalf("CopyImage() error = %v", err)
+	}
+	if len(f.CopiedImages) != 1 {
+		t.Fatalf("len(CopiedImages) = %d, want 1", len(f.CopiedImages))
+	}
+	if f.CopiedImages[0].Src != "src:tag" || f.CopiedImages[0].Dst != "dst:tag" {
+		t.Errorf("CopiedImages[0] = %+v", f.CopiedImages[0])
+	}
+}
+
+func TestFakeProviderCopyImageError(t *testing.T) {
+	f := NewFakeProvider()
+	f.CopyImageErr = errors.New("copy failed")
+
+	err := f.CopyImage(context.Background(), "src", "dst")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSplitByKnownRegistries(t *testing.T) {
+	registries := []RegistryConfig{
+		{Name: "gcr.io/k8s-staging-foo"},
+		{Name: "us-docker.pkg.dev/k8s-artifacts-prod/images"},
+	}
+
+	tests := []struct {
+		fullName    image.Registry
+		wantReg     image.Registry
+		wantImg     image.Name
+		expectError bool
+	}{
+		{
+			fullName: "gcr.io/k8s-staging-foo/myimage",
+			wantReg:  "gcr.io/k8s-staging-foo",
+			wantImg:  "myimage",
+		},
+		{
+			fullName: "gcr.io/k8s-staging-foo/sub/path/image",
+			wantReg:  "gcr.io/k8s-staging-foo",
+			wantImg:  "sub/path/image",
+		},
+		{
+			fullName: "us-docker.pkg.dev/k8s-artifacts-prod/images/kube-apiserver",
+			wantReg:  "us-docker.pkg.dev/k8s-artifacts-prod/images",
+			wantImg:  "kube-apiserver",
+		},
+		{
+			fullName:    "unknown.registry.io/foo",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.fullName), func(t *testing.T) {
+			reg, img, err := splitByKnownRegistries(tt.fullName, registries)
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if reg != tt.wantReg {
+				t.Errorf("reg = %q, want %q", reg, tt.wantReg)
+			}
+			if img != tt.wantImg {
+				t.Errorf("img = %q, want %q", img, tt.wantImg)
+			}
+		})
+	}
+}
+
+func TestSupportedMediaType(t *testing.T) {
+	tests := []struct {
+		input     string
+		expectErr bool
+	}{
+		{"application/vnd.docker.distribution.manifest.v2+json", false},
+		{"application/vnd.docker.distribution.manifest.list.v2+json", false},
+		{"application/vnd.oci.image.manifest.v1+json", false},
+		{"application/vnd.oci.image.index.v1+json", false},
+		{"", false}, // empty defaults to DockerManifestSchema2
+		{"application/vnd.unknown", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := supportedMediaType(tt.input)
+			if tt.expectErr && err == nil {
+				t.Error("expected error")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Phase 2 of #1701. Add `registry.Provider` and `auth` interfaces to decouple the promoter from concrete registry/auth implementations.

- `registry.Provider` interface with `ReadRegistries`/`CopyImage`, `CraneProvider` and `FakeProvider` implementations
- `auth.TokenProvider`, `auth.IdentityTokenProvider`, `auth.ServiceActivator` interfaces with GCP and static/noop implementations
- Wire optional interface fields into `DefaultPromoterImplementation` with fallback to legacy code paths

#### Which issue(s) this PR fixes:

Refers to #1701

#### Special notes for your reviewer:

Part of the promoter rewrite stack. Phase 1 was merged in #1702.

#### Does this PR introduce a user-facing change?

```release-note
None
```