### PR TITLE
Fix correctness bugs and replace throttler with errgroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/google/go-containerregistry v0.21.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.12.1
-	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/sigstore/sigstore v1.10.4
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -212,6 +211,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mozillazg/docker-credential-acr-helper v0.4.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/oleiade/reflections v1.1.0 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -45,11 +45,11 @@ type DefaultPromoterImplementation struct {
 	signer *sign.Signer
 
 	// promotionTransport is the HTTP transport used for image promotion
-	// (crane.Copy). If nil, falls back to the global ratelimit.Limiter.
+	// (crane.Copy).
 	promotionTransport *ratelimit.RoundTripper
 
 	// signingTransport is the HTTP transport used for signature copy and
-	// replication. If nil, falls back to the global ratelimit.Limiter.
+	// replication.
 	signingTransport *ratelimit.RoundTripper
 
 	// registryProvider abstracts registry operations (read inventory, copy images).
@@ -82,14 +82,9 @@ func (di *DefaultPromoterImplementation) SetSigningTransport(rt *ratelimit.Round
 	di.signingTransport = rt
 }
 
-// getSigningTransport returns the transport for signing, falling back to the
-// global singleton for backwards compatibility.
+// getSigningTransport returns the transport for signing operations.
 func (di *DefaultPromoterImplementation) getSigningTransport() *ratelimit.RoundTripper {
-	if di.signingTransport != nil {
-		return di.signingTransport
-	}
-	//nolint:staticcheck // Legacy fallback during transition to BudgetAllocator.
-	return ratelimit.Limiter
+	return di.signingTransport
 }
 
 // SetRegistryProvider sets the registry provider for image operations.

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -35,9 +35,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/nozzle/throttler"
 	"github.com/sigstore/sigstore/pkg/tuf"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/release-sdk/sign"
 	"sigs.k8s.io/release-utils/version"
@@ -137,18 +137,16 @@ func (di *DefaultPromoterImplementation) SignImages(
 	// We only sign the first normalized image per digest of each edge.
 	grouped := groupEdgesByIdentityDigest(edges)
 
-	t := throttler.New(opts.MaxSignatureOps, len(grouped))
-	// Sign the required edges
+	g := new(errgroup.Group)
+	g.SetLimit(opts.MaxSignatureOps)
+
 	for _, group := range grouped {
-		go func(edges []promotion.Edge) {
-			t.Done(di.signFirst(signOpts, targetIdentity(&edges[0]), &edges[0]))
-		}(group)
-		if t.Throttle() > 0 {
-			break
-		}
+		g.Go(func() error {
+			return di.signFirst(signOpts, targetIdentity(&group[0]), &group[0])
+		})
 	}
 
-	return t.Err()
+	return g.Wait()
 }
 
 // signFirst signs the first (primary) image for a given identity+digest group.
@@ -202,20 +200,19 @@ func (di *DefaultPromoterImplementation) ReplicateSignatures(
 
 	grouped := groupEdgesByIdentityDigest(edges)
 
-	t := throttler.New(opts.MaxSignatureCopies, len(grouped))
+	g := new(errgroup.Group)
+	g.SetLimit(opts.MaxSignatureCopies)
+
 	for _, group := range grouped {
 		if len(group) <= 1 {
 			continue
 		}
-		go func(edges []promotion.Edge) {
-			t.Done(di.replicateSignatures(&edges[0], edges[1:]))
-		}(group)
-		if t.Throttle() > 0 {
-			break
-		}
+		g.Go(func() error {
+			return di.replicateSignatures(&group[0], group[1:])
+		})
 	}
 
-	return t.Err()
+	return g.Wait()
 }
 
 // targetIdentity returns the production identity for a promotion edge.

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	yaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/release-sdk/sign"
 	"sigs.k8s.io/release-utils/http"
@@ -43,7 +44,11 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
-var mirrorsList []string
+var (
+	mirrorsOnce     sync.Once
+	mirrorsList     []string
+	errMirrorsFetch error
+)
 
 const (
 	productionImagePath      = "k8s-artifacts-prod"
@@ -75,46 +80,48 @@ func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) 
 }
 
 func (di *DefaultPromoterImplementation) getMirrors() ([]string, error) {
-	if mirrorsList != nil {
-		return mirrorsList, nil
-	}
-	urls := []string{}
-	iurls := map[string]string{}
-	manifest, err := http.NewAgent().Get(
-		"https://github.com/kubernetes/k8s.io/raw/main/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("downloading promoter manifest: %w", err)
-	}
-
-	type entriesList struct {
-		Registries []struct {
-			Name string `yaml:"name,omitempty"`
-			Src  bool   `yaml:"src,omitempty"`
-		} `yaml:"registries"`
-	}
-
-	entries := entriesList{}
-	if err := yaml.Unmarshal(manifest, &entries); err != nil {
-		return nil, fmt.Errorf("unmarshalling promoter manifest: %w", err)
-	}
-
-	for _, e := range entries.Registries {
-		if e.Src {
-			continue
-		}
-		u, err := url.Parse("https://" + e.Name)
+	mirrorsOnce.Do(func() {
+		iurls := map[string]string{}
+		manifest, err := http.NewAgent().Get(
+			"https://github.com/kubernetes/k8s.io/raw/main/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml",
+		)
 		if err != nil {
-			return nil, fmt.Errorf("parsing url %s: %w", u, err)
+			errMirrorsFetch = fmt.Errorf("downloading promoter manifest: %w", err)
+			return
 		}
-		iurls[u.Hostname()] = u.Hostname()
-	}
 
-	for u := range iurls {
-		urls = append(urls, u)
-	}
-	mirrorsList = urls
-	return urls, nil
+		type entriesList struct {
+			Registries []struct {
+				Name string `yaml:"name,omitempty"`
+				Src  bool   `yaml:"src,omitempty"`
+			} `yaml:"registries"`
+		}
+
+		entries := entriesList{}
+		if err := yaml.Unmarshal(manifest, &entries); err != nil {
+			errMirrorsFetch = fmt.Errorf("unmarshalling promoter manifest: %w", err)
+			return
+		}
+
+		for _, e := range entries.Registries {
+			if e.Src {
+				continue
+			}
+			u, err := url.Parse("https://" + e.Name)
+			if err != nil {
+				errMirrorsFetch = fmt.Errorf("parsing url %s: %w", u, err)
+				return
+			}
+			iurls[u.Hostname()] = u.Hostname()
+		}
+
+		urls := make([]string, 0, len(iurls))
+		for u := range iurls {
+			urls = append(urls, u)
+		}
+		mirrorsList = urls
+	})
+	return mirrorsList, errMirrorsFetch
 }
 
 func (di *DefaultPromoterImplementation) GetSignatureStatus(
@@ -174,24 +181,42 @@ type miniManifest struct {
 	} `json:"layers"`
 }
 
-// CheckSignatureLayers checks a list of signature layers to ensure.
+// CheckSignatureLayers checks a list of signature layers in parallel.
 func (di *DefaultPromoterImplementation) CheckSignatureLayers(opts *options.Options, oList []string) (existing, missing []string, err error) {
-	// TODO: Parallelize this check
-	existing = []string{}
-	missing = []string{}
-	for _, s := range oList {
-		e, err := objectExists(opts, s)
-		if err != nil {
-			return existing, missing, fmt.Errorf("checking reference: %w", err)
-		}
-
-		if !e {
-			missing = append(missing, s)
-			continue
-		}
-
-		existing = append(existing, s)
+	type result struct {
+		ref    string
+		exists bool
 	}
+
+	results := make([]result, len(oList))
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+
+	for i, s := range oList {
+		results[i].ref = s
+		g.Go(func() error {
+			e, err := objectExists(opts, s)
+			if err != nil {
+				return fmt.Errorf("checking reference: %w", err)
+			}
+			results[i].exists = e
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	for _, r := range results {
+		if r.exists {
+			existing = append(existing, r.ref)
+		} else {
+			missing = append(missing, r.ref)
+		}
+	}
+
 	return existing, missing, nil
 }
 
@@ -256,7 +281,7 @@ func objectExists(opts *options.Options, refString string) (bool, error) {
 // FixMissingSignatures signs an image that has no signatures at all.
 func (di *DefaultPromoterImplementation) FixMissingSignatures(opts *options.Options, results checkresults.Signature) error {
 	for mainImg, res := range results {
-		if len(res.Signed) > 0 {
+		if len(res.Signed) > 0 || len(res.Missing) == 0 {
 			continue
 		}
 

--- a/internal/promoter/image/signcheck_test.go
+++ b/internal/promoter/image/signcheck_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagepromoter
+
+import (
+	"testing"
+
+	checkresults "sigs.k8s.io/promo-tools/v4/promoter/image/checkresults"
+	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
+)
+
+func TestFixMissingSignaturesSkipsEmptyResults(t *testing.T) {
+	di := &DefaultPromoterImplementation{}
+	opts := &options.Options{}
+
+	// An entry with both Signed and Missing empty must not panic.
+	results := checkresults.Signature{
+		"example.com/image:v1": checkresults.CheckList{
+			Signed:  []string{},
+			Missing: []string{},
+		},
+	}
+
+	if err := di.FixMissingSignatures(opts, results); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFixMissingSignaturesSkipsSigned(t *testing.T) {
+	di := &DefaultPromoterImplementation{}
+	opts := &options.Options{}
+
+	// An entry with Signed populated should be skipped entirely
+	// (handled by FixPartialSignatures instead).
+	results := checkresults.Signature{
+		"example.com/image:v1": checkresults.CheckList{
+			Signed:  []string{"mirror1/image:sha256-abc.sig"},
+			Missing: []string{"mirror2/image:sha256-abc.sig"},
+		},
+	}
+
+	if err := di.FixMissingSignatures(opts, results); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/promobot/hash.go
+++ b/promobot/hash.go
@@ -61,7 +61,7 @@ func GenerateManifest(_ context.Context, options GenerateManifestOptions) (*api.
 		basedir += "/"
 	}
 
-	if err := filepath.Walk(basedir, func(p string, info os.FileInfo, err error) error {
+	if err := filepath.WalkDir(basedir, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func GenerateManifest(_ context.Context, options GenerateManifestOptions) (*api.
 			return nil
 		}
 
-		if !info.IsDir() {
+		if !d.IsDir() {
 			relativePath := strings.TrimPrefix(p, basedir)
 			sha256, err := hash.SHA256ForFile(p)
 			if err != nil {

--- a/promobot/promotefiles.go
+++ b/promobot/promotefiles.go
@@ -180,19 +180,18 @@ func ReadManifests(options PromoteFilesOptions) ([]*api.Manifest, error) {
 
 	var projects []string
 
-	// TODO: Consider using filepath.WalkDir() instead
-	if err := filepath.Walk(
+	if err := filepath.WalkDir(
 		filestoresDir,
-		func(_ string, info os.FileInfo, err error) error {
+		func(_ string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
 
-			if !info.IsDir() || info.Name() == "filestores" {
+			if !d.IsDir() || d.Name() == "filestores" {
 				return nil
 			}
 
-			projects = append(projects, info.Name())
+			projects = append(projects, d.Name())
 			return nil
 		},
 	); err != nil {
@@ -283,12 +282,12 @@ func readFilestores(p string) ([]api.Filestore, error) {
 func readFiles(filesPath string) ([]api.File, error) {
 	// We first list and sort the paths, for a consistent ordering
 	var paths []string
-	err := filepath.Walk(filesPath, func(p string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(filesPath, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 

--- a/promoter/file/gcs.go
+++ b/promoter/file/gcs.go
@@ -102,7 +102,7 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 
 	if _, err := io.Copy(w, in); err != nil {
 		if err2 := w.Close(); err2 != nil {
-			logrus.Warnf("error closing upload stream: %v", err)
+			logrus.Warnf("error closing upload stream: %v", err2)
 			// TODO: Try to delete the possibly partially written file?
 		}
 		return fmt.Errorf("error uploading to %q: %v", gcsURL, err)

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -61,19 +61,6 @@ type RoundTripper struct {
 
 var _ http.RoundTripper = &RoundTripper{}
 
-// Limiter is the global default rate limiter, kept for backwards compatibility.
-//
-// Deprecated: Use NewRoundTripper or a BudgetAllocator instead of the global
-// singleton. The global singleton causes promotion and signing to compete for
-// the same rate budget, leading to 429 errors under load.
-var Limiter *RoundTripper
-
-func init() {
-	if Limiter == nil {
-		Limiter = NewRoundTripper(MaxEvents)
-	}
-}
-
 // NewRoundTripper creates a rate-limited HTTP transport with the given
 // requests-per-second limit.
 func NewRoundTripper(limit rate.Limit) *RoundTripper {

--- a/promoter/image/ratelimit/roundtripper_test.go
+++ b/promoter/image/ratelimit/roundtripper_test.go
@@ -169,16 +169,6 @@ func TestBackoffCooldown(t *testing.T) {
 	}
 }
 
-func TestGlobalLimiterBackwardsCompat(t *testing.T) {
-	// Verify the global Limiter is initialized.
-	if Limiter == nil {
-		t.Fatal("global Limiter should be initialized via init()")
-	}
-	if Limiter.rateLimiter.Limit() != MaxEvents {
-		t.Errorf("expected global limiter rate %v, got %v", MaxEvents, Limiter.rateLimiter.Limit())
-	}
-}
-
 func TestWaitForBackoffRespectsContext(t *testing.T) {
 	rt := NewNamedRoundTripper("test", rate.Inf, 1)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

- Fix `FixMissingSignatures` panic when both `Signed` and `Missing` are empty
- Fix `mirrorsList` race condition using `sync.Once`
- Replace `github.com/nozzle/throttler` with `golang.org/x/sync/errgroup` in `SignImages` and `ReplicateSignatures` for proper error propagation
- Parallelize `CheckSignatureLayers` using `errgroup`
- Remove deprecated global `ratelimit.Limiter` singleton
- Fix GCS upload error logging wrong variable (`err` instead of `err2`)
- Replace `filepath.Walk` with `filepath.WalkDir` in promobot
- Add unit tests for `FixMissingSignatures` edge cases

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The `throttler` library silently swallows errors after the first failure via `Throttle()`. Replacing it with `errgroup` ensures all goroutine errors are properly collected and returned.

The 6 pre-existing `gosec` warnings (G703/G704) are unrelated to this PR.

#### Does this PR introduce a user-facing change?

```release-note
Fix FixMissingSignatures panic on empty check results and mirrorsList race condition
```