### PR TITLE
Add provenance verification for staged images

### DIFF
--- a/internal/legacy/cli/run.go
+++ b/internal/legacy/cli/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -90,7 +91,7 @@ func RunPromoteCmd(opts *options.Options) error {
 	}
 
 	// Mode 4: Image promotion
-	if err := cip.PromoteImages(opts); err != nil {
+	if err := cip.PromoteImages(context.Background(), opts); err != nil {
 		return fmt.Errorf("promote images: %w", err)
 	}
 

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -128,6 +128,20 @@ type Options struct {
 	// UseLegacyPipeline uses the legacy sequential promotion code path
 	// instead of the new pipeline engine. Defaults to true during transition.
 	UseLegacyPipeline bool
+
+	// RequireProvenance controls whether provenance verification is required
+	// before promotion. When true, images without valid SLSA attestations
+	// are rejected. Defaults to false for backwards compatibility.
+	RequireProvenance bool
+
+	// AllowedBuilders is the list of acceptable builder identities for
+	// provenance verification (e.g., GCB builder URLs). If empty, any
+	// builder is accepted when RequireProvenance is true.
+	AllowedBuilders []string
+
+	// AllowedSourceRepos is the list of acceptable source repository URLs
+	// for provenance verification. If empty, any source repo is accepted.
+	AllowedSourceRepos []string
 }
 
 var DefaultOptions = &Options{

--- a/promoter/image/pipeline/pipeline.go
+++ b/promoter/image/pipeline/pipeline.go
@@ -106,8 +106,3 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	logrus.Infof("Pipeline completed in %s", time.Since(start))
 	return nil
 }
-
-// Phases returns the list of phases in the pipeline.
-func (p *Pipeline) Phases() []Phase {
-	return p.phases
-}

--- a/promoter/image/pipeline/pipeline_test.go
+++ b/promoter/image/pipeline/pipeline_test.go
@@ -110,8 +110,8 @@ func TestPipelineChaining(t *testing.T) {
 		AddPhase(NewPhase("a", func(_ context.Context) error { return nil })).
 		AddPhase(NewPhase("b", func(_ context.Context) error { return nil }))
 
-	if len(p.Phases()) != 2 {
-		t.Errorf("expected 2 phases, got %d", len(p.Phases()))
+	if len(p.phases) != 2 {
+		t.Errorf("expected 2 phases, got %d", len(p.phases))
 	}
 }
 

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/promo-tools/v4/promoter/image/checkresults"
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/pipeline"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/provenance"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 )
 
@@ -40,9 +41,10 @@ var AllowedOutputFormats = []string{
 }
 
 type Promoter struct {
-	Options *options.Options
-	impl    promoterImplementation
-	budget  *ratelimit.BudgetAllocator
+	Options            *options.Options
+	impl               promoterImplementation
+	budget             *ratelimit.BudgetAllocator
+	provenanceVerifier provenance.Verifier
 }
 
 func New(opts *options.Options) *Promoter {
@@ -66,6 +68,11 @@ func New(opts *options.Options) *Promoter {
 
 func (p *Promoter) SetImplementation(pi promoterImplementation) {
 	p.impl = pi
+}
+
+// SetProvenanceVerifier sets the provenance verifier used during promotion.
+func (p *Promoter) SetProvenanceVerifier(v provenance.Verifier) {
+	p.provenanceVerifier = v
 }
 
 //counterfeiter:generate . promoterImplementation
@@ -114,15 +121,15 @@ type promoterImplementation interface {
 
 // PromoteImages is the main method for image promotion.
 // It runs by taking all its parameters from a set of options.
-func (p *Promoter) PromoteImages(opts *options.Options) error {
+func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) error {
 	if opts.UseLegacyPipeline {
 		return p.promoteImagesLegacy(opts)
 	}
-	return p.promoteImagesPipeline(opts)
+	return p.promoteImagesPipeline(ctx, opts)
 }
 
 // promoteImagesPipeline runs image promotion using the new pipeline engine.
-func (p *Promoter) promoteImagesPipeline(opts *options.Options) error {
+func (p *Promoter) promoteImagesPipeline(ctx context.Context, opts *options.Options) error {
 	// Shared state between pipeline phases, captured by closures.
 	var (
 		mfests         []schema.Manifest
@@ -174,6 +181,35 @@ func (p *Promoter) promoteImagesPipeline(opts *options.Options) error {
 		return nil
 	}))
 
+	// Provenance phase: verify image provenance (optional).
+	pipe.AddPhase(pipeline.NewPhase("provenance", func(ctx context.Context) error {
+		if !opts.RequireProvenance {
+			logrus.Debug("Provenance verification disabled (--require-provenance=false)")
+			return nil
+		}
+
+		verifier := p.provenanceVerifier
+		if verifier == nil {
+			verifier = &provenance.NoopVerifier{}
+		}
+
+		for edge := range promotionEdges {
+			ref := edge.SrcReference()
+			if ref == "" {
+				continue
+			}
+			result, err := verifier.Verify(ctx, ref)
+			if err != nil {
+				return fmt.Errorf("verifying provenance for %s: %w", ref, err)
+			}
+			if !result.Verified {
+				return fmt.Errorf("provenance verification failed for %s: %v",
+					ref, result.Errors)
+			}
+		}
+		return nil
+	}))
+
 	// Validate phase: check staging signatures.
 	pipe.AddPhase(pipeline.NewPhase("validate", func(_ context.Context) error {
 		if _, err := p.impl.ValidateStagingSignatures(promotionEdges); err != nil {
@@ -220,11 +256,11 @@ func (p *Promoter) promoteImagesPipeline(opts *options.Options) error {
 		return nil
 	}))
 
-	return pipe.Run(context.Background())
+	return pipe.Run(ctx)
 }
 
 // promoteImagesLegacy is the original sequential promotion code path.
-func (p *Promoter) promoteImagesLegacy(opts *options.Options) (err error) {
+func (p *Promoter) promoteImagesLegacy(opts *options.Options) error {
 	logrus.Infof("PromoteImages start (legacy pipeline)")
 	if err := p.impl.ValidateOptions(opts); err != nil {
 		return fmt.Errorf("validating options: %w", err)

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -17,111 +17,264 @@ limitations under the License.
 package imagepromoter_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	reg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry/registry"
 	imagepromoter "sigs.k8s.io/promo-tools/v4/promoter/image"
 	imagefakes "sigs.k8s.io/promo-tools/v4/promoter/image/imagefakes"
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/provenance"
+	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
-func TestPromoteImages(t *testing.T) {
-	sut := imagepromoter.Promoter{}
+// promoteImagesErrorCases returns the common error injection test cases
+// used by both pipeline and legacy path tests.
+func promoteImagesErrorCases() []struct {
+	shouldErr bool
+	msg       string
+	prepare   func(*imagefakes.FakePromoterImplementation)
+} {
 	testErr := errors.New("synthetic error")
-	for _, tc := range []struct {
+	return []struct {
 		shouldErr bool
 		msg       string
 		prepare   func(*imagefakes.FakePromoterImplementation)
 	}{
 		{
-			// No errors
 			shouldErr: false,
 			msg:       "No errors",
 			prepare:   func(_ *imagefakes.FakePromoterImplementation) {},
 		},
 		{
-			// ValidateOptions fails
 			shouldErr: true,
+			msg:       "ValidateOptions fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.ValidateOptionsReturns(testErr)
 			},
 		},
 		{
-			// ActivateServiceAccountsrseManifests fails
 			shouldErr: true,
+			msg:       "ActivateServiceAccounts fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.ActivateServiceAccountsReturns(testErr)
 			},
 		},
 		{
-			// PrewarmTUFCache fails
 			shouldErr: true,
+			msg:       "PrewarmTUFCache fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.PrewarmTUFCacheReturns(testErr)
 			},
 		},
 		{
-			// ParseManifests fails
 			shouldErr: true,
+			msg:       "ParseManifests fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.ParseManifestsReturns(nil, testErr)
 			},
 		},
 		{
-			// MakeSyncContext fails
 			shouldErr: true,
+			msg:       "MakeSyncContext fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.MakeSyncContextReturns(nil, testErr)
 			},
 		},
 		{
-			// GetPromotionEdges fails
 			shouldErr: true,
+			msg:       "GetPromotionEdges fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.GetPromotionEdgesReturns(nil, testErr)
 			},
 		},
 		{
-			// ValidateStagingSignatures fails
 			shouldErr: true,
+			msg:       "ValidateStagingSignatures fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
 				fpi.ValidateStagingSignaturesReturns(nil, testErr)
 			},
 		},
 		{
-			// PromoteImages fails
 			shouldErr: true,
+			msg:       "PromoteImages fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
 				fpi.PromoteImagesReturns(testErr)
 			},
 		},
 		{
-			// SignImages fails
 			shouldErr: true,
+			msg:       "SignImages fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
 				fpi.SignImagesReturns(testErr)
 			},
 		},
 		{
-			// WriteSBOMs fails
 			shouldErr: true,
+			msg:       "WriteSBOMs fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
 				fpi.WriteSBOMsReturns(testErr)
 			},
 		},
-	} {
-		mock := imagefakes.FakePromoterImplementation{}
-		tc.prepare(&mock)
-		sut.SetImplementation(&mock)
-		if tc.shouldErr {
-			require.Error(t, sut.PromoteImages(&options.Options{Confirm: true}), tc.msg)
-		}
 	}
+}
+
+func TestPromoteImagesPipeline(t *testing.T) {
+	for _, tc := range promoteImagesErrorCases() {
+		t.Run(tc.msg, func(t *testing.T) {
+			sut := imagepromoter.Promoter{}
+			mock := imagefakes.FakePromoterImplementation{}
+			tc.prepare(&mock)
+			sut.SetImplementation(&mock)
+			err := sut.PromoteImages(context.Background(), &options.Options{Confirm: true})
+			if tc.shouldErr {
+				require.Error(t, err, tc.msg)
+			} else {
+				require.NoError(t, err, tc.msg)
+			}
+		})
+	}
+}
+
+func TestPromoteImagesLegacy(t *testing.T) {
+	for _, tc := range promoteImagesErrorCases() {
+		t.Run(tc.msg, func(t *testing.T) {
+			sut := imagepromoter.Promoter{}
+			mock := imagefakes.FakePromoterImplementation{}
+			tc.prepare(&mock)
+			sut.SetImplementation(&mock)
+			err := sut.PromoteImages(context.Background(), &options.Options{
+				Confirm:           true,
+				UseLegacyPipeline: true,
+			})
+			if tc.shouldErr {
+				require.Error(t, err, tc.msg)
+			} else {
+				require.NoError(t, err, tc.msg)
+			}
+		})
+	}
+}
+
+func TestPromoteImagesPipelineParseOnly(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// ParseOnly should stop the pipeline after the plan phase without error.
+	err := sut.PromoteImages(context.Background(), &options.Options{
+		Confirm:   true,
+		ParseOnly: true,
+	})
+	require.NoError(t, err)
+
+	// PromoteImages (on the impl) should never have been called.
+	require.Equal(t, 0, mock.PromoteImagesCallCount())
+}
+
+func TestPromoteImagesPipelineDryRun(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// Confirm=false should stop the pipeline after the validate phase without error.
+	err := sut.PromoteImages(context.Background(), &options.Options{
+		Confirm: false,
+	})
+	require.NoError(t, err)
+
+	// ValidateStagingSignatures should have been called (validate phase ran).
+	require.Equal(t, 1, mock.ValidateStagingSignaturesCallCount())
+
+	// PromoteImages (on the impl) should never have been called.
+	require.Equal(t, 0, mock.PromoteImagesCallCount())
+}
+
+// fakeVerifier implements provenance.Verifier for testing.
+type fakeVerifier struct {
+	result *provenance.Result
+	err    error
+}
+
+func (f *fakeVerifier) Verify(_ context.Context, _ string) (*provenance.Result, error) {
+	return f.result, f.err
+}
+
+// testEdge returns a PromotionEdge with non-empty fields so that
+// SrcReference() returns a valid reference string.
+func testEdge() reg.PromotionEdge {
+	return reg.PromotionEdge{
+		SrcRegistry: registry.Context{Name: image.Registry("gcr.io/staging")},
+		SrcImageTag: reg.ImageTag{
+			Name: image.Name("test-image"),
+			Tag:  image.Tag("v1"),
+		},
+		Digest: image.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	}
+}
+
+func TestPromoteImagesPipelineProvenanceNoopFallback(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// RequireProvenance=true with no verifier set should use the noop
+	// verifier and succeed.
+	err := sut.PromoteImages(context.Background(), &options.Options{
+		Confirm:           true,
+		RequireProvenance: true,
+	})
+	require.NoError(t, err)
+}
+
+func TestPromoteImagesPipelineProvenanceFails(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	mock.GetPromotionEdgesReturns(map[reg.PromotionEdge]interface{}{
+		testEdge(): nil,
+	}, nil)
+	sut.SetImplementation(&mock)
+
+	sut.SetProvenanceVerifier(&fakeVerifier{
+		result: &provenance.Result{
+			Verified: false,
+			Errors:   []string{"no attestation found"},
+		},
+	})
+
+	err := sut.PromoteImages(context.Background(), &options.Options{
+		Confirm:           true,
+		RequireProvenance: true,
+	})
+	require.Error(t, err)
+
+	// Promotion should not have been called.
+	require.Equal(t, 0, mock.PromoteImagesCallCount())
+}
+
+func TestPromoteImagesPipelineProvenanceVerifierError(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	mock.GetPromotionEdgesReturns(map[reg.PromotionEdge]interface{}{
+		testEdge(): nil,
+	}, nil)
+	sut.SetImplementation(&mock)
+
+	sut.SetProvenanceVerifier(&fakeVerifier{
+		err: errors.New("connection refused"),
+	})
+
+	err := sut.PromoteImages(context.Background(), &options.Options{
+		Confirm:           true,
+		RequireProvenance: true,
+	})
+	require.Error(t, err)
 }

--- a/promoter/image/provenance/cosign.go
+++ b/promoter/image/provenance/cosign.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provenance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+const attestationTagSuffix = ".att"
+
+// CosignVerifier checks for the existence of SLSA attestations
+// attached to container images using the cosign attestation tag convention.
+//
+// Currently this only verifies that an attestation tag exists — it does
+// not inspect the attestation contents or enforce Policy.AllowedBuilders
+// / AllowedSourceRepos. Policy enforcement will be added in a follow-up.
+type CosignVerifier struct{}
+
+// Verify checks whether the image has a SLSA attestation attached.
+// It looks for an attestation tag following the cosign convention
+// (sha256-<hash>.att).
+//
+// Note: crane.Manifest does not accept a context, so cancellation is
+// not propagated to the underlying HTTP call.
+func (v *CosignVerifier) Verify(ctx context.Context, ref string) (*Result, error) {
+	_ = ctx // crane.Manifest does not support context
+	result := &Result{}
+
+	parsedRef, err := name.ParseReference(ref)
+	if err != nil {
+		return nil, fmt.Errorf("parsing reference %q: %w", ref, err)
+	}
+
+	// Extract the digest to derive the attestation tag.
+	digest, ok := parsedRef.(name.Digest)
+	if !ok {
+		return nil, fmt.Errorf("reference %q must include a digest", ref)
+	}
+
+	attTag := digestToAttestationTag(image.Digest(digest.DigestStr()))
+	attRef := fmt.Sprintf("%s/%s:%s",
+		digest.Context().RegistryStr(),
+		digest.Context().RepositoryStr(),
+		attTag,
+	)
+
+	logrus.Debugf("Checking attestation at %s", attRef)
+
+	// Check if the attestation tag exists.
+	opts := []crane.Option{
+		crane.WithAuthFromKeychain(gcrane.Keychain),
+		crane.WithUserAgent(image.UserAgent),
+	}
+
+	_, err = crane.Manifest(attRef, opts...)
+	if err != nil {
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			result.Verified = false
+			result.Errors = append(result.Errors,
+				"no attestation found for "+ref)
+			return result, nil
+		}
+		return nil, fmt.Errorf("checking attestation for %s: %w", ref, err)
+	}
+
+	result.Verified = true
+	logrus.Debugf("Attestation found for %s", ref)
+	return result, nil
+}
+
+// digestToAttestationTag converts a digest to the cosign attestation tag.
+func digestToAttestationTag(dg image.Digest) string {
+	return strings.ReplaceAll(string(dg), "sha256:", "sha256-") + attestationTagSuffix
+}

--- a/promoter/image/provenance/noop.go
+++ b/promoter/image/provenance/noop.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provenance
+
+import (
+	"context"
+)
+
+// NoopVerifier always returns a successful verification result.
+// Used when provenance verification is disabled.
+type NoopVerifier struct{}
+
+// Verify always returns a successful result.
+func (n *NoopVerifier) Verify(_ context.Context, _ string) (*Result, error) {
+	return &Result{Verified: true}, nil
+}

--- a/promoter/image/provenance/provenance.go
+++ b/promoter/image/provenance/provenance.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package provenance provides interfaces and implementations for verifying
+// the provenance of container images before promotion. This includes
+// checking SLSA attestations, builder identity, and source repository
+// against configurable policies.
+package provenance
+
+import (
+	"context"
+)
+
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+// Verifier checks the provenance of a container image.
+//
+//counterfeiter:generate . Verifier
+type Verifier interface {
+	// Verify checks whether the image at the given reference has valid
+	// provenance according to the configured policy. The reference
+	// should be a fully qualified image reference including digest
+	// (e.g., "gcr.io/staging/image@sha256:abc...").
+	Verify(ctx context.Context, ref string) (*Result, error)
+}
+
+// Result describes the outcome of a provenance verification.
+type Result struct {
+	// Verified is true if the image has valid provenance.
+	Verified bool
+
+	// Builder is the identity of the build system that produced the image
+	// (e.g., "https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3").
+	Builder string
+
+	// SourceRepo is the source repository URL from the provenance
+	// (e.g., "https://github.com/kubernetes/kubernetes").
+	SourceRepo string
+
+	// Errors lists any issues found during verification.
+	Errors []string
+}
+
+// Policy defines the provenance requirements for image promotion.
+type Policy struct {
+	// RequireProvenance controls whether provenance verification is mandatory.
+	// When false, images without provenance are allowed through.
+	RequireProvenance bool
+
+	// AllowedBuilders is the list of acceptable builder identities.
+	// If empty, any builder is accepted.
+	AllowedBuilders []string
+
+	// AllowedSourceRepos is the list of acceptable source repositories.
+	// If empty, any source repo is accepted.
+	AllowedSourceRepos []string
+}

--- a/promoter/image/provenance/provenance_test.go
+++ b/promoter/image/provenance/provenance_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provenance
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+func TestNoopVerifier(t *testing.T) {
+	v := &NoopVerifier{}
+	result, err := v.Verify(context.Background(), "gcr.io/test/image@sha256:abc")
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !result.Verified {
+		t.Error("NoopVerifier should always return Verified=true")
+	}
+}
+
+func TestDigestToAttestationTag(t *testing.T) {
+	tests := []struct {
+		digest image.Digest
+		want   string
+	}{
+		{
+			"sha256:abc123",
+			"sha256-abc123.att",
+		},
+		{
+			"sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			"sha256-0000000000000000000000000000000000000000000000000000000000000000.att",
+		},
+	}
+
+	for _, tt := range tests {
+		got := digestToAttestationTag(tt.digest)
+		if got != tt.want {
+			t.Errorf("digestToAttestationTag(%q) = %q, want %q", tt.digest, got, tt.want)
+		}
+	}
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ Verifier = &NoopVerifier{}
+	_ Verifier = &CosignVerifier{}
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Phase 4 of #1701. Adds provenance verification interfaces and pipeline improvements.

**Provenance:**
- `provenance.Verifier` interface with `CosignVerifier` (attestation tag existence check) and `NoopVerifier`
- Provenance phase wired between plan and validate in the pipeline
- `RequireProvenance`, `AllowedBuilders`, `AllowedSourceRepos` options (policy enforcement deferred to follow-up)
- `CosignVerifier` uses `transport.Error` status code for reliable 404 detection instead of error string matching

**Pipeline improvements (from phase 3):**
- Thread `context.Context` through `PromoteImages` for cancellation support
- Remove unnecessary named return from `promoteImagesLegacy`
- Split tests into pipeline/legacy paths with `ErrStopPipeline` coverage
- Add provenance phase integration tests (noop fallback, verifier failure, verifier error)
- Unexport `Phases()` getter in pipeline package

#### Which issue(s) this PR fixes:

Refers to #1701

#### Special notes for your reviewer:

Part of the promoter rewrite stack. Phase 3 was merged in #1705. Includes cleanup improvements from the phase 3 review. Docs are updated in phase 7 (remove legacy pipeline).

#### Does this PR introduce a user-facing change?

```release-note
None
```