### PR TITLE
Add Docker manifest v1 to supported media types

### DIFF
--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -206,6 +206,8 @@ func supportedMediaType(mediaType string) (cr.MediaType, error) {
 		return cr.OCIManifestSchema1, nil
 	case cr.OCIImageIndex:
 		return cr.OCIImageIndex, nil
+	case cr.DockerManifestSchema1, cr.DockerManifestSchema1Signed:
+		return cr.MediaType(mediaType), nil
 	default:
 		// Default to DockerManifestSchema2 for backwards compatibility.
 		if mediaType == "" {

--- a/promoter/image/registry/provider_test.go
+++ b/promoter/image/registry/provider_test.go
@@ -211,6 +211,8 @@ func TestSupportedMediaType(t *testing.T) {
 		{"application/vnd.docker.distribution.manifest.list.v2+json", false},
 		{"application/vnd.oci.image.manifest.v1+json", false},
 		{"application/vnd.oci.image.index.v1+json", false},
+		{"application/vnd.docker.distribution.manifest.v1+json", false},
+		{"application/vnd.docker.distribution.manifest.v1+prettyjws", false},
 		{"", false}, // empty defaults to DockerManifestSchema2
 		{"application/vnd.unknown", true},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Add `DockerManifestSchema1` and `DockerManifestSchema1Signed` (`prettyjws`)
to the `supportedMediaType` function. Registries containing old images use
these types, causing ~15k error log lines per promotion run.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Recognize Docker manifest v1 media types to eliminate ~15k spurious error log lines per promotion run.
```