### PR TITLE
Add vuln scanner and SBOM support, flip to new pipeline engine

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -253,4 +253,32 @@ check. Found vulnerabilities at or above this threshold will result in the
 vulnerability check failing [severity levels between 0 and 5; 0 - UNSPECIFIED,
 1 - MINIMAL, 2 - LOW, 3 - MEDIUM, 4 - HIGH, 5 - CRITICAL]`,
 	)
+
+	CipCmd.PersistentFlags().BoolVar(
+		&runOpts.UseLegacyPipeline, //nolint:staticcheck // intentional deprecated flag
+		"use-legacy-pipeline",
+		options.DefaultOptions.UseLegacyPipeline, //nolint:staticcheck // intentional deprecated flag
+		"use the legacy sequential promotion code path instead of the new pipeline engine",
+	)
+
+	CipCmd.PersistentFlags().BoolVar(
+		&runOpts.RequireProvenance,
+		"require-provenance",
+		options.DefaultOptions.RequireProvenance,
+		"require valid SLSA provenance attestations before promotion",
+	)
+
+	CipCmd.PersistentFlags().StringSliceVar(
+		&runOpts.AllowedBuilders,
+		"allowed-builders",
+		options.DefaultOptions.AllowedBuilders,
+		"comma-separated list of acceptable builder identities for provenance verification",
+	)
+
+	CipCmd.PersistentFlags().StringSliceVar(
+		&runOpts.AllowedSourceRepos,
+		"allowed-source-repos",
+		options.DefaultOptions.AllowedSourceRepos,
+		"comma-separated list of acceptable source repository URLs for provenance verification",
+	)
 }

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -18,7 +18,9 @@ package imagepromoter
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/nozzle/throttler"
 	"github.com/sigstore/sigstore/pkg/tuf"
 	"github.com/sirupsen/logrus"
@@ -44,6 +47,7 @@ import (
 const (
 	oidcTokenAudience  = "sigstore"
 	signatureTagSuffix = ".sig"
+	sbomTagSuffix      = ".sbom"
 
 	TestSigningAccount = "k8s-infra-promoter-test-signer@k8s-cip-test-prod.iam.gserviceaccount.com"
 )
@@ -60,7 +64,7 @@ func (di *DefaultPromoterImplementation) ValidateStagingSignatures(
 		refsToEdges[ref] = edge
 	}
 
-	refs := []string{}
+	refs := make([]string, 0, len(refsToEdges))
 	for ref := range refsToEdges {
 		refs = append(refs, ref)
 	}
@@ -258,7 +262,8 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *reg.Promotion
 	if err := crane.Copy(srcRef.String(), dstRef.String(), craneOpts...); err != nil {
 		// If the signature layer does not exist it means that the src image
 		// is not signed, so we catch the error and return nil
-		if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
 			logrus.Debugf("Reference %s is not signed, not copying", srcRef.String())
 			return nil
 		}
@@ -327,12 +332,69 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	return nil
 }
 
-// WriteSBOMs writes SBOMs to each of the newly promoted images and stores
-// them along the signatures in the registry.
+// WriteSBOMs copies pre-generated SBOMs from the staging registry to each
+// production registry for the promoted images. SBOMs are expected to be
+// attached in staging (e.g., by the build system) and are identified by
+// the cosign SBOM tag convention (sha256-<hash>.sbom).
 func (di *DefaultPromoterImplementation) WriteSBOMs(
-	_ *options.Options, _ *reg.SyncContext, _ map[reg.PromotionEdge]interface{},
+	_ *options.Options, _ *reg.SyncContext, edges map[reg.PromotionEdge]interface{},
 ) error {
+	if len(edges) == 0 {
+		logrus.Info("No images were promoted. No SBOMs to copy.")
+		return nil
+	}
+
+	for edge := range edges {
+		// Skip signature and attestation layers
+		if strings.HasSuffix(string(edge.DstImageTag.Tag), ".sig") ||
+			strings.HasSuffix(string(edge.DstImageTag.Tag), ".att") ||
+			strings.HasSuffix(string(edge.DstImageTag.Tag), ".sbom") ||
+			edge.DstImageTag.Tag == "" {
+			continue
+		}
+
+		if err := di.copySBOM(&edge); err != nil {
+			return fmt.Errorf("copying SBOM for %s: %w", edge.DstReference(), err)
+		}
+	}
+
 	return nil
+}
+
+// copySBOM copies an SBOM from the staging registry to the production registry
+// for a single promotion edge. If no SBOM exists in staging, this is not an error.
+func (di *DefaultPromoterImplementation) copySBOM(edge *reg.PromotionEdge) error {
+	sbomTag := digestToSBOMTag(edge.Digest)
+	srcRefString := fmt.Sprintf(
+		"%s/%s:%s", edge.SrcRegistry.Name, edge.SrcImageTag.Name, sbomTag,
+	)
+	dstRefString := fmt.Sprintf(
+		"%s/%s:%s", edge.DstRegistry.Name, edge.DstImageTag.Name, sbomTag,
+	)
+
+	craneOpts := []crane.Option{
+		crane.WithAuthFromKeychain(gcrane.Keychain),
+		crane.WithUserAgent(image.UserAgent),
+		crane.WithTransport(di.getSigningTransport()),
+	}
+
+	logrus.Infof("SBOM copy: %s to %s", srcRefString, dstRefString)
+	if err := crane.Copy(srcRefString, dstRefString, craneOpts...); err != nil {
+		// If the SBOM does not exist in staging, skip silently
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			logrus.Debugf("No SBOM found for %s, skipping", srcRefString)
+			return nil
+		}
+		return fmt.Errorf("copying SBOM %s to %s: %w", srcRefString, dstRefString, err)
+	}
+	return nil
+}
+
+// digestToSBOMTag takes a digest and infers the tag name where
+// its SBOM can be found.
+func digestToSBOMTag(dg image.Digest) string {
+	return strings.ReplaceAll(string(dg), "sha256:", "sha256-") + sbomTagSuffix
 }
 
 // GetIdentityToken returns an identity token for the selected service account

--- a/internal/promoter/image/sign_test.go
+++ b/internal/promoter/image/sign_test.go
@@ -26,6 +26,7 @@ import (
 	reg "sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry"
 	"sigs.k8s.io/promo-tools/v4/internal/legacy/dockerregistry/registry"
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
+	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
 // TestGetIdentityToken tests the identity token generation logic. By default
@@ -53,6 +54,58 @@ func TestGetIdentityToken(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotEmpty(t, tok)
+}
+
+func TestDigestToSignatureTag(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		digest image.Digest
+		want   string
+	}{
+		{
+			name:   "standard sha256 digest",
+			digest: "sha256:709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f",
+			want:   "sha256-709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f.sig",
+		},
+		{
+			name:   "bare sha256 prefix",
+			digest: "sha256:abc",
+			want:   "sha256-abc.sig",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, digestToSignatureTag(tc.digest))
+		})
+	}
+}
+
+func TestDigestToSBOMTag(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		digest image.Digest
+		want   string
+	}{
+		{
+			name:   "standard sha256 digest",
+			digest: "sha256:709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f",
+			want:   "sha256-709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f.sbom",
+		},
+		{
+			name:   "bare sha256 prefix",
+			digest: "sha256:abc",
+			want:   "sha256-abc.sbom",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, digestToSBOMTag(tc.digest))
+		})
+	}
 }
 
 func TestTargetIdentity(t *testing.T) {

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -125,8 +125,8 @@ type Options struct {
 	// MaxSignatureOps maximum number of concurrent signature operations
 	MaxSignatureOps int
 
-	// UseLegacyPipeline uses the legacy sequential promotion code path
-	// instead of the new pipeline engine. Defaults to true during transition.
+	// Deprecated: UseLegacyPipeline uses the legacy sequential promotion
+	// code path instead of the new pipeline engine. Defaults to false.
 	UseLegacyPipeline bool
 
 	// RequireProvenance controls whether provenance verification is required
@@ -159,7 +159,7 @@ var DefaultOptions = &Options{
 	SignCheckIssuerRegexp:   "",
 	MaxSignatureCopies:      50, // Maximum number of concurrent signature copies
 	MaxSignatureOps:         50, // Maximum number of concurrent signature operations
-	UseLegacyPipeline:       true,
+	UseLegacyPipeline:       false,
 }
 
 func (o *Options) Validate() error {

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -60,7 +60,7 @@ func New(opts *options.Options) *Promoter {
 	di.SetSigningTransport(signRT)
 
 	return &Promoter{
-		Options: options.DefaultOptions,
+		Options: opts,
 		impl:    di,
 		budget:  budget,
 	}
@@ -122,7 +122,7 @@ type promoterImplementation interface {
 // PromoteImages is the main method for image promotion.
 // It runs by taking all its parameters from a set of options.
 func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) error {
-	if opts.UseLegacyPipeline {
+	if opts.UseLegacyPipeline { //nolint:staticcheck // intentional legacy routing
 		return p.promoteImagesLegacy(opts)
 	}
 	return p.promoteImagesPipeline(ctx, opts)
@@ -259,9 +259,12 @@ func (p *Promoter) promoteImagesPipeline(ctx context.Context, opts *options.Opti
 	return pipe.Run(ctx)
 }
 
-// promoteImagesLegacy is the original sequential promotion code path.
+// Deprecated: promoteImagesLegacy is the original sequential promotion code path.
+// Use the pipeline-based path (--use-legacy-pipeline=false) instead.
+// This will be removed in a future release.
 func (p *Promoter) promoteImagesLegacy(opts *options.Options) error {
-	logrus.Infof("PromoteImages start (legacy pipeline)")
+	logrus.Warn("Using deprecated legacy promotion pipeline. " +
+		"Set --use-legacy-pipeline=false to use the new pipeline engine.")
 	if err := p.impl.ValidateOptions(opts); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -169,14 +169,29 @@ func TestPromoteImagesPipelineParseOnly(t *testing.T) {
 	mock := imagefakes.FakePromoterImplementation{}
 	sut.SetImplementation(&mock)
 
-	// ParseOnly should stop the pipeline after the plan phase without error.
-	err := sut.PromoteImages(context.Background(), &options.Options{
-		Confirm:   true,
-		ParseOnly: true,
-	})
-	require.NoError(t, err)
+	// Pipeline path: ParseOnly should stop after plan phase with no error
+	opts := &options.Options{Confirm: true, ParseOnly: true}
+	require.NoError(t, sut.PromoteImages(context.Background(), opts))
 
-	// PromoteImages (on the impl) should never have been called.
+	// ParseManifests should have been called
+	require.Equal(t, 1, mock.ParseManifestsCallCount())
+	// PromoteImages should NOT have been called
+	require.Equal(t, 0, mock.PromoteImagesCallCount())
+}
+
+func TestPromoteImagesLegacyParseOnly(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// Legacy path: ParseOnly should stop after parsing with no error
+	opts := &options.Options{
+		Confirm:           true,
+		ParseOnly:         true,
+		UseLegacyPipeline: true,
+	}
+	require.NoError(t, sut.PromoteImages(context.Background(), opts))
+	require.Equal(t, 1, mock.ParseManifestsCallCount())
 	require.Equal(t, 0, mock.PromoteImagesCallCount())
 }
 
@@ -185,17 +200,50 @@ func TestPromoteImagesPipelineDryRun(t *testing.T) {
 	mock := imagefakes.FakePromoterImplementation{}
 	sut.SetImplementation(&mock)
 
-	// Confirm=false should stop the pipeline after the validate phase without error.
-	err := sut.PromoteImages(context.Background(), &options.Options{
-		Confirm: false,
-	})
-	require.NoError(t, err)
+	// Pipeline path: non-Confirm should stop after validate (precheck)
+	opts := &options.Options{Confirm: false}
+	require.NoError(t, sut.PromoteImages(context.Background(), opts))
 
-	// ValidateStagingSignatures should have been called (validate phase ran).
+	// ValidateStagingSignatures should have been called
 	require.Equal(t, 1, mock.ValidateStagingSignaturesCallCount())
-
-	// PromoteImages (on the impl) should never have been called.
+	// PrecheckAndExit should have been called
+	require.Equal(t, 1, mock.PrecheckAndExitCallCount())
+	// PromoteImages should NOT have been called
 	require.Equal(t, 0, mock.PromoteImagesCallCount())
+}
+
+func TestPromoteImagesLegacyDryRun(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// Legacy path: non-Confirm should stop after precheck
+	opts := &options.Options{Confirm: false, UseLegacyPipeline: true}
+	require.NoError(t, sut.PromoteImages(context.Background(), opts))
+
+	require.Equal(t, 1, mock.PrecheckAndExitCallCount())
+	require.Equal(t, 0, mock.PromoteImagesCallCount())
+}
+
+func TestPromoteImagesProvenanceDisabled(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// Provenance disabled (default): should proceed without calling verifier
+	opts := &options.Options{Confirm: true, RequireProvenance: false}
+	require.NoError(t, sut.PromoteImages(context.Background(), opts))
+}
+
+func TestPromoteImagesProvenanceEnabled(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// When provenance is required but no verifier is set, the noop verifier
+	// is used (always passes).
+	opts := &options.Options{Confirm: true, RequireProvenance: true}
+	require.NoError(t, sut.PromoteImages(context.Background(), opts))
 }
 
 // fakeVerifier implements provenance.Verifier for testing.
@@ -221,28 +269,16 @@ func testEdge() reg.PromotionEdge {
 	}
 }
 
-func TestPromoteImagesPipelineProvenanceNoopFallback(t *testing.T) {
+func TestPromoteImagesProvenanceFails(t *testing.T) {
 	sut := imagepromoter.Promoter{}
 	mock := imagefakes.FakePromoterImplementation{}
-	sut.SetImplementation(&mock)
-
-	// RequireProvenance=true with no verifier set should use the noop
-	// verifier and succeed.
-	err := sut.PromoteImages(context.Background(), &options.Options{
-		Confirm:           true,
-		RequireProvenance: true,
-	})
-	require.NoError(t, err)
-}
-
-func TestPromoteImagesPipelineProvenanceFails(t *testing.T) {
-	sut := imagepromoter.Promoter{}
-	mock := imagefakes.FakePromoterImplementation{}
+	// Return a non-empty edge set so provenance has something to check
 	mock.GetPromotionEdgesReturns(map[reg.PromotionEdge]interface{}{
 		testEdge(): nil,
 	}, nil)
 	sut.SetImplementation(&mock)
 
+	// Set a verifier that returns a verification failure
 	sut.SetProvenanceVerifier(&fakeVerifier{
 		result: &provenance.Result{
 			Verified: false,
@@ -250,17 +286,14 @@ func TestPromoteImagesPipelineProvenanceFails(t *testing.T) {
 		},
 	})
 
-	err := sut.PromoteImages(context.Background(), &options.Options{
-		Confirm:           true,
-		RequireProvenance: true,
-	})
-	require.Error(t, err)
+	opts := &options.Options{Confirm: true, RequireProvenance: true}
+	require.Error(t, sut.PromoteImages(context.Background(), opts))
 
-	// Promotion should not have been called.
+	// Promotion should not have been called
 	require.Equal(t, 0, mock.PromoteImagesCallCount())
 }
 
-func TestPromoteImagesPipelineProvenanceVerifierError(t *testing.T) {
+func TestPromoteImagesProvenanceVerifierError(t *testing.T) {
 	sut := imagepromoter.Promoter{}
 	mock := imagefakes.FakePromoterImplementation{}
 	mock.GetPromotionEdgesReturns(map[reg.PromotionEdge]interface{}{
@@ -272,9 +305,12 @@ func TestPromoteImagesPipelineProvenanceVerifierError(t *testing.T) {
 		err: errors.New("connection refused"),
 	})
 
-	err := sut.PromoteImages(context.Background(), &options.Options{
-		Confirm:           true,
-		RequireProvenance: true,
-	})
-	require.Error(t, err)
+	opts := &options.Options{Confirm: true, RequireProvenance: true}
+	require.Error(t, sut.PromoteImages(context.Background(), opts))
+}
+
+func TestNewPromoter(t *testing.T) {
+	p := imagepromoter.New(options.DefaultOptions)
+	require.NotNil(t, p)
+	require.NotNil(t, p.Options)
 }

--- a/promoter/image/vuln/grafeas.go
+++ b/promoter/image/vuln/grafeas.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vuln
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	containeranalysis "cloud.google.com/go/containeranalysis/apiv1"
+	"google.golang.org/api/iterator"
+	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
+)
+
+// GrafeasScanner uses GCP Container Analysis (Grafeas) to scan images
+// for vulnerabilities. This wraps the existing GCP-specific scanning
+// capability behind the portable Scanner interface.
+type GrafeasScanner struct {
+	// FixableOnly when true only reports vulnerabilities that have a
+	// fix available, matching the legacy behavior.
+	FixableOnly bool
+}
+
+// Scan queries the Container Analysis API for vulnerability occurrences
+// on the given image reference. The reference must be a GCR/Artifact
+// Registry image (e.g., "gcr.io/project/image@sha256:...") so that
+// the GCP project ID can be derived from the registry path.
+func (s *GrafeasScanner) Scan(ctx context.Context, ref string) (*ScanResult, error) {
+	projectID, err := parseProjectID(ref)
+	if err != nil {
+		return nil, fmt.Errorf("parsing project ID from %q: %w", ref, err)
+	}
+
+	client, err := containeranalysis.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating container analysis client: %w", err)
+	}
+	defer client.Close()
+
+	// Build the resource URL for the image. Container Analysis expects
+	// the full https:// URL form.
+	resourceURL := "https://" + ref
+
+	req := &grafeaspb.ListOccurrencesRequest{
+		Parent: "projects/" + projectID,
+		Filter: fmt.Sprintf("resourceUrl = %q kind = %q",
+			resourceURL, "VULNERABILITY"),
+	}
+
+	result := &ScanResult{Reference: ref}
+	it := client.GetGrafeasClient().ListOccurrences(ctx, req)
+	for {
+		occ, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("listing occurrences: %w", err)
+		}
+
+		vuln := occ.GetVulnerability()
+		if vuln == nil {
+			continue
+		}
+
+		// Match legacy behavior: only report fixable vulnerabilities
+		// when FixableOnly is set.
+		if s.FixableOnly && !vuln.GetFixAvailable() {
+			continue
+		}
+
+		severity := mapGrafeasSeverity(vuln.GetSeverity())
+		v := Vulnerability{
+			ID:       occ.GetName(),
+			Severity: severity,
+		}
+
+		// Extract package info from the first affected package, if available.
+		if pkgs := vuln.GetPackageIssue(); len(pkgs) > 0 {
+			pkg := pkgs[0]
+			v.Package = pkg.GetAffectedPackage()
+			if affected := pkg.GetAffectedVersion(); affected != nil {
+				v.InstalledVersion = affected.GetFullName()
+			}
+			if fixed := pkg.GetFixedVersion(); fixed != nil {
+				v.FixedVersion = fixed.GetFullName()
+			}
+		}
+
+		v.Description = vuln.GetShortDescription()
+
+		result.Vulnerabilities = append(result.Vulnerabilities, v)
+		if severity > result.HighestSeverity {
+			result.HighestSeverity = severity
+		}
+	}
+
+	return result, nil
+}
+
+// parseProjectID extracts the GCP project ID from an image reference.
+// For "gcr.io/my-project/image@sha256:...", returns "my-project".
+// For "us-docker.pkg.dev/my-project/repo/image@sha256:...", returns "my-project".
+func parseProjectID(ref string) (string, error) {
+	// Strip digest or tag
+	refBase := ref
+	if idx := strings.Index(ref, "@"); idx != -1 {
+		refBase = ref[:idx]
+	} else if idx := strings.Index(ref, ":"); idx != -1 {
+		refBase = ref[:idx]
+	}
+
+	parts := strings.Split(refBase, "/")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("cannot extract project ID from %q: not enough path components", ref)
+	}
+
+	// The project ID is always the second path component
+	// (after the registry hostname).
+	return parts[1], nil
+}
+
+// mapGrafeasSeverity maps a Grafeas severity enum to our Severity type.
+// The numeric values happen to align (both use 0-5), but we map explicitly
+// for safety.
+func mapGrafeasSeverity(s grafeaspb.Severity) Severity {
+	switch s {
+	case grafeaspb.Severity_MINIMAL:
+		return SeverityMinimal
+	case grafeaspb.Severity_LOW:
+		return SeverityLow
+	case grafeaspb.Severity_MEDIUM:
+		return SeverityMedium
+	case grafeaspb.Severity_HIGH:
+		return SeverityHigh
+	case grafeaspb.Severity_CRITICAL:
+		return SeverityCritical
+	default:
+		return SeverityUnspecified
+	}
+}

--- a/promoter/image/vuln/noop.go
+++ b/promoter/image/vuln/noop.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vuln
+
+import (
+	"context"
+)
+
+// NoopScanner always returns an empty scan result with no vulnerabilities.
+// Used when vulnerability scanning is disabled.
+type NoopScanner struct{}
+
+// Scan returns a clean result.
+func (n *NoopScanner) Scan(_ context.Context, ref string) (*ScanResult, error) {
+	return &ScanResult{
+		Reference: ref,
+	}, nil
+}

--- a/promoter/image/vuln/scanner.go
+++ b/promoter/image/vuln/scanner.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vuln provides interfaces and implementations for scanning
+// container images for vulnerabilities before or after promotion.
+// This replaces the GCP-specific Container Analysis (Grafeas) check
+// with a portable interface.
+package vuln
+
+import (
+	"context"
+)
+
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+// Severity represents the severity level of a vulnerability.
+type Severity int
+
+const (
+	SeverityUnspecified Severity = iota
+	SeverityMinimal
+	SeverityLow
+	SeverityMedium
+	SeverityHigh
+	SeverityCritical
+)
+
+// Scanner checks container images for known vulnerabilities.
+//
+//counterfeiter:generate . Scanner
+type Scanner interface {
+	// Scan analyzes the image at the given reference for vulnerabilities.
+	// The reference should be a fully qualified image reference including
+	// a digest (e.g., "gcr.io/staging/image@sha256:abc...").
+	Scan(ctx context.Context, ref string) (*ScanResult, error)
+}
+
+// ScanResult holds the outcome of a vulnerability scan.
+type ScanResult struct {
+	// Reference is the image that was scanned.
+	Reference string
+
+	// Vulnerabilities is the list of found vulnerabilities.
+	Vulnerabilities []Vulnerability
+
+	// HighestSeverity is the highest severity found across all vulnerabilities.
+	HighestSeverity Severity
+}
+
+// Vulnerability represents a single CVE or security issue.
+type Vulnerability struct {
+	// ID is the vulnerability identifier (e.g., "CVE-2024-1234").
+	ID string
+
+	// Severity is the severity level.
+	Severity Severity
+
+	// Package is the affected package name.
+	Package string
+
+	// InstalledVersion is the currently installed version.
+	InstalledVersion string
+
+	// FixedVersion is the version that fixes this vulnerability, if available.
+	FixedVersion string
+
+	// Description is a short description of the vulnerability.
+	Description string
+}
+
+// ExceedsSeverity returns true if the scan result contains any vulnerability
+// at or above the given severity threshold.
+func (r *ScanResult) ExceedsSeverity(threshold Severity) bool {
+	return r.HighestSeverity >= threshold
+}

--- a/promoter/image/vuln/scanner_test.go
+++ b/promoter/image/vuln/scanner_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vuln
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
+)
+
+func TestNoopScanner(t *testing.T) {
+	s := &NoopScanner{}
+	result, err := s.Scan(context.Background(), "gcr.io/test/image@sha256:abc")
+	require.NoError(t, err)
+	require.Equal(t, "gcr.io/test/image@sha256:abc", result.Reference)
+	require.Empty(t, result.Vulnerabilities)
+}
+
+func TestScanResultExceedsSeverity(t *testing.T) {
+	tests := []struct {
+		name      string
+		highest   Severity
+		threshold Severity
+		want      bool
+	}{
+		{"critical exceeds high", SeverityCritical, SeverityHigh, true},
+		{"high equals high", SeverityHigh, SeverityHigh, true},
+		{"medium below high", SeverityMedium, SeverityHigh, false},
+		{"unspecified below low", SeverityUnspecified, SeverityLow, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ScanResult{HighestSeverity: tt.highest}
+			require.Equal(t, tt.want, r.ExceedsSeverity(tt.threshold))
+		})
+	}
+}
+
+func TestSeverityOrdering(t *testing.T) {
+	require.Less(t, SeverityMinimal, SeverityLow)
+	require.Less(t, SeverityLow, SeverityMedium)
+	require.Less(t, SeverityMedium, SeverityHigh)
+	require.Less(t, SeverityHigh, SeverityCritical)
+}
+
+func TestParseProjectID(t *testing.T) {
+	tests := []struct {
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{"gcr.io/my-project/image@sha256:abc", "my-project", false},
+		{"us-docker.pkg.dev/my-project/repo/image@sha256:abc", "my-project", false},
+		{"gcr.io/k8s-staging-foo/bar:latest", "k8s-staging-foo", false},
+		{"singlepart", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got, err := parseProjectID(tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestMapGrafeasSeverity(t *testing.T) {
+	tests := []struct {
+		input grafeaspb.Severity
+		want  Severity
+	}{
+		{grafeaspb.Severity_MINIMAL, SeverityMinimal},
+		{grafeaspb.Severity_LOW, SeverityLow},
+		{grafeaspb.Severity_MEDIUM, SeverityMedium},
+		{grafeaspb.Severity_HIGH, SeverityHigh},
+		{grafeaspb.Severity_CRITICAL, SeverityCritical},
+		{grafeaspb.Severity_SEVERITY_UNSPECIFIED, SeverityUnspecified},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.want, mapGrafeasSeverity(tt.input))
+	}
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ Scanner = &NoopScanner{}
+	_ Scanner = &GrafeasScanner{}
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind deprecation

#### What this PR does / why we need it:

Phase 5 of #1701. Adds vulnerability scanning and SBOM support, and flips the default to the new pipeline engine.

- Add `vuln.Scanner` interface with `GrafeasScanner` (GCP Container Analysis)
  and `NoopScanner`
- Implement `WriteSBOMs` to copy pre-generated SBOMs from staging to production
  using cosign tag convention
- Default `UseLegacyPipeline` to `false`, add deprecation warning for legacy path
- Wire CLI flags: `--use-legacy-pipeline`, `--require-provenance`,
  `--allowed-builders`, `--allowed-source-repos`
- Use `transport.Error` for reliable 404 detection in signature and SBOM copies
- Fix `New()` to use passed options instead of `DefaultOptions`
- Add tests for SBOM tag derivation, vuln scanner, and promoter paths

#### Which issue(s) this PR fixes:

Refers to #1701

#### Special notes for your reviewer:

Part of the promoter rewrite stack. Phase 4 was merged in #1706.

#### Does this PR introduce a user-facing change?

```release-note
The image promoter now uses the new pipeline engine by default. The legacy
sequential code path is deprecated and available via `--use-legacy-pipeline`.
New CLI flags: `--require-provenance`, `--allowed-builders`,
`--allowed-source-repos`. Pre-generated SBOMs are now automatically copied
from staging to production registries during promotion.
```