### PR TITLE
Handle missing source signatures in replicateSignatures

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -370,6 +370,11 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 			crane.WithTransport(di.getSigningTransport()),
 		}
 		if err := crane.Copy(srcRef.String(), dstRef.String(), opts...); err != nil {
+			var terr *transport.Error
+			if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+				logrus.Debugf("Signature %s not found, skipping", srcRef.String())
+				continue
+			}
 			return fmt.Errorf(
 				"copying signature %s to %s: %w",
 				srcRef.String(), dstRef.String(), err,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Skip images whose source `.sig` tag does not exist in the primary registry instead of failing the entire replication job with `MANIFEST_UNKNOWN`. This matches the 404 handling already present in `copyAttachedObjects`.

The `ci-k8sio-image-signature-replication` periodic job fails when it encounters images that were promoted before signing was enabled or whose signatures were garbage collected.

#### Which issue(s) this PR fixes:

Part of #1714

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fix signature replication failing on images without signatures
```