### PR TITLE
Fix default promotion threads being zero

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -54,7 +54,9 @@ Promote images from a staging registry to production
 	},
 }
 
-var runOpts = &options.Options{}
+var runOpts = &options.Options{
+	Threads: options.DefaultOptions.Threads,
+}
 
 // TODO: Function 'init' is too long (171 > 60) (funlen)
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Fix `runOpts` zero-initializing `Threads` to `0`, which causes `g.SetLimit(0)` to block all promotion goroutines indefinitely. The `DefaultOptions.Threads` value of `10` was never wired up.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fix default promotion threads being zero, which caused image promotion to hang indefinitely.
```