### PR TITLE
Fix registry inventory key mismatch causing all images to be _LOST_

### DIFF
--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -220,6 +220,7 @@ func ReadStagingRepo(
 		ctx,
 		[]registry.RegistryConfig{{Name: o.StagingRepo}},
 		true, // recursive
+		nil,
 	)
 	if err != nil {
 		return registry.RegInvImage{}, err

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -66,9 +66,14 @@ func (di *DefaultPromoterImplementation) GetPromotionEdges(
 		return nil, fmt.Errorf("converting manifests to edges: %w", err)
 	}
 
-	// Collect registries we need to read
+	// Collect registries we need to read (full paths including image names)
 	regs := promotion.GetRegistriesToRead(edges)
 	configs := registry.RegistryConfigsFromContexts(regs)
+
+	// Collect base registries (without image name suffixes) for correct
+	// inventory keying in splitByKnownRegistries.
+	baseRegs := promotion.GetBaseRegistries(edges)
+	baseConfigs := registry.RegistryConfigsFromContexts(baseRegs)
 
 	for _, cfg := range configs {
 		logrus.Debugf("reading registry %s (src=%v)", cfg.Name, cfg.Src)
@@ -76,7 +81,7 @@ func (di *DefaultPromoterImplementation) GetPromotionEdges(
 
 	// Read registry inventories (non-recursive, specific repos only)
 	ctx := context.Background()
-	inv, err := di.registryProvider.ReadRegistries(ctx, configs, false)
+	inv, err := di.registryProvider.ReadRegistries(ctx, configs, false, baseConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("reading registries: %w", err)
 	}

--- a/internal/promoter/image/snapshot.go
+++ b/internal/promoter/image/snapshot.go
@@ -153,6 +153,7 @@ func (di *DefaultPromoterImplementation) GetRegistryImageInventory(
 				context.Background(),
 				[]registry.RegistryConfig{registryConfig},
 				true,
+				nil,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("reading registry for minimal snapshot: %w", err)
@@ -169,6 +170,7 @@ func (di *DefaultPromoterImplementation) GetRegistryImageInventory(
 		context.Background(),
 		[]registry.RegistryConfig{registryConfig},
 		true,
+		nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("reading registries: %w", err)

--- a/promoter/image/promotion/edge.go
+++ b/promoter/image/promotion/edge.go
@@ -271,6 +271,26 @@ func EdgesToRegInvImage(
 	return rii
 }
 
+// GetBaseRegistries collects the unique base registries (without image name
+// suffixes) from the edges. These are used by ReadRegistries to correctly
+// key the inventory so that vertexPropsFor can look up digests by the
+// original registry name from the edge.
+func GetBaseRegistries(edges map[Edge]interface{}) []registry.Context {
+	rcs := make(map[registry.Context]interface{})
+
+	for edge := range edges {
+		rcs[edge.SrcRegistry] = nil
+		rcs[edge.DstRegistry] = nil
+	}
+
+	rcsFinal := make([]registry.Context, 0, len(rcs))
+	for rc := range rcs {
+		rcsFinal = append(rcsFinal, rc)
+	}
+
+	return rcsFinal
+}
+
 // GetRegistriesToRead collects all unique Docker repositories we want to read
 // from. This way, we don't have to read the entire Docker registry, but only
 // those paths that we are thinking of modifying.

--- a/promoter/image/promotion/edge_test.go
+++ b/promoter/image/promotion/edge_test.go
@@ -352,3 +352,108 @@ func TestGetRegistriesToRead(t *testing.T) {
 	require.True(t, names["gcr.io/staging/foo"])
 	require.True(t, names["us.gcr.io/prod/foo"])
 }
+
+func TestGetBaseRegistries(t *testing.T) {
+	edges := map[Edge]interface{}{
+		{
+			SrcRegistry: testSrcRC,
+			SrcImageTag: ImageTag{Name: "foo"},
+			DstRegistry: testDstRC1,
+			DstImageTag: ImageTag{Name: "foo"},
+		}: nil,
+		{
+			SrcRegistry: testSrcRC,
+			SrcImageTag: ImageTag{Name: "bar"},
+			DstRegistry: testDstRC2,
+			DstImageTag: ImageTag{Name: "bar"},
+		}: nil,
+	}
+
+	rcs := GetBaseRegistries(edges)
+	require.Len(t, rcs, 3)
+
+	names := make(map[image.Registry]bool)
+	for _, rc := range rcs {
+		names[rc.Name] = true
+	}
+	// Base registries should NOT have image names appended.
+	require.True(t, names["gcr.io/staging"])
+	require.True(t, names["us.gcr.io/prod"])
+	require.True(t, names["eu.gcr.io/prod"])
+}
+
+func TestGetPromotionCandidatesWithBaseRegistries(t *testing.T) {
+	// This test verifies the fix for the inventory key mismatch bug.
+	// When ReadRegistries uses base registries for splitByKnownRegistries,
+	// the inventory is keyed correctly and digests are found.
+	srcReg := registry.Context{
+		Name: "gcr.io/k8s-staging-foo",
+		Src:  true,
+	}
+	dstReg := registry.Context{
+		Name: "us-docker.pkg.dev/k8s-artifacts-prod/images/foo",
+	}
+
+	edges := map[Edge]interface{}{
+		{
+			SrcRegistry: srcReg,
+			SrcImageTag: ImageTag{Name: "myimage", Tag: "v1.0"},
+			DstRegistry: dstReg,
+			DstImageTag: ImageTag{Name: "myimage", Tag: "v1.0"},
+			Digest:      testDigest1,
+		}: nil,
+	}
+
+	// Inventory keyed by BASE registry name with image name as sub-key
+	// (this is the correct keying produced when base registries are used).
+	// Both src and dst have the digest+tag → already promoted.
+	inv := map[image.Registry]registry.RegInvImage{
+		"gcr.io/k8s-staging-foo": {
+			"myimage": registry.DigestTags{
+				testDigest1: {"v1.0"},
+			},
+		},
+		"us-docker.pkg.dev/k8s-artifacts-prod/images/foo": {
+			"myimage": registry.DigestTags{
+				testDigest1: {"v1.0"},
+			},
+		},
+	}
+
+	candidates, clean := GetPromotionCandidates(edges, inv)
+	require.True(t, clean)
+	// Already promoted, so no candidates.
+	require.Empty(t, candidates)
+
+	// Now test with a digest that needs promotion (exists in src, not in dst).
+	inv = map[image.Registry]registry.RegInvImage{
+		"gcr.io/k8s-staging-foo": {
+			"myimage": registry.DigestTags{
+				testDigest1: {"v1.0"},
+			},
+		},
+		"us-docker.pkg.dev/k8s-artifacts-prod/images/foo": {
+			"myimage": registry.DigestTags{},
+		},
+	}
+
+	candidates, clean = GetPromotionCandidates(edges, inv)
+	require.True(t, clean)
+	require.Len(t, candidates, 1)
+
+	// Verify that with WRONG keying (full-path keys as produced by the
+	// old buggy code), digests would NOT be found and candidates would
+	// be empty (all _LOST_).
+	invBadKeys := map[image.Registry]registry.RegInvImage{
+		"gcr.io/k8s-staging-foo/myimage": {
+			"": registry.DigestTags{
+				testDigest1: {"v1.0"},
+			},
+		},
+	}
+
+	candidates, clean = GetPromotionCandidates(edges, invBadKeys)
+	require.True(t, clean)
+	// With wrong keys, nothing is found → no candidates (all _LOST_).
+	require.Empty(t, candidates)
+}

--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -59,8 +59,12 @@ func NewCraneProvider(opts ...CraneOption) *CraneProvider {
 
 // ReadRegistries reads the image inventory from one or more registries using
 // google.Walk (recursive) or google.List (non-recursive).
+// baseRegistries, when non-nil, provides the base registry paths used to
+// key the returned inventory. This is needed when registries contain
+// full image paths (e.g. "gcr.io/staging/image") but the inventory must
+// be keyed by the base registry (e.g. "gcr.io/staging").
 func (p *CraneProvider) ReadRegistries(
-	ctx context.Context, registries []RegistryConfig, recurse bool,
+	ctx context.Context, registries []RegistryConfig, recurse bool, baseRegistries []RegistryConfig,
 ) (*Inventory, error) {
 	logrus.Infof("Reading %d registries (recursive: %v)", len(registries), recurse)
 
@@ -72,13 +76,20 @@ func (p *CraneProvider) ReadRegistries(
 		ggcrV1Google.WithContext(ctx),
 	}
 
+	// Use base registries for splitting repo paths into registry+image
+	// name. When not provided, fall back to the registries parameter.
+	splitRegs := baseRegistries
+	if len(splitRegs) == 0 {
+		splitRegs = registries
+	}
+
 	for _, r := range registries {
 		repo, err := name.NewRepository(string(r.Name))
 		if err != nil {
 			return nil, fmt.Errorf("parsing repo name %s: %w", r.Name, err)
 		}
 
-		recordTags := makeTagRecorder(inv, &mu, registries)
+		recordTags := makeTagRecorder(inv, &mu, splitRegs)
 
 		if recurse {
 			if err := ggcrV1Google.Walk(repo, recordTags, walkOpts...); err != nil {

--- a/promoter/image/registry/fake.go
+++ b/promoter/image/registry/fake.go
@@ -72,7 +72,7 @@ func (f *FakeProvider) AddImage(
 
 // ReadRegistries returns the pre-populated inventory.
 func (f *FakeProvider) ReadRegistries(
-	_ context.Context, _ []RegistryConfig, _ bool,
+	_ context.Context, _ []RegistryConfig, _ bool, _ []RegistryConfig,
 ) (*Inventory, error) {
 	if f.ReadRegistriesErr != nil {
 		return nil, f.ReadRegistriesErr

--- a/promoter/image/registry/provider.go
+++ b/promoter/image/registry/provider.go
@@ -32,7 +32,10 @@ import (
 type Provider interface {
 	// ReadRegistries reads the image inventory from one or more registries.
 	// If recurse is true, child repositories are walked recursively.
-	ReadRegistries(ctx context.Context, registries []RegistryConfig, recurse bool) (*Inventory, error)
+	// baseRegistries, when non-nil, provides the base registry paths
+	// (without image name suffixes) used to key the returned inventory.
+	// When nil, the registries parameter is used for keying instead.
+	ReadRegistries(ctx context.Context, registries []RegistryConfig, recurse bool, baseRegistries []RegistryConfig) (*Inventory, error)
 
 	// CopyImage copies a container image from the source reference to the
 	// destination reference. References can be by digest (FQIN) or tag (PQIN).

--- a/promoter/image/registry/provider_test.go
+++ b/promoter/image/registry/provider_test.go
@@ -103,7 +103,7 @@ func TestFakeProviderReadRegistries(t *testing.T) {
 	f := NewFakeProvider()
 	f.AddImage("gcr.io/test", "img", "sha256:abc", "v1")
 
-	inv, err := f.ReadRegistries(context.Background(), nil, false)
+	inv, err := f.ReadRegistries(context.Background(), nil, false, nil)
 	if err != nil {
 		t.Fatalf("ReadRegistries() error = %v", err)
 	}
@@ -116,7 +116,7 @@ func TestFakeProviderReadRegistriesError(t *testing.T) {
 	f := NewFakeProvider()
 	f.ReadRegistriesErr = errors.New("boom")
 
-	_, err := f.ReadRegistries(context.Background(), nil, false)
+	_, err := f.ReadRegistries(context.Background(), nil, false, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/promoter/image/registry/registryfakes/fake_provider.go
+++ b/promoter/image/registry/registryfakes/fake_provider.go
@@ -38,12 +38,13 @@ type FakeProvider struct {
 	copyImageReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ReadRegistriesStub        func(context.Context, []registry.RegistryConfig, bool) (*registry.Inventory, error)
+	ReadRegistriesStub        func(context.Context, []registry.RegistryConfig, bool, []registry.RegistryConfig) (*registry.Inventory, error)
 	readRegistriesMutex       sync.RWMutex
 	readRegistriesArgsForCall []struct {
 		arg1 context.Context
 		arg2 []registry.RegistryConfig
 		arg3 bool
+		arg4 []registry.RegistryConfig
 	}
 	readRegistriesReturns struct {
 		result1 *registry.Inventory
@@ -120,11 +121,16 @@ func (fake *FakeProvider) CopyImageReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeProvider) ReadRegistries(arg1 context.Context, arg2 []registry.RegistryConfig, arg3 bool) (*registry.Inventory, error) {
+func (fake *FakeProvider) ReadRegistries(arg1 context.Context, arg2 []registry.RegistryConfig, arg3 bool, arg4 []registry.RegistryConfig) (*registry.Inventory, error) {
 	var arg2Copy []registry.RegistryConfig
 	if arg2 != nil {
 		arg2Copy = make([]registry.RegistryConfig, len(arg2))
 		copy(arg2Copy, arg2)
+	}
+	var arg4Copy []registry.RegistryConfig
+	if arg4 != nil {
+		arg4Copy = make([]registry.RegistryConfig, len(arg4))
+		copy(arg4Copy, arg4)
 	}
 	fake.readRegistriesMutex.Lock()
 	ret, specificReturn := fake.readRegistriesReturnsOnCall[len(fake.readRegistriesArgsForCall)]
@@ -132,13 +138,14 @@ func (fake *FakeProvider) ReadRegistries(arg1 context.Context, arg2 []registry.R
 		arg1 context.Context
 		arg2 []registry.RegistryConfig
 		arg3 bool
-	}{arg1, arg2Copy, arg3})
+		arg4 []registry.RegistryConfig
+	}{arg1, arg2Copy, arg3, arg4Copy})
 	stub := fake.ReadRegistriesStub
 	fakeReturns := fake.readRegistriesReturns
-	fake.recordInvocation("ReadRegistries", []interface{}{arg1, arg2Copy, arg3})
+	fake.recordInvocation("ReadRegistries", []interface{}{arg1, arg2Copy, arg3, arg4Copy})
 	fake.readRegistriesMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -152,17 +159,17 @@ func (fake *FakeProvider) ReadRegistriesCallCount() int {
 	return len(fake.readRegistriesArgsForCall)
 }
 
-func (fake *FakeProvider) ReadRegistriesCalls(stub func(context.Context, []registry.RegistryConfig, bool) (*registry.Inventory, error)) {
+func (fake *FakeProvider) ReadRegistriesCalls(stub func(context.Context, []registry.RegistryConfig, bool, []registry.RegistryConfig) (*registry.Inventory, error)) {
 	fake.readRegistriesMutex.Lock()
 	defer fake.readRegistriesMutex.Unlock()
 	fake.ReadRegistriesStub = stub
 }
 
-func (fake *FakeProvider) ReadRegistriesArgsForCall(i int) (context.Context, []registry.RegistryConfig, bool) {
+func (fake *FakeProvider) ReadRegistriesArgsForCall(i int) (context.Context, []registry.RegistryConfig, bool, []registry.RegistryConfig) {
 	fake.readRegistriesMutex.RLock()
 	defer fake.readRegistriesMutex.RUnlock()
 	argsForCall := fake.readRegistriesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeProvider) ReadRegistriesReturns(result1 *registry.Inventory, result2 error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Fixes a regression introduced in v4.3.0 where `GetPromotionEdges` passed full-path registries (with image names appended, e.g. `gcr.io/staging/driver`) from `GetRegistriesToRead` to `ReadRegistries`. `makeTagRecorder` used these for `splitByKnownRegistries`, which produced an exact match with an empty image name, keying the inventory as `inv["gcr.io/staging/driver"][""]`.

However, `vertexPropsFor` looks up by the original edge registry name `inv["gcr.io/staging"]["driver"]`, which never matched, causing every source digest to be marked `_LOST_` and **no images to be promoted**.

The fix adds `GetBaseRegistries` to collect the original registry contexts (without image name suffixes) from edges, and passes them to `ReadRegistries` as separate `baseRegistries` for correct inventory keying.

#### Special notes for your reviewer:

This broke all image promotion in production with v4.3.0. The `post-k8sio-image-promo` Prow job succeeds but promotes zero images.

#### Does this PR introduce a user-facing change?

```release-note
Fix regression where image promotion marked all source images as _LOST_ due to registry inventory key mismatch.
```