### PR TITLE
Add pipeline engine for phased promotion workflow

### DIFF
--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -124,6 +124,10 @@ type Options struct {
 
 	// MaxSignatureOps maximum number of concurrent signature operations
 	MaxSignatureOps int
+
+	// UseLegacyPipeline uses the legacy sequential promotion code path
+	// instead of the new pipeline engine. Defaults to true during transition.
+	UseLegacyPipeline bool
 }
 
 var DefaultOptions = &Options{
@@ -141,6 +145,7 @@ var DefaultOptions = &Options{
 	SignCheckIssuerRegexp:   "",
 	MaxSignatureCopies:      50, // Maximum number of concurrent signature copies
 	MaxSignatureOps:         50, // Maximum number of concurrent signature operations
+	UseLegacyPipeline:       true,
 }
 
 func (o *Options) Validate() error {

--- a/promoter/image/pipeline/pipeline.go
+++ b/promoter/image/pipeline/pipeline.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pipeline provides a generic pipeline engine for orchestrating
+// promotion workflows. Each pipeline consists of ordered phases that
+// execute sequentially, sharing state through the caller's closures.
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ErrStopPipeline is a sentinel error that a phase can return to cleanly
+// stop the pipeline without indicating a failure. The pipeline's Run method
+// returns nil when this error is encountered.
+var ErrStopPipeline = errors.New("pipeline stopped")
+
+// Phase is a single step in the promotion pipeline.
+type Phase interface {
+	// Name returns a human-readable name for the phase (e.g., "plan", "promote").
+	Name() string
+
+	// Run executes the phase. It should return an error if the phase fails.
+	Run(ctx context.Context) error
+}
+
+// PhaseFunc adapts an ordinary function into a Phase.
+type PhaseFunc struct {
+	name string
+	fn   func(ctx context.Context) error
+}
+
+// NewPhase creates a Phase from a name and function.
+func NewPhase(name string, fn func(ctx context.Context) error) *PhaseFunc {
+	return &PhaseFunc{name: name, fn: fn}
+}
+
+// Name returns the phase name.
+func (p *PhaseFunc) Name() string { return p.name }
+
+// Run executes the phase function.
+func (p *PhaseFunc) Run(ctx context.Context) error { return p.fn(ctx) }
+
+// Pipeline orchestrates a sequence of phases.
+type Pipeline struct {
+	phases []Phase
+}
+
+// New creates an empty pipeline.
+func New() *Pipeline {
+	return &Pipeline{}
+}
+
+// AddPhase appends a phase to the pipeline and returns the pipeline
+// for chaining.
+func (p *Pipeline) AddPhase(phase Phase) *Pipeline {
+	p.phases = append(p.phases, phase)
+	return p
+}
+
+// Run executes all phases in order. If any phase fails, execution
+// stops and the error is returned.
+func (p *Pipeline) Run(ctx context.Context) error {
+	logrus.Infof("Pipeline starting with %d phases", len(p.phases))
+	start := time.Now()
+
+	for i, phase := range p.phases {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pipeline cancelled: %w", ctx.Err())
+		default:
+		}
+
+		logrus.Infof("Phase %d/%d: %s", i+1, len(p.phases), phase.Name())
+		phaseStart := time.Now()
+
+		if err := phase.Run(ctx); err != nil {
+			if errors.Is(err, ErrStopPipeline) {
+				logrus.Infof("Phase %q requested pipeline stop", phase.Name())
+				return nil
+			}
+			return fmt.Errorf("phase %q failed: %w", phase.Name(), err)
+		}
+
+		logrus.Infof("Phase %q completed in %s", phase.Name(), time.Since(phaseStart))
+	}
+
+	logrus.Infof("Pipeline completed in %s", time.Since(start))
+	return nil
+}
+
+// Phases returns the list of phases in the pipeline.
+func (p *Pipeline) Phases() []Phase {
+	return p.phases
+}

--- a/promoter/image/pipeline/pipeline_test.go
+++ b/promoter/image/pipeline/pipeline_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPipelineEmpty(t *testing.T) {
+	p := New()
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("empty pipeline should succeed, got: %v", err)
+	}
+}
+
+func TestPipelineExecutesInOrder(t *testing.T) {
+	var order []string
+
+	p := New()
+	p.AddPhase(NewPhase("first", func(_ context.Context) error {
+		order = append(order, "first")
+		return nil
+	}))
+	p.AddPhase(NewPhase("second", func(_ context.Context) error {
+		order = append(order, "second")
+		return nil
+	}))
+	p.AddPhase(NewPhase("third", func(_ context.Context) error {
+		order = append(order, "third")
+		return nil
+	}))
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(order) != 3 {
+		t.Fatalf("expected 3 phases, got %d", len(order))
+	}
+	for i, want := range []string{"first", "second", "third"} {
+		if order[i] != want {
+			t.Errorf("order[%d] = %q, want %q", i, order[i], want)
+		}
+	}
+}
+
+func TestPipelineStopsOnError(t *testing.T) {
+	var executed []string
+
+	p := New()
+	p.AddPhase(NewPhase("ok", func(_ context.Context) error {
+		executed = append(executed, "ok")
+		return nil
+	}))
+	p.AddPhase(NewPhase("fail", func(_ context.Context) error {
+		executed = append(executed, "fail")
+		return errors.New("boom")
+	}))
+	p.AddPhase(NewPhase("skipped", func(_ context.Context) error {
+		executed = append(executed, "skipped")
+		return nil
+	}))
+
+	err := p.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(executed) != 2 {
+		t.Fatalf("expected 2 phases executed, got %d: %v", len(executed), executed)
+	}
+	if executed[0] != "ok" || executed[1] != "fail" {
+		t.Errorf("unexpected execution order: %v", executed)
+	}
+}
+
+func TestPipelineCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	p := New()
+	p.AddPhase(NewPhase("should-not-run", func(_ context.Context) error {
+		t.Error("phase should not have run")
+		return nil
+	}))
+
+	err := p.Run(ctx)
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+}
+
+func TestPipelineChaining(t *testing.T) {
+	p := New().
+		AddPhase(NewPhase("a", func(_ context.Context) error { return nil })).
+		AddPhase(NewPhase("b", func(_ context.Context) error { return nil }))
+
+	if len(p.Phases()) != 2 {
+		t.Errorf("expected 2 phases, got %d", len(p.Phases()))
+	}
+}
+
+func TestPhaseFuncName(t *testing.T) {
+	p := NewPhase("test-phase", func(_ context.Context) error { return nil })
+	if p.Name() != "test-phase" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "test-phase")
+	}
+}
+
+func TestPipelinePassesContext(t *testing.T) {
+	type ctxKey string
+	key := ctxKey("test")
+
+	p := New()
+	p.AddPhase(NewPhase("check-ctx", func(ctx context.Context) error {
+		val := ctx.Value(key)
+		if val != "hello" {
+			t.Errorf("context value = %v, want %q", val, "hello")
+		}
+		return nil
+	}))
+
+	ctx := context.WithValue(context.Background(), key, "hello")
+	if err := p.Run(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPipelineErrStopPipeline(t *testing.T) {
+	var executed []string
+
+	p := New()
+	p.AddPhase(NewPhase("runs", func(_ context.Context) error {
+		executed = append(executed, "runs")
+		return nil
+	}))
+	p.AddPhase(NewPhase("stops", func(_ context.Context) error {
+		executed = append(executed, "stops")
+		return ErrStopPipeline
+	}))
+	p.AddPhase(NewPhase("skipped", func(_ context.Context) error {
+		executed = append(executed, "skipped")
+		return nil
+	}))
+
+	err := p.Run(context.Background())
+	if err != nil {
+		t.Fatalf("ErrStopPipeline should result in nil error, got: %v", err)
+	}
+	if len(executed) != 2 {
+		t.Fatalf("expected 2 phases, got %d: %v", len(executed), executed)
+	}
+	if executed[0] != "runs" || executed[1] != "stops" {
+		t.Errorf("unexpected order: %v", executed)
+	}
+}
+
+func TestPipelineSharedState(t *testing.T) {
+	// Verify that phases can share state through closures.
+	var result int
+
+	p := New()
+	p.AddPhase(NewPhase("produce", func(_ context.Context) error {
+		result = 42
+		return nil
+	}))
+	p.AddPhase(NewPhase("consume", func(_ context.Context) error {
+		if result != 42 {
+			t.Errorf("shared state = %d, want 42", result)
+		}
+		return nil
+	}))
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -19,6 +19,7 @@ package imagepromoter
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -29,6 +30,7 @@ import (
 	impl "sigs.k8s.io/promo-tools/v4/internal/promoter/image"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/checkresults"
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/pipeline"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 )
 
@@ -110,12 +112,120 @@ type promoterImplementation interface {
 	PrintSection(string, bool)
 }
 
-// PromoteImages is the main method for image promotion
-// it runs by taking all its parameters from a set of options.
-func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
-	logrus.Infof("PromoteImages start")
-	// Validate the options. Perhaps another image-specific
-	// validation function may be needed.
+// PromoteImages is the main method for image promotion.
+// It runs by taking all its parameters from a set of options.
+func (p *Promoter) PromoteImages(opts *options.Options) error {
+	if opts.UseLegacyPipeline {
+		return p.promoteImagesLegacy(opts)
+	}
+	return p.promoteImagesPipeline(opts)
+}
+
+// promoteImagesPipeline runs image promotion using the new pipeline engine.
+func (p *Promoter) promoteImagesPipeline(opts *options.Options) error {
+	// Shared state between pipeline phases, captured by closures.
+	var (
+		mfests         []schema.Manifest
+		sc             *reg.SyncContext
+		promotionEdges map[reg.PromotionEdge]interface{}
+	)
+
+	pipe := pipeline.New()
+
+	// Setup phase: validate, activate accounts, prewarm caches.
+	pipe.AddPhase(pipeline.NewPhase("setup", func(_ context.Context) error {
+		if err := p.impl.ValidateOptions(opts); err != nil {
+			return fmt.Errorf("validating options: %w", err)
+		}
+		if err := p.impl.ActivateServiceAccounts(opts); err != nil {
+			return fmt.Errorf("activating service accounts: %w", err)
+		}
+		if err := p.impl.PrewarmTUFCache(); err != nil {
+			return fmt.Errorf("prewarming TUF cache: %w", err)
+		}
+		return nil
+	}))
+
+	// Plan phase: parse manifests, build sync context, compute edges.
+	pipe.AddPhase(pipeline.NewPhase("plan", func(_ context.Context) error {
+		var err error
+		mfests, err = p.impl.ParseManifests(opts)
+		if err != nil {
+			return fmt.Errorf("parsing manifests: %w", err)
+		}
+
+		p.impl.PrintVersion()
+		p.impl.PrintSection("START (PROMOTION)", opts.Confirm)
+
+		sc, err = p.impl.MakeSyncContext(opts, mfests)
+		if err != nil {
+			return fmt.Errorf("creating sync context: %w", err)
+		}
+
+		promotionEdges, err = p.impl.GetPromotionEdges(sc, mfests)
+		if err != nil {
+			return fmt.Errorf("computing promotion edges: %w", err)
+		}
+
+		if opts.ParseOnly {
+			logrus.Info("Manifests parsed, exiting as ParseOnly is set")
+			return pipeline.ErrStopPipeline
+		}
+		return nil
+	}))
+
+	// Validate phase: check staging signatures.
+	pipe.AddPhase(pipeline.NewPhase("validate", func(_ context.Context) error {
+		if _, err := p.impl.ValidateStagingSignatures(promotionEdges); err != nil {
+			return fmt.Errorf("checking signatures in staging images: %w", err)
+		}
+
+		if !opts.Confirm {
+			if err := p.impl.PrecheckAndExit(opts, mfests); err != nil {
+				return err
+			}
+			return pipeline.ErrStopPipeline
+		}
+		return nil
+	}))
+
+	// Promote phase: copy images.
+	pipe.AddPhase(pipeline.NewPhase("promote", func(_ context.Context) error {
+		if err := p.impl.PromoteImages(sc, promotionEdges); err != nil {
+			return fmt.Errorf("running promotion: %w", err)
+		}
+
+		// Rebalance rate limit budget: give signing the full capacity.
+		if p.budget != nil {
+			if err := p.budget.GiveAll("signing"); err != nil {
+				logrus.WithError(err).Warn("Failed to rebalance rate limit budget")
+			}
+		}
+		return nil
+	}))
+
+	// Sign phase: sign promoted images.
+	pipe.AddPhase(pipeline.NewPhase("sign", func(_ context.Context) error {
+		if err := p.impl.SignImages(opts, sc, promotionEdges); err != nil {
+			return fmt.Errorf("signing images: %w", err)
+		}
+		return nil
+	}))
+
+	// Attest phase: write SBOMs and attestations.
+	pipe.AddPhase(pipeline.NewPhase("attest", func(_ context.Context) error {
+		if err := p.impl.WriteSBOMs(opts, sc, promotionEdges); err != nil {
+			return fmt.Errorf("writing SBOMs: %w", err)
+		}
+		return nil
+	}))
+
+	return pipe.Run(context.Background())
+}
+
+// promoteImagesLegacy is the original sequential promotion code path.
+func (p *Promoter) promoteImagesLegacy(opts *options.Options) (err error) {
+	logrus.Infof("PromoteImages start (legacy pipeline)")
 	if err := p.impl.ValidateOptions(opts); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
@@ -124,13 +234,10 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 		return fmt.Errorf("activating service accounts: %w", err)
 	}
 
-	// Prewarm the TUF cache with the targets and keys. This is done
-	// to avoid collisions when signing and verifying in parallel
 	if err := p.impl.PrewarmTUFCache(); err != nil {
 		return fmt.Errorf("prewarming TUF cache: %w", err)
 	}
 
-	logrus.Infof("Parsing manifests")
 	mfests, err := p.impl.ParseManifests(opts)
 	if err != nil {
 		return fmt.Errorf("parsing manifests: %w", err)
@@ -139,59 +246,47 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 	p.impl.PrintVersion()
 	p.impl.PrintSection("START (PROMOTION)", opts.Confirm)
 
-	logrus.Infof("Creating sync context manifests")
 	sc, err := p.impl.MakeSyncContext(opts, mfests)
 	if err != nil {
 		return fmt.Errorf("creating sync context: %w", err)
 	}
 
-	logrus.Infof("Getting promotion edges")
 	promotionEdges, err := p.impl.GetPromotionEdges(sc, mfests)
 	if err != nil {
 		return fmt.Errorf("filtering edges: %w", err)
 	}
 
-	// TODO: Let's rethink this option
 	if opts.ParseOnly {
 		logrus.Info("Manifests parsed, exiting as ParseOnly is set")
 		return nil
 	}
 
-	// Verify any signatures in staged images
-	logrus.Infof("Validating staging signatures")
 	if _, err := p.impl.ValidateStagingSignatures(promotionEdges); err != nil {
-		return fmt.Errorf("checking signtaures in staging images: %w", err)
+		return fmt.Errorf("checking signatures in staging images: %w", err)
 	}
 
-	// Check the pull request
 	if !opts.Confirm {
 		return p.impl.PrecheckAndExit(opts, mfests)
 	}
 
-	logrus.Infof("Promoting images")
 	if err := p.impl.PromoteImages(sc, promotionEdges); err != nil {
 		return fmt.Errorf("running promotion: %w", err)
 	}
 
-	// Promotion is done — give the full rate limit budget to signing,
-	// which is typically the bottleneck for large image sets.
 	if p.budget != nil {
 		if err := p.budget.GiveAll("signing"); err != nil {
 			logrus.WithError(err).Warn("Failed to rebalance rate limit budget")
 		}
 	}
 
-	logrus.Infof("Signing images")
 	if err := p.impl.SignImages(opts, sc, promotionEdges); err != nil {
 		return fmt.Errorf("signing images: %w", err)
 	}
 
-	logrus.Infof("Writing SBOMs")
 	if err := p.impl.WriteSBOMs(opts, sc, promotionEdges); err != nil {
 		return fmt.Errorf("writing SBOMs: %w", err)
 	}
 
-	logrus.Infof("Finish")
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Phase 3 of #1701. Add a generic pipeline engine and wire promotion phases as closures in `promoter.go`.

- `pipeline.Pipeline` engine with ordered `Phase` execution, context cancellation, and `ErrStopPipeline` for clean early termination
- `PhaseFunc` adapter to create phases from closures that capture shared state
- `PromoteImages()` dispatches to new pipeline or legacy path via `UseLegacyPipeline` option (defaults to legacy during transition)
- Pipeline phases: setup, plan, validate, promote, sign, attest

#### Which issue(s) this PR fixes:

Refers to #1701

#### Special notes for your reviewer:

Part of the promoter rewrite stack. Phase 2 was merged in #1704.

#### Does this PR introduce a user-facing change?

```release-note
None
```