### PR TITLE
Improve promotion phase logging and remove PrintSection

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -19,8 +19,6 @@ package cip
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -293,24 +291,6 @@ vulnerability check failing [severity levels between 0 and 5; 0 - UNSPECIFIED,
 	)
 }
 
-// logTimingHook is a logrus hook that records elapsed time between log entries.
-type logTimingHook struct {
-	lastTime time.Time
-	mu       sync.RWMutex
-}
-
-func (h *logTimingHook) Fire(e *logrus.Entry) error {
-	h.mu.Lock()
-	e.Data["diff"] = e.Time.Sub(h.lastTime).Round(time.Millisecond)
-	h.lastTime = e.Time
-	h.mu.Unlock()
-	return nil
-}
-
-func (h *logTimingHook) Levels() []logrus.Level {
-	return logrus.AllLevels
-}
-
 func runPromoteCmd(opts *options.Options) error {
 	cip := promoter.New(opts)
 
@@ -319,7 +299,6 @@ func runPromoteCmd(opts *options.Options) error {
 		FullTimestamp:    true,
 		TimestampFormat:  "15:04:05.000",
 	})
-	logrus.AddHook(&logTimingHook{lastTime: time.Now()})
 
 	logrus.Infof("Options to check the Signatures: SignCheckIdentity: %s | SignCheckIdentityRegexp: %s | SignCheckIssuer: %s | SignCheckIssuerRegexp: %s",
 		opts.SignCheckIdentity, opts.SignCheckIdentityRegexp, opts.SignCheckIssuer, opts.SignCheckIssuerRegexp,

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -132,7 +134,10 @@ func (di *DefaultPromoterImplementation) PromoteImages(
 		)
 	}
 
-	logrus.Info("---------- BEGIN PROMOTION ----------")
+	total := len(edges)
+	logrus.Infof("Promoting %d images using %d threads", total, opts.Threads)
+
+	var completed atomic.Int64
 
 	ctx := context.Background()
 	g, ctx := errgroup.WithContext(ctx)
@@ -156,9 +161,11 @@ func (di *DefaultPromoterImplementation) PromoteImages(
 			}
 
 			logrus.Infof("Copying %s to %s", srcVertex, dstVertex)
+			start := time.Now()
 			if err := di.registryProvider.CopyImage(ctx, srcVertex, dstVertex); err != nil {
 				return fmt.Errorf("copying %s to %s: %w", srcVertex, dstVertex, err)
 			}
+			logrus.Infof("Copied %s (%d/%d) in %s", dstVertex, completed.Add(1), total, time.Since(start).Round(time.Millisecond))
 			return nil
 		})
 	}
@@ -167,6 +174,5 @@ func (di *DefaultPromoterImplementation) PromoteImages(
 		return fmt.Errorf("running image promotion: %w", err)
 	}
 
-	di.PrintSection("END (PROMOTION)", true)
 	return nil
 }

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -159,16 +159,6 @@ func (di *DefaultPromoterImplementation) PrintVersion() {
 	logrus.Info(version.Get())
 }
 
-// printSection handles the start/finish labels in the
-// former legacy cli/run code.
-func (di *DefaultPromoterImplementation) PrintSection(message string, confirm bool) {
-	dryRunLabel := ""
-	if !confirm {
-		dryRunLabel = "(DRY RUN) "
-	}
-	logrus.Infof("********** %s %s**********", message, dryRunLabel)
-}
-
 // printSecDisclaimer prints a disclaimer about false positives
 // that may be found in container image layers.
 func (di *DefaultPromoterImplementation) PrintSecDisclaimer() {

--- a/internal/promoter/image/securityscan.go
+++ b/internal/promoter/image/securityscan.go
@@ -60,6 +60,5 @@ func (di *DefaultPromoterImplementation) ScanEdges(
 		}
 	}
 
-	di.PrintSection("END (VULNSCAN)", opts.Confirm)
 	return nil
 }

--- a/internal/promoter/image/snapshot.go
+++ b/internal/promoter/image/snapshot.go
@@ -50,7 +50,6 @@ func (di *DefaultPromoterImplementation) Snapshot(opts *options.Options, rii reg
 	}
 
 	// TODO: Maybe store the snapshot somewhere?
-	di.PrintSection("END (SNAPSHOT)", opts.Confirm)
 	fmt.Println(snapshot)
 	return nil
 }

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -199,12 +199,6 @@ type FakePromoterImplementation struct {
 	printSecDisclaimerMutex       sync.RWMutex
 	printSecDisclaimerArgsForCall []struct {
 	}
-	PrintSectionStub        func(string, bool)
-	printSectionMutex       sync.RWMutex
-	printSectionArgsForCall []struct {
-		arg1 string
-		arg2 bool
-	}
 	PrintVersionStub        func()
 	printVersionMutex       sync.RWMutex
 	printVersionArgsForCall []struct {
@@ -1187,39 +1181,6 @@ func (fake *FakePromoterImplementation) PrintSecDisclaimerCalls(stub func()) {
 	fake.printSecDisclaimerMutex.Lock()
 	defer fake.printSecDisclaimerMutex.Unlock()
 	fake.PrintSecDisclaimerStub = stub
-}
-
-func (fake *FakePromoterImplementation) PrintSection(arg1 string, arg2 bool) {
-	fake.printSectionMutex.Lock()
-	fake.printSectionArgsForCall = append(fake.printSectionArgsForCall, struct {
-		arg1 string
-		arg2 bool
-	}{arg1, arg2})
-	stub := fake.PrintSectionStub
-	fake.recordInvocation("PrintSection", []interface{}{arg1, arg2})
-	fake.printSectionMutex.Unlock()
-	if stub != nil {
-		fake.PrintSectionStub(arg1, arg2)
-	}
-}
-
-func (fake *FakePromoterImplementation) PrintSectionCallCount() int {
-	fake.printSectionMutex.RLock()
-	defer fake.printSectionMutex.RUnlock()
-	return len(fake.printSectionArgsForCall)
-}
-
-func (fake *FakePromoterImplementation) PrintSectionCalls(stub func(string, bool)) {
-	fake.printSectionMutex.Lock()
-	defer fake.printSectionMutex.Unlock()
-	fake.PrintSectionStub = stub
-}
-
-func (fake *FakePromoterImplementation) PrintSectionArgsForCall(i int) (string, bool) {
-	fake.printSectionMutex.RLock()
-	defer fake.printSectionMutex.RUnlock()
-	argsForCall := fake.printSectionArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakePromoterImplementation) PrintVersion() {

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -139,7 +139,6 @@ type promoterImplementation interface {
 	// Utility functions
 	PrintVersion()
 	PrintSecDisclaimer()
-	PrintSection(string, bool)
 }
 
 // PromoteImages is the main method for image promotion.
@@ -176,7 +175,6 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 		}
 
 		p.impl.PrintVersion()
-		p.impl.PrintSection("START (PROMOTION)", opts.Confirm)
 
 		promotionEdges, err = p.impl.GetPromotionEdges(opts, mfests)
 		if err != nil {
@@ -291,7 +289,6 @@ func (p *Promoter) Snapshot(opts *options.Options) (err error) {
 	}
 
 	p.impl.PrintVersion()
-	p.impl.PrintSection("START (SNAPSHOT)", opts.Confirm)
 
 	mfests, err := p.impl.GetSnapshotManifests(opts)
 	if err != nil {
@@ -332,7 +329,6 @@ func (p *Promoter) SecurityScan(opts *options.Options) error {
 	}
 
 	p.impl.PrintVersion()
-	p.impl.PrintSection("START (VULN CHECK)", opts.Confirm)
 	p.impl.PrintSecDisclaimer()
 
 	promotionEdges, err := p.impl.GetPromotionEdges(opts, mfests)

--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -83,7 +83,9 @@ func (p *CraneProvider) ReadRegistries(
 		splitRegs = registries
 	}
 
-	for _, r := range registries {
+	for i, r := range registries {
+		logrus.Infof("Reading registry %d/%d: %s", i+1, len(registries), r.Name)
+
 		repo, err := name.NewRepository(string(r.Name))
 		if err != nil {
 			return nil, fmt.Errorf("parsing repo name %s: %w", r.Name, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Replace legacy `---------- BEGIN PROMOTION ----------` marker with `Promoting N images using M threads`
- Add per-image completion logging with progress counter and timing: `Copied <dst> (N/total) in Xs`
- Add per-registry progress logging during inventory reading: `Reading registry N/total: <name>`
- Remove `PrintSection` entirely since the pipeline already logs phase transitions with timing
- Remove `logTimingHook` that added noisy `diff=0s` to every log line

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Improve promotion logging with per-image progress counters and copy timing
```