### PR TITLE
Give full rate limit budget to the active phase

### DIFF
--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -51,12 +51,12 @@ type Promoter struct {
 }
 
 func New(opts *options.Options) *Promoter {
-	// Create a budget allocator that splits the rate limit between
-	// promotion (70%) and signing (30%). After promotion completes,
-	// signing gets the full budget via GiveAll.
+	// Create a budget allocator that gives the full rate limit to the
+	// active phase. Promotion runs first with 100% budget, then after
+	// it completes, signing gets the full budget via GiveAll.
 	budget := ratelimit.NewBudgetAllocator(ratelimit.MaxEvents)
-	promoRT := budget.Allocate("promotion", 0.7)
-	signRT := budget.Allocate("signing", 0.3)
+	promoRT := budget.Allocate("promotion", 1.0)
+	signRT := budget.Allocate("signing", 0.0)
 
 	di := impl.NewDefaultPromoterImplementation(opts)
 	di.SetPromotionTransport(promoRT)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Since promotion and signing run sequentially, give 100% of the rate limit budget to promotion instead of splitting 70/30. After promotion completes, `GiveAll` rebalances to signing. This increases promotion throughput from 35 to 50 req/sec.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Give full rate limit budget to the active pipeline phase, increasing promotion throughput from 35 to 50 req/sec.
```