### PR TITLE
Add kpromo cip replicate-signatures subcommand

### DIFF
--- a/cmd/kpromo/cmd/cip/replicate.go
+++ b/cmd/kpromo/cmd/cip/replicate.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cip
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	promoter "sigs.k8s.io/promo-tools/v4/promoter/image"
+)
+
+var replicateCmd = &cobra.Command{
+	Use:   "replicate-signatures",
+	Short: "Replicate image signatures to mirror registries",
+	Long: `replicate-signatures - Replicate image signatures to mirror registries
+
+This subcommand reads the promotion manifests to discover which images
+should exist in which registries, then copies any missing signature tags
+from the primary registry to the mirrors.
+
+The operation is fully idempotent; re-running when everything is already
+replicated is a series of fast existence checks.
+
+Example usage:
+
+  kpromo cip replicate-signatures \
+    --thin-manifest-dir=/path/to/manifests \
+    --confirm
+`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		p := promoter.New(runOpts)
+		if err := p.ReplicateSignatures(context.Background(), runOpts); err != nil {
+			return fmt.Errorf("replicate signatures: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	CipCmd.AddCommand(replicateCmd)
+}

--- a/docs/image-promotion.md
+++ b/docs/image-promotion.md
@@ -16,6 +16,7 @@ and work with any OCI-compliant registry.
   - [Rate limiting](#rate-limiting)
 - [Server-side operations](#server-side-operations)
 - [Signing and attestation](#signing-and-attestation)
+- [Standalone signature replication](#standalone-signature-replication)
 - [Provenance verification](#provenance-verification)
 - [Vulnerability scanning](#vulnerability-scanning)
 - [Grabbing snapshots](#grabbing-snapshots)
@@ -171,8 +172,9 @@ The promotion flow is organized into sequential pipeline phases:
 | 3 | **provenance** | Optional SLSA provenance verification (see [Provenance verification](#provenance-verification)) |
 | 4 | **validate** | Validate staging image signatures |
 | 5 | **promote** | Copy images from staging to production |
-| 6 | **sign** | Sign promoted images with cosign, replicate signatures to mirrors |
-| 7 | **attest** | Copy pre-generated SBOMs from staging to production, generate promotion provenance |
+| 6 | **sign** | Sign promoted images with cosign (primary registry only) |
+| 7 | **replicate** | Copy signatures to mirror registries (see [Standalone signature replication](#standalone-signature-replication)) |
+| 8 | **attest** | Copy pre-generated SBOMs from staging to production, generate promotion provenance |
 
 Without `--confirm`, the pipeline stops after the validate phase (dry-run
 precheck). With `--parse-only`, it stops after parsing manifests.
@@ -212,6 +214,28 @@ Related flags:
 - `--certificate-oidc-issuer` — OIDC issuer for the signing identity
 - `--max-signature-copies` — max concurrent signature copies (default: `50`)
 - `--max-signature-ops` — max concurrent signature operations (default: `50`)
+
+## Standalone signature replication
+
+When images are promoted to multiple mirror registries, signatures must be
+replicated from the primary registry to all mirrors. This normally happens
+inline during promotion (in the sign phase), but can also be run standalone
+via the `replicate-signatures` subcommand:
+
+```console
+kpromo cip replicate-signatures \
+  --thin-manifest-dir=/path/to/manifests \
+  --confirm
+```
+
+Without `--confirm` the command performs a dry run: it parses manifests and
+computes edges, but does not copy any signatures.
+
+The standalone mode reads **all** edges from the manifests (not just unsynced
+ones), so it works even when images were promoted long ago. Each signature copy
+is idempotent -- existing signatures are detected via a HEAD request and
+skipped. This makes it safe to run frequently (e.g. via a periodic Prow job)
+alongside the main promotion pipeline.
 
 ## Provenance verification
 

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -96,6 +96,20 @@ func (di *DefaultPromoterImplementation) GetPromotionEdges(
 	return promotionEdges, nil
 }
 
+// EdgesFromManifests converts manifests directly to promotion edges without
+// filtering against live registry state. This is used by the standalone
+// replicate-signatures subcommand which needs ALL edges (not just unsynced ones)
+// to ensure signatures exist everywhere.
+func (di *DefaultPromoterImplementation) EdgesFromManifests(
+	mfests []schema.Manifest,
+) (map[reg.PromotionEdge]interface{}, error) {
+	edges, err := reg.ToPromotionEdges(mfests)
+	if err != nil {
+		return nil, fmt.Errorf("converting manifests to edges: %w", err)
+	}
+	return edges, nil
+}
+
 // PromoteImages starts an image promotion of a set of edges.
 func (di *DefaultPromoterImplementation) PromoteImages(
 	sc *reg.SyncContext,

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -354,6 +354,15 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 
 	// Copy the signatures to the missing registries
 	for _, dstRef := range dstRefs {
+		// Skip if the signature tag already exists at the destination.
+		if _, err := remote.Head(dstRef,
+			remote.WithAuthFromKeychain(gcrane.Keychain),
+			remote.WithTransport(di.getSigningTransport()),
+		); err == nil {
+			logrus.WithField("dst", dstRef.String()).Debug("Signature already exists, skipping")
+			continue
+		}
+
 		logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.String())
 		opts := []crane.Option{
 			crane.WithAuthFromKeychain(gcrane.Keychain),

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -54,6 +54,19 @@ type FakePromoterImplementation struct {
 		result1 []schema.Manifest
 		result2 error
 	}
+	EdgesFromManifestsStub        func([]schema.Manifest) (map[inventory.PromotionEdge]interface{}, error)
+	edgesFromManifestsMutex       sync.RWMutex
+	edgesFromManifestsArgsForCall []struct {
+		arg1 []schema.Manifest
+	}
+	edgesFromManifestsReturns struct {
+		result1 map[inventory.PromotionEdge]interface{}
+		result2 error
+	}
+	edgesFromManifestsReturnsOnCall map[int]struct {
+		result1 map[inventory.PromotionEdge]interface{}
+		result2 error
+	}
 	FixMissingSignaturesStub        func(*imagepromotera.Options, checkresults.Signature) error
 	fixMissingSignaturesMutex       sync.RWMutex
 	fixMissingSignaturesArgsForCall []struct {
@@ -467,6 +480,75 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i 
 	}
 	fake.appendManifestToSnapshotReturnsOnCall[i] = struct {
 		result1 []schema.Manifest
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePromoterImplementation) EdgesFromManifests(arg1 []schema.Manifest) (map[inventory.PromotionEdge]interface{}, error) {
+	var arg1Copy []schema.Manifest
+	if arg1 != nil {
+		arg1Copy = make([]schema.Manifest, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.edgesFromManifestsMutex.Lock()
+	ret, specificReturn := fake.edgesFromManifestsReturnsOnCall[len(fake.edgesFromManifestsArgsForCall)]
+	fake.edgesFromManifestsArgsForCall = append(fake.edgesFromManifestsArgsForCall, struct {
+		arg1 []schema.Manifest
+	}{arg1Copy})
+	stub := fake.EdgesFromManifestsStub
+	fakeReturns := fake.edgesFromManifestsReturns
+	fake.recordInvocation("EdgesFromManifests", []interface{}{arg1Copy})
+	fake.edgesFromManifestsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePromoterImplementation) EdgesFromManifestsCallCount() int {
+	fake.edgesFromManifestsMutex.RLock()
+	defer fake.edgesFromManifestsMutex.RUnlock()
+	return len(fake.edgesFromManifestsArgsForCall)
+}
+
+func (fake *FakePromoterImplementation) EdgesFromManifestsCalls(stub func([]schema.Manifest) (map[inventory.PromotionEdge]interface{}, error)) {
+	fake.edgesFromManifestsMutex.Lock()
+	defer fake.edgesFromManifestsMutex.Unlock()
+	fake.EdgesFromManifestsStub = stub
+}
+
+func (fake *FakePromoterImplementation) EdgesFromManifestsArgsForCall(i int) []schema.Manifest {
+	fake.edgesFromManifestsMutex.RLock()
+	defer fake.edgesFromManifestsMutex.RUnlock()
+	argsForCall := fake.edgesFromManifestsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePromoterImplementation) EdgesFromManifestsReturns(result1 map[inventory.PromotionEdge]interface{}, result2 error) {
+	fake.edgesFromManifestsMutex.Lock()
+	defer fake.edgesFromManifestsMutex.Unlock()
+	fake.EdgesFromManifestsStub = nil
+	fake.edgesFromManifestsReturns = struct {
+		result1 map[inventory.PromotionEdge]interface{}
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePromoterImplementation) EdgesFromManifestsReturnsOnCall(i int, result1 map[inventory.PromotionEdge]interface{}, result2 error) {
+	fake.edgesFromManifestsMutex.Lock()
+	defer fake.edgesFromManifestsMutex.Unlock()
+	fake.EdgesFromManifestsStub = nil
+	if fake.edgesFromManifestsReturnsOnCall == nil {
+		fake.edgesFromManifestsReturnsOnCall = make(map[int]struct {
+			result1 map[inventory.PromotionEdge]interface{}
+			result2 error
+		})
+	}
+	fake.edgesFromManifestsReturnsOnCall[i] = struct {
+		result1 map[inventory.PromotionEdge]interface{}
 		result2 error
 	}{result1, result2}
 }

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -108,6 +108,7 @@ type promoterImplementation interface {
 	ParseManifests(*options.Options) ([]schema.Manifest, error)
 	MakeSyncContext(*options.Options, []schema.Manifest) (*reg.SyncContext, error)
 	GetPromotionEdges(*reg.SyncContext, []schema.Manifest) (map[reg.PromotionEdge]interface{}, error)
+	EdgesFromManifests([]schema.Manifest) (map[reg.PromotionEdge]interface{}, error)
 	PromoteImages(*reg.SyncContext, map[reg.PromotionEdge]interface{}) error
 
 	// Methods for snapshot mode:
@@ -398,4 +399,60 @@ func (p *Promoter) CheckSignatures(opts *options.Options) error {
 	}
 
 	return nil
+}
+
+// ReplicateSignatures is a standalone mode that copies image signatures
+// from the primary destination registry to all mirror registries.
+// Unlike the inline replicate phase in PromoteImages, this method reads
+// ALL edges from manifests (not just unsynced ones) so it can run
+// independently of the promotion job.
+func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Options) error {
+	var promotionEdges map[reg.PromotionEdge]interface{}
+
+	pipe := pipeline.New()
+
+	// Setup phase: validate, activate accounts, prewarm caches.
+	pipe.AddPhase(pipeline.NewPhase("setup", func(_ context.Context) error {
+		if err := p.impl.ValidateOptions(opts); err != nil {
+			return fmt.Errorf("validating options: %w", err)
+		}
+		if err := p.impl.ActivateServiceAccounts(opts); err != nil {
+			return fmt.Errorf("activating service accounts: %w", err)
+		}
+		if err := p.impl.PrewarmTUFCache(); err != nil {
+			return fmt.Errorf("prewarming TUF cache: %w", err)
+		}
+		return nil
+	}))
+
+	// Plan phase: parse manifests, compute all edges (unfiltered).
+	pipe.AddPhase(pipeline.NewPhase("plan", func(_ context.Context) error {
+		mfests, err := p.impl.ParseManifests(opts)
+		if err != nil {
+			return fmt.Errorf("parsing manifests: %w", err)
+		}
+
+		promotionEdges, err = p.impl.EdgesFromManifests(mfests)
+		if err != nil {
+			return fmt.Errorf("computing edges from manifests: %w", err)
+		}
+
+		logrus.Infof("Found %d edges for signature replication", len(promotionEdges))
+
+		if !opts.Confirm {
+			logrus.Info("Dry run complete (use --confirm to replicate)")
+			return pipeline.ErrStopPipeline
+		}
+		return nil
+	}))
+
+	// Replicate phase: copy signatures to mirror registries.
+	pipe.AddPhase(pipeline.NewPhase("replicate", func(_ context.Context) error {
+		if err := p.impl.ReplicateSignatures(opts, nil, promotionEdges); err != nil {
+			return fmt.Errorf("replicating signatures: %w", err)
+		}
+		return nil
+	}))
+
+	return pipe.Run(ctx)
 }

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -267,6 +267,92 @@ func TestPromoteImagesProvenanceVerifierError(t *testing.T) {
 	require.Error(t, sut.PromoteImages(context.Background(), opts))
 }
 
+func TestReplicateSignatures(t *testing.T) {
+	testErr := errors.New("synthetic error")
+	for _, tc := range []struct {
+		shouldErr bool
+		msg       string
+		prepare   func(*imagefakes.FakePromoterImplementation)
+	}{
+		{
+			shouldErr: false,
+			msg:       "No errors",
+			prepare:   func(_ *imagefakes.FakePromoterImplementation) {},
+		},
+		{
+			shouldErr: true,
+			msg:       "ValidateOptions fails",
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ValidateOptionsReturns(testErr)
+			},
+		},
+		{
+			shouldErr: true,
+			msg:       "ActivateServiceAccounts fails",
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ActivateServiceAccountsReturns(testErr)
+			},
+		},
+		{
+			shouldErr: true,
+			msg:       "PrewarmTUFCache fails",
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.PrewarmTUFCacheReturns(testErr)
+			},
+		},
+		{
+			shouldErr: true,
+			msg:       "ParseManifests fails",
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ParseManifestsReturns(nil, testErr)
+			},
+		},
+		{
+			shouldErr: true,
+			msg:       "EdgesFromManifests fails",
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.EdgesFromManifestsReturns(nil, testErr)
+			},
+		},
+		{
+			shouldErr: true,
+			msg:       "ReplicateSignatures fails",
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ReplicateSignaturesReturns(testErr)
+			},
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			sut := imagepromoter.Promoter{}
+			mock := imagefakes.FakePromoterImplementation{}
+			tc.prepare(&mock)
+			sut.SetImplementation(&mock)
+			err := sut.ReplicateSignatures(context.Background(), &options.Options{Confirm: true})
+			if tc.shouldErr {
+				require.Error(t, err, tc.msg)
+			} else {
+				require.NoError(t, err, tc.msg)
+			}
+		})
+	}
+}
+
+func TestReplicateSignaturesDryRun(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	mock := imagefakes.FakePromoterImplementation{}
+	sut.SetImplementation(&mock)
+
+	// Without --confirm, should stop after plan phase with no error
+	opts := &options.Options{Confirm: false}
+	require.NoError(t, sut.ReplicateSignatures(context.Background(), opts))
+
+	// ParseManifests and EdgesFromManifests should have been called
+	require.Equal(t, 1, mock.ParseManifestsCallCount())
+	require.Equal(t, 1, mock.EdgesFromManifestsCallCount())
+	// ReplicateSignatures should NOT have been called
+	require.Equal(t, 0, mock.ReplicateSignaturesCallCount())
+}
+
 func TestNewPromoter(t *testing.T) {
 	p := imagepromoter.New(options.DefaultOptions)
 	require.NotNil(t, p)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a standalone `kpromo cip replicate-signatures` subcommand that reads promotion manifests, computes edges, and copies missing signature tags from primary registries to mirrors. This enables running signature replication as a dedicated periodic Prow job, decoupled from the promotion pipeline.

#### Which issue(s) this PR fixes:

Refers to  https://github.com/kubernetes-sigs/promo-tools/issues/1714

#### Special notes for your reviewer:

/hold

Companion Prow job PR in kubernetes/test-infra will follow.

#### Does this PR introduce a user-facing change?

```release-note
Add `kpromo cip replicate-signatures` subcommand for standalone signature replication to mirror registries.
```