### PR TITLE
Update golangci-lint to v2.10.1 and enable additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,28 +4,40 @@ run:
 linters:
   default: none
   enable:
+    - arangolint
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
     - canonicalheader
+    - containedctx
     - contextcheck
     - copyloopvar
+    - cyclop
     - decorder
     - dogsled
     - dupl
     - dupword
     - durationcheck
+    - embeddedstructfieldcheck
     - errcheck
     - errchkjson
     - errname
+    - errorlint
+    - exhaustive
+    - exptostd
     - fatcontext
+    - forcetypeassert
+    - funcorder
+    - funlen
     - ginkgolinter
     - gocheckcompilerdirectives
     - gochecksumtype
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
+    - godoclint
     - godot
     - godox
     - goheader
@@ -36,15 +48,29 @@ linters:
     - gosmopolitan
     - govet
     - grouper
+    - iface
     - importas
     - ineffassign
+    - interfacebloat
     - intrange
+    - iotamixing
+    - ireturn
     - loggercheck
+    - maintidx
     - makezero
     - mirror
     - misspell
+    - modernize
+    - musttag
     - nakedret
+    - nestif
+    - nilerr
+    - nilnesserr
+    - nilnil
+    - nlreturn
+    - noctx
     - nolintlint
+    - nonamedreturns
     - nosprintfhostport
     - perfsprint
     - prealloc
@@ -52,6 +78,7 @@ linters:
     - promlinter
     - protogetter
     - reassign
+    - recvcheck
     - revive
     - rowserrcheck
     - sloglint
@@ -59,92 +86,50 @@ linters:
     - sqlclosecheck
     - staticcheck
     - tagalign
+    - tagliatelle
     - testableexamples
     - testifylint
+    - thelper
     - tparallel
     - unconvert
     - unparam
+    - unqueryvet
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
+    - wrapcheck
+    - wsl_v5
     - zerologlint
+    # - depguard
+    # - err113
+    # - exhaustruct
+    # - forbidigo
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - inamedparam
+    # - lll
+    # - mnd
+    # - noinlineerr
+    # - paralleltest
+    # - testpackage
+    # - varnamelen
   settings:
+    cyclop:
+      max-complexity: 30
     errcheck:
       check-type-assertions: true
       check-blank: true
+    exhaustive:
+      default-signifies-exhaustive: true
+    funlen:
+      lines: 200
+      statements: 80
+    gocognit:
+      min-complexity: 55
     gocritic:
-      enabled-checks:
-        - appendCombine
-        - badLock
-        - badRegexp
-        - badSorting
-        - boolExprSimplify
-        - builtinShadow
-        - builtinShadowDecl
-        - commentedOutCode
-        - commentedOutImport
-        - deferInLoop
-        - deferUnlambda
-        - docStub
-        - dupImport
-        - dynamicFmtString
-        - emptyDecl
-        - emptyFallthrough
-        - emptyStringTest
-        - equalFold
-        - evalOrder
-        - exposedSyncMutex
-        - externalErrorReassign
-        - filepathJoin
-        - hexLiteral
-        - httpNoBody
-        - hugeParam
-        - importShadow
-        - indexAlloc
-        - initClause
-        - methodExprCall
-        - nestingReduce
-        - nilValReturn
-        - octalLiteral
-        - paramTypeCombine
-        - preferDecodeRune
-        - preferFilepathJoin
-        - preferFprint
-        - preferStringWriter
-        - preferWriteByte
-        - ptrToRefParam
-        - rangeExprCopy
-        - rangeValCopy
-        - redundantSprint
-        - regexpPattern
-        - regexpSimplify
-        - returnAfterHttpError
-        - ruleguard
-        - sliceClear
-        - sloppyReassign
-        - sortSlice
-        - sprintfQuotedString
-        - sqlQuery
-        - stringConcatSimplify
-        - stringXbytes
-        - stringsCompare
-        - syncMapLoadAndDelete
-        - timeExprSimplify
-        - tooManyResultsChecker
-        - truncateCmp
-        - typeAssertChain
-        - typeDefFirst
-        - typeUnparen
-        - uncheckedInlineErr
-        - unlabelStmt
-        - unnamedResult
-        - unnecessaryBlock
-        - unnecessaryDefer
-        - weakCond
-        - yodaStyleExpr
-        - badSyncOnceFunc
-        - todoCommentWithoutDetail
+      enabled-all: true
     gocyclo:
       min-complexity: 40
     godox:
@@ -152,6 +137,10 @@ linters:
         - BUG
         - FIXME
         - HACK
+    interfacebloat:
+      max: 25
+    nestif:
+      min-complexity: 7
     nolintlint:
       require-explanation: false
       require-specific: true
@@ -171,7 +160,6 @@ linters:
       - linters:
           - dupl
           - gocritic
-          - golint
         path: fake_.*\.go
     paths:
       - third_party$

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,10 @@ update: ## Update go modules (source of truth!).
 update-mocks: ## Update all generated mocks
 	go generate ./...
 	for f in $(shell find . -name fake_*.go); do \
-		cp hack/boilerplate/boilerplate.generatego.txt tmp ;\
-		cat $$f >> tmp ;\
-		mv tmp $$f ;\
+		t=$$(mktemp) ;\
+		cp hack/boilerplate/boilerplate.generatego.txt $$t ;\
+		cat $$f >> $$t ;\
+		mv $$t $$f ;\
 	done
 
 ##@ Verify

--- a/api/files/manifest.go
+++ b/api/files/manifest.go
@@ -39,7 +39,7 @@ type Filestore struct {
 	// It is everything that is not the actual file name itself.
 	// e.g. "gs://prod-artifacts/myproject"
 	Base           string `json:"base,omitempty"`
-	ServiceAccount string `json:"service-account,omitempty"`
+	ServiceAccount string `json:"service-account,omitempty"` //nolint:tagliatelle // API field
 	Src            bool   `json:"src,omitempty"`
 }
 
@@ -67,7 +67,8 @@ type Manifest struct {
 func ParseManifest(b []byte) (*Manifest, error) {
 	m := &Manifest{}
 	if err := yaml.Unmarshal(b, m); err != nil {
-		return nil, fmt.Errorf("error parsing manifest: %v", err)
+		return nil, fmt.Errorf("error parsing manifest: %w", err)
 	}
+
 	return m, nil
 }

--- a/api/files/manifest_test.go
+++ b/api/files/manifest_test.go
@@ -139,14 +139,18 @@ func TestValidateFiles(t *testing.T) {
 }
 
 func checkErrorMatchesExpected(t *testing.T, err error, expected string) {
+	t.Helper()
+
 	if err != nil && expected == "" {
 		t.Errorf("unexpected error: %v", err)
 	}
+
 	if err != nil && expected != "" {
 		if !strings.Contains(err.Error(), expected) {
 			t.Errorf("error %v did not contain expected %v", err, expected)
 		}
 	}
+
 	if err == nil && expected != "" {
 		t.Errorf("expected error %q", expected)
 	}

--- a/api/files/validation.go
+++ b/api/files/validation.go
@@ -44,6 +44,7 @@ func ValidateFilestores(filestores []Filestore) error {
 	}
 
 	var source *Filestore
+
 	destinationCount := 0
 
 	for i := range filestores {
@@ -69,11 +70,13 @@ func ValidateFilestores(filestores []Filestore) error {
 			if source != nil {
 				return errors.New("found multiple source filestores")
 			}
+
 			source = filestore
 		} else {
 			destinationCount++
 		}
 	}
+
 	if source == nil {
 		return errors.New("source filestore not found")
 	}

--- a/cmd/count-requests/main.go
+++ b/cmd/count-requests/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,9 +55,11 @@ type response struct {
 
 // getSubProjects all sub-projects found in kubernetes/k8s.io.
 func getSubProjects() []string {
-	var cmd *exec.Cmd
-	var out []byte
-	var err error
+	var (
+		cmd *exec.Cmd
+		out []byte
+		err error
+	)
 
 	fmt.Println("Retrieving all kubernetes/k8s.io sub-projects...")
 
@@ -68,25 +71,27 @@ func getSubProjects() []string {
 		}
 	}
 	// Create a temporary directory.
-	cmd = exec.Command("mktemp", "-d")
+	cmd = exec.CommandContext(context.Background(), "mktemp", "-d")
 	out, err = cmd.Output()
 	handle(cmd, err)
+
 	tmpDir := strings.TrimSpace(string(out))
 	// Clone the kubernetes/k8s.io repo.
-	cmd = exec.Command("git", "clone", "https://github.com/kubernetes/k8s.io.git", tmpDir)
+	cmd = exec.CommandContext(context.Background(), "git", "clone", "https://github.com/kubernetes/k8s.io.git", tmpDir)
 	_, err = cmd.Output()
 	handle(cmd, err)
 	// List the number of sub-projects in the repo.
 	subProjects := tmpDir + "/k8s.gcr.io/manifests"
-	cmd = exec.Command("ls", subProjects)
+	cmd = exec.CommandContext(context.Background(), "ls", subProjects)
 	out, err = cmd.Output()
 	handle(cmd, err)
 	// Clear the temporary directory.
-	cmd = exec.Command("rm", "-r", tmpDir)
+	cmd = exec.CommandContext(context.Background(), "rm", "-r", tmpDir)
 	_, err = cmd.Output()
 	handle(cmd, err)
 	// Parse the sub-projects into a list of strings.
 	results := []string{}
+
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	for scanner.Scan() {
 		subProject := scanner.Text()
@@ -94,6 +99,7 @@ func getSubProjects() []string {
 			results = append(results, subProject)
 		}
 	}
+
 	return results
 }
 
@@ -108,23 +114,35 @@ func getPayload(resp *http.Response) response {
 	if err != nil {
 		panic(err)
 	}
+
 	var data response
+
 	err = json.Unmarshal(body, &data)
 	if err != nil {
 		panic(err)
 	}
+
 	resp.Body.Close()
+
 	return data
 }
 
 func makeRequest(query string) response {
-	var resp *http.Response
-	var payload response
-	var err error
+	var (
+		resp    *http.Response
+		payload response
+		err     error
+	)
 
 	// Keep requesting until valid response or too many retries.
+
 	for retries := 5; retries >= 1; retries-- {
-		resp, err = http.Get(query) //nolint: gosec
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, query, http.NoBody)
+		if reqErr != nil {
+			panic(reqErr)
+		}
+
+		resp, err = http.DefaultClient.Do(req) //nolint:gosec // URL constructed from trusted config
 		if err == nil {
 			payload = getPayload(resp)
 		} else if retries == 0 {
@@ -160,6 +178,7 @@ func (r *request) countQueries() int {
 			queries++
 		}
 	}
+
 	return queries
 }
 
@@ -172,11 +191,13 @@ finds the sub-project that requires the most requests to validate.`)
 
 func main() {
 	var subProject string
+
 	if len(os.Args) > 2 {
 		fmt.Println("Invalid number of arguments!")
 		printUsage()
 		os.Exit(1)
 	}
+
 	if len(os.Args) == 2 {
 		subProject = os.Args[1]
 		r := request{
@@ -184,10 +205,12 @@ func main() {
 			repo:     subProject,
 		}
 		fmt.Printf("The Auditor would make %d queries to GCR.\n", r.countQueries())
+
 		return
 	}
 	// Find the sub-project requiring the largest number of queries to verify.
 	maxQueries := 0
+
 	for _, sp := range getSubProjects() {
 		r := request{
 			registry: "gcr.io",
@@ -195,10 +218,12 @@ func main() {
 		}
 		numQueries := r.countQueries()
 		fmt.Printf("Sub-project %q requires %d queries.\n", sp, numQueries)
+
 		if maxQueries < numQueries {
 			maxQueries = numQueries
 			subProject = sp
 		}
 	}
+
 	fmt.Printf("[MAX] %q takes %d queries to verify.\n", subProject, maxQueries)
 }

--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -50,6 +50,7 @@ Promote images from a staging registry to production
 		if err := runPromoteCmd(runOpts); err != nil {
 			return fmt.Errorf("run `cip run`: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -58,9 +59,7 @@ var runOpts = &options.Options{
 	Threads: options.DefaultOptions.Threads,
 }
 
-// TODO: Function 'init' is too long (171 > 60) (funlen)
-//
-//nolint:funlen
+//nolint:funlen // cobra command initialization requires many flags
 func init() {
 	CipCmd.PersistentFlags().BoolVar(
 		&runOpts.Confirm,
@@ -194,6 +193,7 @@ network from a registry, it reads from the local manifests only`,
 		0,
 		"the maximum image size (in MiB) allowed for promotion",
 	)
+
 	if err := CipCmd.PersistentFlags().MarkHidden("max-image-size"); err != nil {
 		logrus.Infof("Failed to mark max-image-size flag as hidden: %v", err)
 	}
@@ -308,12 +308,20 @@ func runPromoteCmd(opts *options.Options) error {
 
 	// Snapshots
 	if opts.Snapshot != "" || opts.ManifestBasedSnapshotOf != "" {
-		return cip.Snapshot(opts)
+		if err := cip.Snapshot(opts); err != nil {
+			return fmt.Errorf("snapshot: %w", err)
+		}
+
+		return nil
 	}
 
 	// Security scan
 	if opts.SeverityThreshold >= 0 {
-		return cip.SecurityScan(opts)
+		if err := cip.SecurityScan(opts); err != nil {
+			return fmt.Errorf("security scan: %w", err)
+		}
+
+		return nil
 	}
 
 	// Image promotion

--- a/cmd/kpromo/cmd/cip/replicate.go
+++ b/cmd/kpromo/cmd/cip/replicate.go
@@ -50,6 +50,7 @@ Example usage:
 		if err := p.ReplicateSignatures(context.Background(), runOpts); err != nil {
 			return fmt.Errorf("replicate signatures: %w", err)
 		}
+
 		return nil
 	},
 }

--- a/cmd/kpromo/cmd/gh/gh.go
+++ b/cmd/kpromo/cmd/gh/gh.go
@@ -152,6 +152,7 @@ func checkRequiredFlags(flags *pflag.FlagSet) error {
 	}
 
 	checkRequiredFlags := []string{}
+
 	flags.VisitAll(func(flag *pflag.Flag) {
 		for _, requiredflag := range requiredFlags {
 			if requiredflag == flag.Name && !flag.Changed {
@@ -177,14 +178,17 @@ func run(opts *options) error {
 	}
 
 	releaseCfgs := &gh2gcs.Config{}
+
 	if opts.configFilePath != "" {
 		logrus.Infof("Reading the config file %s...", opts.configFilePath)
+
 		data, err := os.ReadFile(opts.configFilePath)
 		if err != nil {
 			return fmt.Errorf("failed to read the file: %w", err)
 		}
 
 		logrus.Info("Parsing the config...")
+
 		err = yaml.UnmarshalStrict(data, &releaseCfgs)
 		if err != nil {
 			return fmt.Errorf("failed to decode the file: %w", err)
@@ -219,6 +223,7 @@ func run(opts *options) error {
 		if err := gh2gcs.DownloadReleases(&releaseCfg, gh, opts.outputDir); err != nil {
 			return fmt.Errorf("downloading release assets: %w", err)
 		}
+
 		logrus.Infof("Files downloaded to %s directory", opts.outputDir)
 
 		if !opts.downloadOnly {

--- a/cmd/kpromo/cmd/manifest/files.go
+++ b/cmd/kpromo/cmd/manifest/files.go
@@ -38,6 +38,7 @@ var filesCmd = &cobra.Command{
 		if err := runFileManifest(filesOpts); err != nil {
 			return fmt.Errorf("run `kpromo manifest files`: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -62,8 +63,7 @@ func init() {
 		"only export files starting with the provided prefix",
 	)
 
-	// TODO: Consider moving this into a validation function
-	//nolint:errcheck
+	//nolint:errcheck // flag is required, error handled by cobra at runtime
 	filesCmd.MarkPersistentFlagRequired("src")
 
 	ManifestCmd.AddCommand(filesCmd)
@@ -81,7 +81,7 @@ func runFileManifest(opts *promobot.GenerateManifestOptions) error {
 
 	manifest, err := promobot.GenerateManifest(ctx, *opts)
 	if err != nil {
-		return err
+		return fmt.Errorf("generating manifest: %w", err)
 	}
 
 	manifestYAML, err := yaml.Marshal(manifest)
@@ -90,7 +90,7 @@ func runFileManifest(opts *promobot.GenerateManifestOptions) error {
 	}
 
 	if _, err := os.Stdout.Write(manifestYAML); err != nil {
-		return err
+		return fmt.Errorf("writing manifest to stdout: %w", err)
 	}
 
 	return nil

--- a/cmd/kpromo/cmd/manifest/validate.go
+++ b/cmd/kpromo/cmd/manifest/validate.go
@@ -74,11 +74,14 @@ the yaml file manifests can be found. For example:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			cmd.Use = "validate [ manifestsPath | filestores.yaml files1.yaml ]"
+
 			return cmd.Help()
 		}
+
 		if err := runValidate(args); err != nil {
 			return fmt.Errorf("validating manifests: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -104,6 +107,7 @@ func validateSingle(filestoresPath, filesPath string) error {
 	if err != nil {
 		return fmt.Errorf("opening filestores manifest file: %w", err)
 	}
+
 	if i.IsDir() {
 		return errors.New("first argument has to be a yaml file defining the filestores")
 	}
@@ -117,9 +121,11 @@ func validateSingle(filestoresPath, filesPath string) error {
 	}
 
 	if err := m.Validate(); err != nil {
-		return err
+		return fmt.Errorf("validating manifest: %w", err)
 	}
+
 	logrus.Infof("Manifest correctly validated from:\n - FileStores: %s\n - Files: %s", filestoresPath, filesPath)
+
 	return nil
 }
 
@@ -129,6 +135,7 @@ func validateDirectory(mPath string) error {
 	if err != nil {
 		return fmt.Errorf("opening manifest path %s: %w", mPath, err)
 	}
+
 	if !i.IsDir() {
 		return fmt.Errorf("path is not a directory: %s", mPath)
 	}
@@ -139,11 +146,14 @@ func validateDirectory(mPath string) error {
 	if err != nil {
 		return fmt.Errorf("reading manifests from %s: %w", mPath, err)
 	}
+
 	for i, m := range manifests {
 		if err := m.Validate(); err != nil {
 			return fmt.Errorf("validating manifest %d from %s: %w", i, mPath, err)
 		}
 	}
+
 	logrus.Infof("%d correct manifests found in %s", len(manifests), mPath)
+
 	return nil
 }

--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -77,6 +77,7 @@ func (o *promoteOptions) Validate() error {
 	if len(o.tags) == 0 {
 		return errors.New("cannot start promotion --tag is required")
 	}
+
 	if o.userFork == "" {
 		return errors.New("cannot start promotion --fork is required")
 	}
@@ -91,6 +92,7 @@ func (o *promoteOptions) Validate() error {
 	if !isSet || token == "" {
 		return fmt.Errorf("cannot promote images if GitHub token env var %s is not set", github.TokenEnvKey)
 	}
+
 	return nil
 }
 
@@ -192,6 +194,7 @@ func runPromote(opts *promoteOptions) error {
 	if err != nil {
 		return fmt.Errorf("parsing user's fork: %w", err)
 	}
+
 	if userForkRepo == "" {
 		userForkRepo = k8sioRepo
 	}
@@ -211,6 +214,7 @@ func runPromote(opts *promoteOptions) error {
 		// Set a minimal depth to prevent downloading the whole repository.
 		Depth: 1,
 	}
+
 	repo, err := github.PrepareFork(branchname, git.DefaultGithubOrg, k8sioRepo, userForkOrg, userForkRepo, opts.useSSH, opts.updateRepo, gitCloneOpts)
 	if err != nil {
 		return fmt.Errorf("while preparing k/k8s.io fork: %w", err)
@@ -239,6 +243,7 @@ func runPromote(opts *promoteOptions) error {
 	if mustRun(opts, "Grow the manifests to add the new tags?") {
 		if helpers.Exists(filepath.Join(repo.Dir(), imagesListPath)) {
 			logrus.Debug("Reading the current image promoter manifest (image list)")
+
 			oldlist, err = os.ReadFile(filepath.Join(repo.Dir(), imagesListPath))
 			if err != nil {
 				return fmt.Errorf("while reading the current promoter image list: %w", err)
@@ -257,6 +262,7 @@ func runPromote(opts *promoteOptions) error {
 		}
 
 		logrus.Infof("Growing manifests for images matching filter %s and matching tag %s", opts.images, opts.tags)
+
 		if err := manifest.Grow(ctx, &opt); err != nil {
 			return fmt.Errorf("growing manifest with image filter %s and tag %s: %w", opts.images, opts.tags, err)
 		}
@@ -295,12 +301,14 @@ func runPromote(opts *promoteOptions) error {
 		// If the manifest was not modified, exit now
 		if bytes.Equal(newlist, oldlist) {
 			logrus.Info("No changes detected in the promoter images list, exiting without changes")
+
 			return nil
 		}
 	}
 
 	// add the modified manifest to staging
 	logrus.Debugf("Adding %s to staging area", imagesListPath)
+
 	if err := repo.Add(imagesListPath); err != nil {
 		return fmt.Errorf("adding image manifest to staging area: %w", err)
 	}
@@ -312,6 +320,7 @@ func runPromote(opts *promoteOptions) error {
 
 	// Commit files
 	logrus.Debug("Creating commit")
+
 	if err := repo.UserCommit(commitMessage); err != nil {
 		return fmt.Errorf("creating commit in %s/%s: %w", git.DefaultGithubOrg, k8sioRepo, err)
 	}
@@ -319,13 +328,14 @@ func runPromote(opts *promoteOptions) error {
 	// Push to fork
 	if mustRun(opts, fmt.Sprintf("Push changes to user's fork at %s/%s?", userForkOrg, userForkRepo)) {
 		logrus.Infof("Pushing manifest changes to %s/%s", userForkOrg, userForkRepo)
+
 		if err := repo.PushToRemote(github.UserForkName, branchname); err != nil {
 			return fmt.Errorf("pushing %s to %s/%s: %w", github.UserForkName, userForkOrg, userForkRepo, err)
 		}
 	} else {
 		// Exit if no push was made
-
 		logrus.Infof("Exiting without creating a PR since changes were not pushed to %s/%s", userForkOrg, userForkRepo)
+
 		return nil
 	}
 
@@ -339,6 +349,7 @@ func runPromote(opts *promoteOptions) error {
 		if err != nil {
 			return fmt.Errorf("creating the pull request in k/k8s.io: %w", err)
 		}
+
 		logrus.Infof(
 			"Successfully created PR: %s%s/%s/pull/%d",
 			github.GitHubURL, git.DefaultGithubOrg, k8sioRepo, pr.GetNumber(),
@@ -354,17 +365,23 @@ func mustRun(opts *promoteOptions, question string) bool {
 	if !opts.interactiveMode {
 		return true
 	}
+
 	_, success, err := helpers.Ask(question+" (Y/n)", "y:Y:yes|n:N:no|y", 10)
 	if err != nil {
 		logrus.Error(err)
-		if userInputErr, ok := err.(helpers.UserInputError); ok && userInputErr.IsCtrlC() {
+
+		var userInputErr helpers.UserInputError
+		if errors.As(err, &userInputErr) {
 			os.Exit(1)
 		}
+
 		return false
 	}
+
 	if success {
 		return true
 	}
+
 	return false
 }
 
@@ -387,14 +404,17 @@ func generatePRBody(opts *promoteOptions) string {
 	for _, tag := range opts.tags {
 		tagString.WriteString(" --tag " + tag)
 	}
+
 	args += tagString.String()
 
 	var imageString strings.Builder
+
 	for _, filterImage := range opts.images {
 		if filterImage != "" {
 			imageString.WriteString(" --image " + filterImage)
 		}
 	}
+
 	args += imageString.String()
 
 	prBody := fmt.Sprintf("Image promotion for %s %s\n", opts.project, strings.Join(opts.tags, " / "))

--- a/cmd/kpromo/cmd/root.go
+++ b/cmd/kpromo/cmd/root.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/log"
@@ -84,5 +86,9 @@ func init() {
 }
 
 func initLogging(*cobra.Command, []string) error {
-	return log.SetupGlobalLogger(rootOpts.logLevel)
+	if err := log.SetupGlobalLogger(rootOpts.logLevel); err != nil {
+		return fmt.Errorf("setting up global logger: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -35,6 +35,7 @@ var filesCmd = &cobra.Command{
 		if err := runFilePromotion(filesOpts); err != nil {
 			return fmt.Errorf("run `kpromo run files`: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -89,7 +90,11 @@ func init() {
 func runFilePromotion(opts *promobot.PromoteFilesOptions) error {
 	ctx := context.Background()
 
-	return promobot.RunPromoteFiles(ctx, *opts)
+	if err := promobot.RunPromoteFiles(ctx, *opts); err != nil {
+		return fmt.Errorf("promoting files: %w", err)
+	}
+
+	return nil
 }
 
 // TODO: Validate options

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -56,6 +56,7 @@ kpromo to the first three images it finds run:
 			}
 
 			p := imagepromoter.New(opts)
+
 			return p.CheckSignatures(opts)
 		},
 	}

--- a/cmd/verify-gcr-quota/main.go
+++ b/cmd/verify-gcr-quota/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -52,6 +53,7 @@ func main() {
 
 	// Create all the workers.
 	start := time.Now()
+
 	spawnWorkers(numWorkers, c)
 	requests := numWorkers
 
@@ -65,24 +67,28 @@ func main() {
 		if msg.statusCode == targetStatusCode {
 			t := time.Now()
 			elapsed := t.Sub(start)
+
 			fmt.Println("We were throttled by GCR!")
 			fmt.Println("Unique Endpoints: ", len(queries))
 			fmt.Println("Took: ", elapsed.Minutes(), "minutes")
 			fmt.Println("Status Code: ", targetStatusCode)
 			fmt.Println("Body: ", msg.body)
 			fmt.Println("Time to ")
+
 			break
 		}
 
 		// Spawn a new worker.
 		go worker(c)
+
 		requests++
 	}
 }
 
 // getRandQuery randomly selects a query from the list of queries.
 func getRandQuery() string {
-	i := rand.Intn(len(queries)) //nolint: gosec
+	i := rand.Intn(len(queries)) //nolint:gosec // non-cryptographic use
+
 	return queries[i]
 }
 
@@ -90,6 +96,7 @@ func getRandQuery() string {
 func spawnWorkers(n int, c chan message) {
 	for n > 0 {
 		go worker(c)
+
 		n--
 	}
 }
@@ -98,7 +105,15 @@ func spawnWorkers(n int, c chan message) {
 // response to the given channel.
 func worker(c chan message) {
 	query := getRandQuery()
-	resp, err := http.Get(query) //nolint: gosec
+
+	req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, query, http.NoBody)
+	if reqErr != nil {
+		fmt.Println("Encountered an error creating HTTP request: ", reqErr)
+
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL constructed from trusted config
 	if err != nil {
 		fmt.Println("Encountered an error during HTTP GET request: ", err)
 	}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 2.6.1
+    version: 2.10.1
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/gh2gcs/gh2gcs.go
+++ b/gh2gcs/gh2gcs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gh2gcs
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -58,7 +59,11 @@ func DownloadReleases(releaseCfg *ReleaseConfig, ghClient *github.GitHub, output
 		tagsString,
 	)
 
-	return ghClient.DownloadReleaseAssets(releaseCfg.Org, releaseCfg.Repo, tags, outputDir)
+	if err := ghClient.DownloadReleaseAssets(releaseCfg.Org, releaseCfg.Repo, tags, outputDir); err != nil {
+		return fmt.Errorf("downloading release assets: %w", err)
+	}
+
+	return nil
 }
 
 // Upload copies a set of release assets from local directory to GCS
@@ -73,7 +78,7 @@ func Upload(cfg *ReleaseConfig, _ *github.GitHub, outputDir string) error {
 
 		gcs := object.NewGCS()
 		if err := gcs.CopyToRemote(srcDir, gcsPath); err != nil {
-			return err
+			return fmt.Errorf("copying to remote %s: %w", gcsPath, err)
 		}
 	}
 

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v2.6.1
+VERSION=v2.10.1
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=${URL_BASE}/${VERSION}/install.sh
 # If you update the version above you might need to update the checksum

--- a/image/consts/consts.go
+++ b/image/consts/consts.go
@@ -17,13 +17,13 @@ limitations under the License.
 package consts
 
 const (
-	// Production registry root URL.
+	// ProdRegistry is the production registry root URL.
 	ProdRegistry = "registry.k8s.io"
 
-	// Staging repository root URL prefix.
+	// StagingRepoPrefix is the staging repository root URL prefix.
 	StagingRepoPrefix = "gcr.io/k8s-staging-"
 
-	// The suffix of the default image repository to promote images from
+	// StagingRepoSuffix is the suffix of the default image repository to promote images from
 	// i.e., gcr.io/<staging-prefix>-<staging-suffix>
 	// e.g., gcr.io/k8s-staging-foo.
 	StagingRepoSuffix = "kubernetes"

--- a/image/image.go
+++ b/image/image.go
@@ -38,16 +38,17 @@ type ManifestList []struct {
 }
 
 // NewManifestListFromFile parses an image promoter manifest file.
-func NewManifestListFromFile(manifestPath string) (imagesList *ManifestList, err error) {
+func NewManifestListFromFile(manifestPath string) (*ManifestList, error) {
 	if !helpers.Exists(manifestPath) {
 		return nil, errors.New("could not find image promoter manifest")
 	}
-	yamlCode, err := os.ReadFile(filepath.Clean(manifestPath))
+
+	yamlCode, err := os.ReadFile(filepath.Clean(manifestPath)) //nolint:gosec // path already sanitized via filepath.Clean
 	if err != nil {
 		return nil, fmt.Errorf("reading yaml code from file: %w", err)
 	}
 
-	imagesList = &ManifestList{}
+	imagesList := &ManifestList{}
 	if err := imagesList.Parse(yamlCode); err != nil {
 		return nil, fmt.Errorf("parsing manifest yaml: %w", err)
 	}
@@ -57,7 +58,11 @@ func NewManifestListFromFile(manifestPath string) (imagesList *ManifestList, err
 
 // Parse reads yaml code into an ImagePromoterManifest object.
 func (imagesList *ManifestList) Parse(yamlCode []byte) error {
-	return yaml.Unmarshal(yamlCode, imagesList)
+	if err := yaml.Unmarshal(yamlCode, imagesList); err != nil {
+		return fmt.Errorf("unmarshalling image manifest list: %w", err)
+	}
+
+	return nil
 }
 
 // Write writes the promoter image list into an YAML file.
@@ -67,7 +72,7 @@ func (imagesList *ManifestList) Write(filePath string) error {
 		return fmt.Errorf("while marshalling image list: %w", err)
 	}
 	// Write the yaml into the specified file
-	if err := os.WriteFile(filepath.Clean(filePath), yamlCode, os.FileMode(0o644)); err != nil {
+	if err := os.WriteFile(filepath.Clean(filePath), yamlCode, os.FileMode(0o644)); err != nil { //nolint:gosec // path already sanitized via filepath.Clean
 		return fmt.Errorf("writing yaml code into file: %w", err)
 	}
 
@@ -100,12 +105,15 @@ func (imagesList *ManifestList) ToYAML() ([]byte, error) {
 			tags := imgData.DMap[digestSHA]
 			sort.Strings(tags)
 			fmt.Fprintf(&yamlCode, "    %q: [", digestSHA)
+
 			for i, tag := range tags {
 				if i > 0 {
 					yamlCode.WriteString(",")
 				}
+
 				fmt.Fprintf(&yamlCode, "%q", tag)
 			}
+
 			yamlCode.WriteString("]\n")
 		}
 	}
@@ -118,6 +126,7 @@ func sortImageDigestMapByTag(imageDMap map[string][]string) []string {
 	// we need to sort the map by value (tags)
 	tags := make([]string, 0, len(imageDMap))
 	valuesToKeys := make(map[string][]string)
+
 	for k, v := range imageDMap {
 		// find the smallest tag for each image digest
 		sort.Strings(v)
@@ -126,6 +135,7 @@ func sortImageDigestMapByTag(imageDMap map[string][]string) []string {
 		if _, ok := valuesToKeys[first]; !ok {
 			tags = append(tags, first)
 		}
+
 		valuesToKeys[first] = append(valuesToKeys[first], k)
 	}
 	// Then, sort the tags lexicographically

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -30,9 +30,8 @@ func TestNewManifestListFromFile(t *testing.T) {
 	listYAML += "    \"sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f\": [\"3.2\"]\n"
 	listYAML += "    \"sha256:a319ac2280eb7e3a59e252e54b76327cb4a33cf8389053b0d78277f22bbca2fa\": [\"3.3\"]\n"
 
-	tempFile, err := os.CreateTemp("", "release-test")
+	tempFile, err := os.CreateTemp(t.TempDir(), "release-test")
 	require.NoError(t, err, "creating temp file")
-	defer os.Remove(tempFile.Name())
 
 	_, err = tempFile.WriteString(listYAML)
 	require.NoError(t, err, "wrinting temporary promoter image list")
@@ -150,15 +149,14 @@ func TestPromoterImageWrite(t *testing.T) {
 	expectedFile += "- name: kube-scheduler\n  dmap:\n"
 	expectedFile += "    \"sha256:022b81d70447014f63fdc734df48cb9e3a2854c48f65acdca67aac5c1974fc22\": [\"v1.19.0-rc.2\"]\n"
 
-	tempFileSorted, err := os.CreateTemp("", "release-test")
+	tempFileSorted, err := os.CreateTemp(t.TempDir(), "release-test")
 	require.NoError(t, err, "creating temp file")
-	defer os.Remove(tempFileSorted.Name())
 
 	err = imageList.Write(tempFileSorted.Name())
 	require.NoError(t, err, "writing data to disk")
 
 	// Read back the file to see if it correct
-	fileContents, err := os.ReadFile(tempFileSorted.Name())
+	fileContents, err := os.ReadFile(tempFileSorted.Name()) //nolint:gosec // test file from os.CreateTemp
 	require.NoError(t, err, "reading temporary file")
 
 	require.Equal(t, expectedFile, string(fileContents))

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
@@ -124,13 +125,7 @@ func (o *GrowOptions) Validate() error {
 }
 
 func containsTag(tags []image.Tag, check string) bool {
-	for _, tag := range tags {
-		if tag == image.Tag(check) {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(tags, image.Tag(check))
 }
 
 // Grow modifies a manifest by adding images into it.
@@ -138,8 +133,10 @@ func Grow(
 	ctx context.Context,
 	o *GrowOptions,
 ) error {
-	var err error
-	var riiCombined registry.RegInvImage
+	var (
+		err         error
+		riiCombined registry.RegInvImage
+	)
 
 	// (1) Scan the BaseDir and find the promoter manifest to modify.
 	mfest, err := Find(o)
@@ -184,26 +181,34 @@ func Write(m schema.Manifest, rii registry.RegInvImage) error {
 	logrus.Infoln("RENDER", imagesPath)
 
 	// Write the file.
-	err := os.WriteFile( //nolint: gosec
-		imagesPath, []byte(rii.ToYAML(registry.YamlMarshalingOpts{})), 0o644)
-	return err
+	if err := os.WriteFile( //nolint:gosec // file permissions are intentional
+		imagesPath, []byte(rii.ToYAML(registry.YamlMarshalingOpts{})), 0o644); err != nil {
+		return fmt.Errorf("writing images file %s: %w", imagesPath, err)
+	}
+
+	return nil
 }
 
 // Find finds the manifest to modify.
 func Find(o *GrowOptions) (schema.Manifest, error) {
-	var err error
-	var manifests []schema.Manifest
+	var (
+		err       error
+		manifests []schema.Manifest
+	)
+
 	manifests, err = schema.ParseThinManifestsFromDir(o.BaseDir, false)
 	if err != nil {
-		return schema.Manifest{}, err
+		return schema.Manifest{}, fmt.Errorf("parsing thin manifests from %s: %w", o.BaseDir, err)
 	}
 
 	logrus.Infof("%d manifests parsed", len(manifests))
+
 	for _, manifest := range manifests {
 		if manifest.SrcRegistry.Name == o.StagingRepo {
 			return manifest, nil
 		}
 	}
+
 	return schema.Manifest{},
 		fmt.Errorf("could not find Manifest for %q", o.StagingRepo)
 }
@@ -216,6 +221,7 @@ func ReadStagingRepo(
 	o *GrowOptions,
 ) (registry.RegInvImage, error) {
 	provider := registry.NewCraneProvider()
+
 	inv, err := provider.ReadRegistries(
 		ctx,
 		[]registry.RegistryConfig{{Name: o.StagingRepo}},
@@ -223,7 +229,7 @@ func ReadStagingRepo(
 		nil,
 	)
 	if err != nil {
-		return registry.RegInvImage{}, err
+		return registry.RegInvImage{}, fmt.Errorf("reading registries: %w", err)
 	}
 
 	return inv.Images[o.StagingRepo], nil
@@ -268,6 +274,7 @@ func ApplyFilters(o *GrowOptions, rii registry.RegInvImage) (registry.RegInvImag
 // filterImage.
 func FilterByImages(rii registry.RegInvImage, filterImages []image.Name) registry.RegInvImage {
 	filtered := make(registry.RegInvImage)
+
 	for imageName, digestTags := range rii {
 		for _, filterImage := range filterImages {
 			if imageName == filterImage {
@@ -275,6 +282,7 @@ func FilterByImages(rii registry.RegInvImage, filterImages []image.Name) registr
 			}
 		}
 	}
+
 	return filtered
 }
 
@@ -309,6 +317,7 @@ func FilterByTags(rii registry.RegInvImage, filterTags []image.Tag) registry.Reg
 // filterDigest.
 func FilterByDigests(rii registry.RegInvImage, filterDigests []image.Digest) registry.RegInvImage {
 	filtered := make(registry.RegInvImage)
+
 	for imageName, digestTags := range rii {
 		for digest, tags := range digestTags {
 			for _, filterDigest := range filterDigests {
@@ -316,6 +325,7 @@ func FilterByDigests(rii registry.RegInvImage, filterDigests []image.Digest) reg
 					if filtered[imageName] == nil {
 						filtered[imageName] = make(registry.DigestTags)
 					}
+
 					filtered[imageName][digest] = tags
 				}
 			}
@@ -328,21 +338,25 @@ func FilterByDigests(rii registry.RegInvImage, filterDigests []image.Digest) reg
 // ExcludeTags removes tags in rii that match excludedTags.
 func ExcludeTags(rii registry.RegInvImage, excludedTags map[image.Tag]bool) registry.RegInvImage {
 	filtered := make(registry.RegInvImage)
+
 	for imageName, digestTags := range rii {
 		for digest, tags := range digestTags {
 			for _, tag := range tags {
 				if _, excludeMe := excludedTags[tag]; excludeMe {
 					continue
 				}
+
 				if filtered[imageName] == nil {
 					filtered[imageName] = make(registry.DigestTags)
 				}
+
 				filtered[imageName][digest] = append(
 					filtered[imageName][digest],
 					tag)
 			}
 		}
 	}
+
 	return filtered
 }
 
@@ -353,24 +367,30 @@ func Union(a, b registry.RegInvImage) registry.RegInvImage {
 		// injection.
 		if a[imageName] == nil {
 			a[imageName] = digestTags
+
 			continue
 		}
+
 		for digest, tags := range digestTags {
 			// If a has the image but not this digest, inject just this digest
 			// and all associated tags.
 			if a[imageName][digest] == nil {
 				a[imageName][digest] = tags
+
 				continue
 			}
 			// If c has the digest already, try to inject those tags in b that
 			// are not already in a.
 			tagSlice := registry.TagSlice{}
+
 			for tag := range tags.Union(a[imageName][digest]) {
 				if tag == "latest" {
 					continue
 				}
+
 				tagSlice = append(tagSlice, tag)
 			}
+
 			a[imageName][digest] = tagSlice
 		}
 	}

--- a/image/manifest/manifest_test.go
+++ b/image/manifest/manifest_test.go
@@ -125,16 +125,11 @@ func TestFind(t *testing.T) {
 
 		require.Equal(t, test.expectedManifest, gotManifest)
 
-		var gotErrStr string
-		var expectedErrStr string
-		if gotErr != nil {
-			gotErrStr = gotErr.Error()
-		}
 		if test.expectedErr != nil {
-			expectedErrStr = test.expectedErr.Error()
+			require.ErrorContains(t, gotErr, test.expectedErr.Error())
+		} else {
+			require.NoError(t, gotErr)
 		}
-
-		require.Equal(t, expectedErrStr, gotErrStr)
 	}
 }
 

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -37,23 +37,28 @@ import (
 
 // ParseManifests reads the manifest file or manifest directory
 // and parses them to return a slice of Manifest objects.
-func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (mfests []schema.Manifest, err error) {
+func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) ([]schema.Manifest, error) {
 	// If the options have a manifest file defined, we use that one
 	if opts.Manifest != "" {
 		mfest, err := schema.ParseManifestFromFile(opts.Manifest)
 		if err != nil {
-			return mfests, fmt.Errorf("parsing the manifest file: %w", err)
+			return nil, fmt.Errorf("parsing the manifest file: %w", err)
 		}
 
-		mfests = []schema.Manifest{mfest}
-		// The thin manifests
-	} else if opts.ThinManifestDir != "" {
-		mfests, err = schema.ParseThinManifestsFromDir(opts.ThinManifestDir, opts.UseProwManifestDiff)
+		return []schema.Manifest{mfest}, nil
+	}
+
+	// The thin manifests
+	if opts.ThinManifestDir != "" {
+		mfests, err := schema.ParseThinManifestsFromDir(opts.ThinManifestDir, opts.UseProwManifestDiff)
 		if err != nil {
 			return nil, fmt.Errorf("parsing thin manifest directory: %w", err)
 		}
+
+		return mfests, nil
 	}
-	return mfests, nil
+
+	return nil, nil
 }
 
 // GetPromotionEdges checks the manifests and determines from
@@ -61,7 +66,7 @@ func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (
 // promoted.
 func (di *DefaultPromoterImplementation) GetPromotionEdges(
 	opts *options.Options, mfests []schema.Manifest,
-) (map[promotion.Edge]interface{}, error) {
+) (map[promotion.Edge]any, error) {
 	// Convert manifests to edges
 	edges, err := promotion.ToEdges(mfests)
 	if err != nil {
@@ -83,6 +88,7 @@ func (di *DefaultPromoterImplementation) GetPromotionEdges(
 
 	// Read registry inventories (non-recursive, specific repos only)
 	ctx := context.Background()
+
 	inv, err := di.registryProvider.ReadRegistries(ctx, configs, false, baseConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("reading registries: %w", err)
@@ -103,25 +109,28 @@ func (di *DefaultPromoterImplementation) GetPromotionEdges(
 // to ensure signatures exist everywhere.
 func (di *DefaultPromoterImplementation) EdgesFromManifests(
 	mfests []schema.Manifest,
-) (map[promotion.Edge]interface{}, error) {
+) (map[promotion.Edge]any, error) {
 	edges, err := promotion.ToEdges(mfests)
 	if err != nil {
 		return nil, fmt.Errorf("converting manifests to edges: %w", err)
 	}
+
 	return edges, nil
 }
 
 // PromoteImages copies images for a set of promotion edges.
 func (di *DefaultPromoterImplementation) PromoteImages(
 	opts *options.Options,
-	edges map[promotion.Edge]interface{},
+	edges map[promotion.Edge]any,
 ) error {
 	if len(edges) == 0 {
 		logrus.Info("Nothing to promote.")
+
 		return nil
 	}
 
 	logrus.Info("Pending promotions:")
+
 	for edge := range edges {
 		logrus.Infof(
 			"%s/%s:%s (%s) to %s/%s",
@@ -161,11 +170,15 @@ func (di *DefaultPromoterImplementation) PromoteImages(
 			}
 
 			logrus.Infof("Copying %s to %s", srcVertex, dstVertex)
+
 			start := time.Now()
+
 			if err := di.registryProvider.CopyImage(ctx, srcVertex, dstVertex); err != nil {
 				return fmt.Errorf("copying %s to %s: %w", srcVertex, dstVertex, err)
 			}
+
 			logrus.Infof("Copied %s (%d/%d) in %s", dstVertex, completed.Add(1), total, time.Since(start).Round(time.Millisecond))
+
 			return nil
 		})
 	}

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -19,6 +19,7 @@ package imagepromoter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -82,11 +83,6 @@ func (di *DefaultPromoterImplementation) SetSigningTransport(rt *ratelimit.Round
 	di.signingTransport = rt
 }
 
-// getSigningTransport returns the transport for signing operations.
-func (di *DefaultPromoterImplementation) getSigningTransport() *ratelimit.RoundTripper {
-	return di.signingTransport
-}
-
 // SetRegistryProvider sets the registry provider for image operations.
 func (di *DefaultPromoterImplementation) SetRegistryProvider(p registry.Provider) {
 	di.registryProvider = p
@@ -139,6 +135,7 @@ func (di *DefaultPromoterImplementation) ValidateOptions(opts *options.Options) 
 			return errors.New("either a manifest or a thin manifest dir have to be set")
 		}
 	}
+
 	return nil
 }
 
@@ -147,17 +144,27 @@ func (di *DefaultPromoterImplementation) ActivateServiceAccounts(opts *options.O
 	if !opts.UseServiceAcct {
 		logrus.Warn("Not setting a service account")
 	}
-	return di.serviceActivator.ActivateServiceAccounts(context.Background(), opts.KeyFiles)
+
+	if err := di.serviceActivator.ActivateServiceAccounts(context.Background(), opts.KeyFiles); err != nil {
+		return fmt.Errorf("activating service accounts: %w", err)
+	}
+
+	return nil
 }
 
 func (di *DefaultPromoterImplementation) PrintVersion() {
 	logrus.Info(version.Get())
 }
 
-// printSecDisclaimer prints a disclaimer about false positives
+// PrintSecDisclaimer prints a disclaimer about false positives
 // that may be found in container image layers.
 func (di *DefaultPromoterImplementation) PrintSecDisclaimer() {
 	logrus.Info(vulnerabilityDiscalimer)
+}
+
+// getSigningTransport returns the transport for signing operations.
+func (di *DefaultPromoterImplementation) getSigningTransport() *ratelimit.RoundTripper {
+	return di.signingTransport
 }
 
 // craneOptions returns common crane options for registry operations,
@@ -170,5 +177,6 @@ func (di *DefaultPromoterImplementation) craneOptions() []crane.Option {
 	if di.promotionTransport != nil {
 		opts = append(opts, crane.WithTransport(di.promotionTransport))
 	}
+
 	return opts
 }

--- a/internal/promoter/image/securityscan.go
+++ b/internal/promoter/image/securityscan.go
@@ -31,10 +31,11 @@ import (
 // promoter using the configured vuln.Scanner.
 func (di *DefaultPromoterImplementation) ScanEdges(
 	opts *options.Options,
-	promotionEdges map[promotion.Edge]interface{},
+	promotionEdges map[promotion.Edge]any,
 ) error {
 	if opts.SeverityThreshold <= 0 {
 		logrus.Info("Vulnerability scanning disabled (threshold <= 0)")
+
 		return nil
 	}
 

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -66,9 +66,10 @@ const (
 // applied during its staging run. If they do it verifies them and
 // returns an error if they are not valid.
 func (di *DefaultPromoterImplementation) ValidateStagingSignatures(
-	edges map[promotion.Edge]interface{},
-) (map[promotion.Edge]interface{}, error) {
+	edges map[promotion.Edge]any,
+) (map[promotion.Edge]any, error) {
 	refsToEdges := map[string]promotion.Edge{}
+
 	for edge := range edges {
 		ref := edge.SrcReference()
 		refsToEdges[ref] = edge
@@ -84,20 +85,25 @@ func (di *DefaultPromoterImplementation) ValidateStagingSignatures(
 		return nil, fmt.Errorf("verify images: %w", err)
 	}
 
-	signedEdges := map[promotion.Edge]interface{}{}
+	signedEdges := map[promotion.Edge]any{}
+
 	res.Range(func(key, _ any) bool {
 		ref, ok := key.(string)
 		if !ok {
 			logrus.Errorf("Interface conversion failed: key is not a string: %v", key)
+
 			return false
 		}
 
 		edge, ok := refsToEdges[ref]
 		if !ok {
 			logrus.Errorf("Reference %s is not in edge map", ref)
+
 			return true
 		}
+
 		signedEdges[edge] = nil
+
 		return true
 	})
 
@@ -107,14 +113,17 @@ func (di *DefaultPromoterImplementation) ValidateStagingSignatures(
 // SignImages signs the promoted images and stores their signatures in
 // the registry.
 func (di *DefaultPromoterImplementation) SignImages(
-	opts *options.Options, edges map[promotion.Edge]interface{},
+	opts *options.Options, edges map[promotion.Edge]any,
 ) error {
 	if !opts.SignImages {
 		logrus.Info("Not signing images (--sign=false)")
+
 		return nil
 	}
+
 	if len(edges) == 0 {
 		logrus.Info("No images were promoted. Nothing to sign.")
+
 		return nil
 	}
 
@@ -126,6 +135,7 @@ func (di *DefaultPromoterImplementation) SignImages(
 	if err != nil {
 		return fmt.Errorf("generating identity token: %w", err)
 	}
+
 	signOpts.IdentityToken = token
 
 	// Creating a new Signer after setting the identity token is MANDATORY
@@ -146,7 +156,11 @@ func (di *DefaultPromoterImplementation) SignImages(
 		})
 	}
 
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("signing images: %w", err)
+	}
+
+	return nil
 }
 
 // signFirst signs the first (primary) image for a given identity+digest group.
@@ -187,14 +201,17 @@ func (di *DefaultPromoterImplementation) signFirst(signOpts *sign.Options, ident
 // to all additional destination registries for images that were promoted to
 // multiple registries.
 func (di *DefaultPromoterImplementation) ReplicateSignatures(
-	opts *options.Options, edges map[promotion.Edge]interface{},
+	opts *options.Options, edges map[promotion.Edge]any,
 ) error {
 	if !opts.SignImages {
 		logrus.Info("Signing disabled, skipping signature replication")
+
 		return nil
 	}
+
 	if len(edges) == 0 {
 		logrus.Info("No images were promoted. Nothing to replicate.")
+
 		return nil
 	}
 
@@ -207,12 +224,17 @@ func (di *DefaultPromoterImplementation) ReplicateSignatures(
 		if len(group) <= 1 {
 			continue
 		}
+
 		g.Go(func() error {
 			return di.replicateSignatures(&group[0], group[1:])
 		})
 	}
 
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("replicating signatures: %w", err)
+	}
+
+	return nil
 }
 
 // targetIdentity returns the production identity for a promotion edge.
@@ -231,6 +253,7 @@ func targetIdentity(edge *promotion.Edge) string {
 			"No production registry path %q used in image, not modifying target signature reference",
 			productionRepositoryPath,
 		)
+
 		return identity
 	}
 
@@ -244,12 +267,14 @@ func targetIdentity(edge *promotion.Edge) string {
 // and digest. Within each group, edges are sorted by destination registry name
 // to ensure deterministic ordering across calls. The first edge in each group
 // is used as the primary for signing and as the source for replication.
-func groupEdgesByIdentityDigest(edges map[promotion.Edge]interface{}) [][]promotion.Edge {
+func groupEdgesByIdentityDigest(edges map[promotion.Edge]any) [][]promotion.Edge {
 	type key struct {
 		identity string
 		digest   image.Digest
 	}
+
 	grouped := map[key][]promotion.Edge{}
+
 	for edge := range edges {
 		// Skip metadata layers
 		if strings.HasSuffix(string(edge.DstImageTag.Tag), ".sig") ||
@@ -271,6 +296,7 @@ func groupEdgesByIdentityDigest(edges map[promotion.Edge]interface{}) [][]promot
 		})
 		result = append(result, group)
 	}
+
 	return result
 }
 
@@ -282,6 +308,7 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *promotion.Edg
 	srcRefString := fmt.Sprintf(
 		"%s/%s:%s", edge.SrcRegistry.Name, edge.SrcImageTag.Name, sigTag,
 	)
+
 	srcRef, err := name.ParseReference(srcRefString)
 	if err != nil {
 		return fmt.Errorf("parsing signed source reference %s: %w", srcRefString, err)
@@ -290,12 +317,14 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *promotion.Edg
 	dstRefString := fmt.Sprintf(
 		"%s/%s:%s", edge.DstRegistry.Name, edge.DstImageTag.Name, sigTag,
 	)
+
 	dstRef, err := name.ParseReference(dstRefString)
 	if err != nil {
 		return fmt.Errorf("parsing reference: %w", err)
 	}
 
 	logrus.Infof("Signature pre copy: %s to %s", srcRefString, dstRefString)
+
 	craneOpts := []crane.Option{
 		crane.WithAuthFromKeychain(gcrane.Keychain),
 		crane.WithUserAgent(image.UserAgent),
@@ -308,12 +337,15 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *promotion.Edg
 		var terr *transport.Error
 		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
 			logrus.Debugf("Reference %s is not signed, not copying", srcRef.String())
+
 			return nil
 		}
+
 		return fmt.Errorf(
 			"copying signature %s to %s: %w", srcRef.String(), dstRef.String(), err,
 		)
 	}
+
 	return nil
 }
 
@@ -332,6 +364,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	sourceRefStr := fmt.Sprintf(
 		"%s/%s:%s", src.DstRegistry.Name, src.DstImageTag.Name, sigTag,
 	)
+
 	srcRef, err := name.ParseReference(sourceRefStr)
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %w", sourceRefStr, err)
@@ -343,8 +376,10 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 		var terr *transport.Error
 		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
 			logrus.WithField("src", sourceRefStr).Debug("Source signature not found, skipping group")
+
 			return nil
 		}
+
 		return fmt.Errorf("checking source signature %s: %w", sourceRefStr, err)
 	}
 
@@ -359,6 +394,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 		if err != nil {
 			return fmt.Errorf("parsing signature destination reference: %w", err)
 		}
+
 		dstRefs = append(dstRefs, ref)
 	}
 
@@ -372,10 +408,12 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 				remote.WithTransport(di.getSigningTransport()),
 			); err == nil {
 				logrus.WithField("dst", dstRef.String()).Debug("Signature already exists, skipping")
+
 				return nil
 			}
 
 			logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.String())
+
 			opts := []crane.Option{
 				crane.WithAuthFromKeychain(gcrane.Keychain),
 				crane.WithUserAgent(image.UserAgent),
@@ -385,18 +423,25 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 				var terr *transport.Error
 				if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
 					logrus.Debugf("Signature %s not found, skipping", srcRef.String())
+
 					return nil
 				}
+
 				return fmt.Errorf(
 					"copying signature %s to %s: %w",
 					srcRef.String(), dstRef.String(), err,
 				)
 			}
+
 			return nil
 		})
 	}
 
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("replicating signatures: %w", err)
+	}
+
+	return nil
 }
 
 // retryBackoff defines the exponential backoff for transient registry errors.
@@ -415,6 +460,7 @@ func isTransient(err error) bool {
 		return terr.StatusCode == http.StatusTooManyRequests ||
 			terr.StatusCode >= http.StatusInternalServerError
 	}
+
 	return false
 }
 
@@ -422,20 +468,28 @@ func isTransient(err error) bool {
 // Non-transient errors are returned immediately.
 func withRetry(fn func() error) error {
 	var lastErr error
+
 	err := wait.ExponentialBackoff(retryBackoff, func() (bool, error) {
 		lastErr = fn()
 		if lastErr == nil {
 			return true, nil // success, stop retrying
 		}
+
 		if !isTransient(lastErr) {
 			return false, lastErr // permanent error, stop retrying
 		}
+
 		return false, nil // transient error, keep retrying
 	})
 	if wait.Interrupted(err) {
 		return lastErr // retries exhausted, return the last transient error
 	}
-	return err
+
+	if err != nil {
+		return fmt.Errorf("exponential backoff: %w", err)
+	}
+
+	return nil
 }
 
 // headWithRetry performs a remote.Head with retries on transient errors.
@@ -445,7 +499,11 @@ func (di *DefaultPromoterImplementation) headWithRetry(ref name.Reference) error
 			remote.WithAuthFromKeychain(gcrane.Keychain),
 			remote.WithTransport(di.getSigningTransport()),
 		)
-		return err
+		if err != nil {
+			return fmt.Errorf("remote head %s: %w", ref.String(), err)
+		}
+
+		return nil
 	})
 }
 
@@ -461,10 +519,11 @@ func (di *DefaultPromoterImplementation) copyWithRetry(src, dst string, opts []c
 // attached in staging (e.g., by the build system) and are identified by
 // the cosign SBOM tag convention (sha256-<hash>.sbom).
 func (di *DefaultPromoterImplementation) WriteSBOMs(
-	opts *options.Options, edges map[promotion.Edge]interface{},
+	opts *options.Options, edges map[promotion.Edge]any,
 ) error {
 	if len(edges) == 0 {
 		logrus.Info("No images were promoted. No SBOMs to copy.")
+
 		return nil
 	}
 
@@ -484,11 +543,16 @@ func (di *DefaultPromoterImplementation) WriteSBOMs(
 			if err := di.copySBOM(&edge); err != nil {
 				return fmt.Errorf("copying SBOM for %s: %w", edge.DstReference(), err)
 			}
+
 			return nil
 		})
 	}
 
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("writing SBOMs: %w", err)
+	}
+
+	return nil
 }
 
 // copySBOM copies an SBOM from the staging registry to the production registry
@@ -509,15 +573,19 @@ func (di *DefaultPromoterImplementation) copySBOM(edge *promotion.Edge) error {
 	}
 
 	logrus.Infof("SBOM copy: %s to %s", srcRefString, dstRefString)
+
 	if err := crane.Copy(srcRefString, dstRefString, craneOpts...); err != nil {
 		// If the SBOM does not exist in staging, skip silently
 		var terr *transport.Error
 		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
 			logrus.Debugf("No SBOM found for %s, skipping", srcRefString)
+
 			return nil
 		}
+
 		return fmt.Errorf("copying SBOM %s to %s: %w", srcRefString, dstRefString, err)
 	}
+
 	return nil
 }
 
@@ -535,23 +603,30 @@ func (di *DefaultPromoterImplementation) GetIdentityToken(
 	// If the test signer file is found switch to test credentials
 	if os.Getenv("CIP_E2E_KEY_FILE") != "" {
 		logrus.Info("Test keyfile set using e2e test credentials")
+
 		serviceAccount = TestSigningAccount
 	}
 
-	return di.identityTokenProvider.GetIdentityToken(
+	token, err := di.identityTokenProvider.GetIdentityToken(
 		context.Background(), serviceAccount, oidcTokenAudience,
 	)
+	if err != nil {
+		return "", fmt.Errorf("getting identity token: %w", err)
+	}
+
+	return token, nil
 }
 
 // WriteProvenanceAttestations generates SLSA provenance attestations for
 // promoted images and pushes them as .att tags to the destination registry.
 func (di *DefaultPromoterImplementation) WriteProvenanceAttestations(
 	_ *options.Options,
-	edges map[promotion.Edge]interface{},
+	edges map[promotion.Edge]any,
 	generator provenance.Generator,
 ) error {
 	if len(edges) == 0 {
 		logrus.Info("No images were promoted. No provenance to generate.")
+
 		return nil
 	}
 
@@ -615,11 +690,13 @@ func (di *DefaultPromoterImplementation) pushAttestation(
 	// Check if attestation already exists (idempotent)
 	if _, err := remote.Head(ref, remote.WithAuthFromKeychain(gcrane.Keychain)); err == nil {
 		logrus.Debugf("Attestation %s already exists, skipping", dstRefString)
+
 		return nil
 	}
 
 	// Create an OCI image with the attestation as a single layer
 	layer := static.NewLayer(attestation, types.MediaType(intotoMediaType))
+
 	img, err := mutate.AppendLayers(empty.Image, layer)
 	if err != nil {
 		return fmt.Errorf("creating attestation image: %w", err)
@@ -630,6 +707,7 @@ func (di *DefaultPromoterImplementation) pushAttestation(
 	img = mutate.ConfigMediaType(img, types.MediaType("application/vnd.oci.image.config.v1+json"))
 
 	logrus.Infof("Provenance attestation: pushing %s", dstRefString)
+
 	if err := remote.Write(ref, img,
 		remote.WithAuthFromKeychain(gcrane.Keychain),
 		remote.WithUserAgent(image.UserAgent),
@@ -655,5 +733,6 @@ func (di *DefaultPromoterImplementation) PrewarmTUFCache() error {
 	); err != nil {
 		return fmt.Errorf("initializing TUF client: %w", err)
 	}
+
 	return nil
 }

--- a/internal/promoter/image/sign_test.go
+++ b/internal/promoter/image/sign_test.go
@@ -220,6 +220,7 @@ func TestTargetIdentity(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			res := targetIdentity(edge)
 			assert(res)
 		})

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -68,6 +69,7 @@ func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) 
 				return nil, fmt.Errorf("invalid image reference %s: %w", refString, err)
 			}
 		}
+
 		return opts.SignCheckReferences, nil
 	}
 
@@ -75,18 +77,22 @@ func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) 
 	if err != nil {
 		return nil, fmt.Errorf("fetching latest images: %w", err)
 	}
+
 	logrus.Infof("Images to check: +%v", images)
+
 	return images, nil
 }
 
 func (di *DefaultPromoterImplementation) getMirrors() ([]string, error) {
 	mirrorsOnce.Do(func() {
 		iurls := map[string]string{}
+
 		manifest, err := http.NewAgent().Get(
 			"https://github.com/kubernetes/k8s.io/raw/main/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml",
 		)
 		if err != nil {
 			errMirrorsFetch = fmt.Errorf("downloading promoter manifest: %w", err)
+
 			return
 		}
 
@@ -100,6 +106,7 @@ func (di *DefaultPromoterImplementation) getMirrors() ([]string, error) {
 		entries := entriesList{}
 		if err := yaml.Unmarshal(manifest, &entries); err != nil {
 			errMirrorsFetch = fmt.Errorf("unmarshalling promoter manifest: %w", err)
+
 			return
 		}
 
@@ -107,11 +114,14 @@ func (di *DefaultPromoterImplementation) getMirrors() ([]string, error) {
 			if e.Src {
 				continue
 			}
+
 			u, err := url.Parse("https://" + e.Name)
 			if err != nil {
 				errMirrorsFetch = fmt.Errorf("parsing url %s: %w", u, err)
+
 				return
 			}
+
 			iurls[u.Hostname()] = u.Hostname()
 		}
 
@@ -119,8 +129,10 @@ func (di *DefaultPromoterImplementation) getMirrors() ([]string, error) {
 		for u := range iurls {
 			urls = append(urls, u)
 		}
+
 		mirrorsList = urls
 	})
+
 	return mirrorsList, errMirrorsFetch
 }
 
@@ -128,14 +140,17 @@ func (di *DefaultPromoterImplementation) GetSignatureStatus(
 	opts *options.Options, images []string,
 ) (checkresults.Signature, error) {
 	results := checkresults.Signature{}
+
 	mirrors, err := di.getMirrors()
 	if err != nil {
 		return results, fmt.Errorf("reading mirrors: %w", err)
 	}
+
 	logrus.Infof(
 		"Checking %d images for signatures, each in %d mirrors",
 		len(images), len(mirrors),
 	)
+
 	for _, refString := range images {
 		ref, err := name.ParseReference(refString)
 		if err != nil {
@@ -148,6 +163,7 @@ func (di *DefaultPromoterImplementation) GetSignatureStatus(
 		}
 
 		targetImages := []string{}
+
 		for _, mirror := range mirrors {
 			rpath := productionRepositoryPath
 			if strings.HasSuffix(mirror, ".gcr.io") {
@@ -161,28 +177,31 @@ func (di *DefaultPromoterImplementation) GetSignatureStatus(
 		}
 
 		logrus.Infof("Checking %s for signatures in %d mirrors", refString, len(targetImages))
+
 		existing, missing, err := di.CheckSignatureLayers(opts, targetImages)
 		if err != nil {
 			return results, fmt.Errorf("checking objects: %w", err)
 		}
+
 		results[refString] = checkresults.CheckList{
 			Signed:  existing,
 			Missing: missing,
 		}
 	}
+
 	return results, nil
 }
 
 // miniManifest is a minimal representation of the sigstore signature manifest.
 type miniManifest struct {
 	Layers []struct {
-		MediaType   string
+		MediaType   string            `json:"mediaType"`
 		Annotations map[string]string `json:"annotations"`
 	} `json:"layers"`
 }
 
 // CheckSignatureLayers checks a list of signature layers in parallel.
-func (di *DefaultPromoterImplementation) CheckSignatureLayers(opts *options.Options, oList []string) (existing, missing []string, err error) {
+func (di *DefaultPromoterImplementation) CheckSignatureLayers(opts *options.Options, oList []string) ([]string, []string, error) {
 	type result struct {
 		ref    string
 		exists bool
@@ -195,19 +214,24 @@ func (di *DefaultPromoterImplementation) CheckSignatureLayers(opts *options.Opti
 
 	for i, s := range oList {
 		results[i].ref = s
+
 		g.Go(func() error {
 			e, err := objectExists(opts, s)
 			if err != nil {
 				return fmt.Errorf("checking reference: %w", err)
 			}
+
 			results[i].exists = e
+
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("checking signature layers: %w", err)
 	}
+
+	var existing, missing []string
 
 	for _, r := range results {
 		if r.exists {
@@ -226,8 +250,10 @@ func objectExists(opts *options.Options, refString string) (bool, error) {
 	if err != nil {
 		if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
 			logrus.WithField("image", refString).Info("No signature found")
+
 			return false, nil
 		}
+
 		return false, fmt.Errorf("pulling signature manifest: %w", err)
 	}
 
@@ -240,7 +266,9 @@ func objectExists(opts *options.Options, refString string) (bool, error) {
 	if len(manifest.Layers) == 0 {
 		return false, nil
 	}
+
 	signedLayers := 0
+
 	for _, layer := range manifest.Layers {
 		if layer.MediaType != "application/vnd.dev.cosign.simplesigning.v1+json" {
 			continue
@@ -256,14 +284,12 @@ func objectExists(opts *options.Options, refString string) (bool, error) {
 
 		certs, err := cryptoutils.LoadCertificatesFromPEM(&b)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("loading certificates from PEM: %w", err)
 		}
 
 		names := cryptoutils.GetSubjectAlternateNames(certs[0])
-		for _, n := range names {
-			if n == opts.SignCheckIdentity {
-				return true, nil
-			}
+		if slices.Contains(names, opts.SignCheckIdentity) {
+			return true, nil
 		}
 
 		signedLayers++
@@ -294,12 +320,14 @@ func (di *DefaultPromoterImplementation) FixMissingSignatures(opts *options.Opti
 		}
 
 		logrus.Infof("Replicating image to %d mirrors", len(res.Missing[1:]))
+
 		for _, targetRef := range res.Missing[1:] {
 			if err := di.replicateReference(opts, res.Missing[0], targetRef); err != nil {
 				return fmt.Errorf("replicating signature: %w", err)
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -321,6 +349,7 @@ func (di *DefaultPromoterImplementation) FixPartialSignatures(opts *options.Opti
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -333,6 +362,7 @@ func (di *DefaultPromoterImplementation) replicateReference(opts *options.Option
 
 	if !opts.SignCheckFix {
 		logrus.Infof(" (NOOP) replicating %s to %s ", srcRef, dstRef)
+
 		return nil
 	}
 
@@ -343,6 +373,7 @@ func (di *DefaultPromoterImplementation) replicateReference(opts *options.Option
 			"copying signature %s to %s: %w", srcRef, dstRef, err,
 		)
 	}
+
 	return nil
 }
 
@@ -350,8 +381,10 @@ func (di *DefaultPromoterImplementation) replicateReference(opts *options.Option
 func (di *DefaultPromoterImplementation) signReference(opts *options.Options, refString string) error {
 	if !opts.SignCheckFix {
 		logrus.Infof(" (NOOP) signing %s", refString)
+
 		return nil
 	}
+
 	logrus.Infof(" signing %s", refString)
 
 	// Options for the new signer
@@ -362,6 +395,7 @@ func (di *DefaultPromoterImplementation) signReference(opts *options.Options, re
 	if err != nil {
 		return fmt.Errorf("generating identity token: %w", err)
 	}
+
 	signOpts.IdentityToken = token
 
 	di.signer = sign.New(signOpts)
@@ -389,14 +423,17 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 	))
 
 	dateCutOff := time.Now().AddDate(0, 0, opts.SignCheckFromDays*-1)
+
 	dateCutOffTo := time.Now()
 	if opts.SignCheckToDays > 0 {
 		dateCutOffTo = time.Now().AddDate(0, 0, opts.SignCheckToDays*-1)
 	}
+
 	logrus.Infof("Checking images from %s to %s",
-		dateCutOff.Local().Format(time.RFC822),   //nolint: gosmopolitan
-		dateCutOffTo.Local().Format(time.RFC822), //nolint: gosmopolitan
+		dateCutOff.Local().Format(time.RFC822),   //nolint:gosmopolitan // local timezone is intentional for human-readable log output
+		dateCutOffTo.Local().Format(time.RFC822), //nolint:gosmopolitan // local timezone is intentional for human-readable log output
 	)
+
 	images := []string{}
 
 	repo, err := name.NewRepository(scanRegistry+"/"+productionRepositoryPath, name.WeakValidation)
@@ -405,6 +442,7 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 	}
 
 	var mt sync.Mutex
+
 	walkFn := func(repo name.Repository, tags *google.Tags, _ error) error {
 		if tags == nil {
 			return nil
@@ -417,6 +455,7 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 			strings.HasSuffix(repo.String(), "-s390x") {
 			return nil
 		}
+
 		logrus.Infof("Indexing %d images from %s", len(tags.Manifests), repo)
 		// First var (_) is the digest
 		for _, manifest := range tags.Manifests {
@@ -439,12 +478,14 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 			}
 
 			mt.Lock()
+
 			images = append(images, strings.ReplaceAll(
 				fmt.Sprintf("%s:%s", repo, manifest.Tags[0]),
 				scanRegistry+"/"+productionRepositoryPath, consts.ProdRegistry),
 			)
 			mt.Unlock()
 		}
+
 		return nil
 	}
 

--- a/internal/promoter/image/snapshot.go
+++ b/internal/promoter/image/snapshot.go
@@ -35,10 +35,11 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
-// Run a snapshot.
+// Snapshot runs a snapshot.
 func (di *DefaultPromoterImplementation) Snapshot(opts *options.Options, rii registry.RegInvImage) error {
 	// Run the snapshot
 	var snapshot string
+
 	switch strings.ToLower(opts.OutputFormat) {
 	case "csv":
 		snapshot = rii.ToCSV()
@@ -51,6 +52,7 @@ func (di *DefaultPromoterImplementation) Snapshot(opts *options.Options, rii reg
 
 	// TODO: Maybe store the snapshot somewhere?
 	fmt.Println(snapshot)
+
 	return nil
 }
 
@@ -80,7 +82,7 @@ func (di *DefaultPromoterImplementation) GetSnapshotSourceRegistry(
 	return srcRegistry, nil
 }
 
-// GetSnapshotManifest creates the manifest list from the
+// GetSnapshotManifests creates the manifest list from the
 // specified snapshot source.
 func (di *DefaultPromoterImplementation) GetSnapshotManifests(
 	opts *options.Options,
@@ -113,6 +115,7 @@ func (di *DefaultPromoterImplementation) AppendManifestToSnapshot(
 	// same list of manifests unchanged
 	if opts.Manifest == "" {
 		logrus.Info("No manifest defined, not appending to snapshot")
+
 		return mfests, nil
 	}
 
@@ -182,6 +185,7 @@ func (di *DefaultPromoterImplementation) GetRegistryImageInventory(
 
 	if opts.MinimalSnapshot {
 		logrus.Info("removing tagless child digests of manifest lists")
+
 		rii = removeChildDigests(inv, rii, mfests[0].Registries[0].Name, di.craneOptions()...)
 	}
 
@@ -211,15 +215,18 @@ func removeChildDigests(
 
 			// Fetch the manifest list to get child digests
 			ref := fmt.Sprintf("%s/%s@%s", registryName, imageName, digest)
+
 			rawManifest, err := crane.Manifest(ref, opts...)
 			if err != nil {
 				logrus.Warnf("failed to read manifest list %s: %v", ref, err)
+
 				continue
 			}
 
 			var idx v1.IndexManifest
 			if err := json.Unmarshal(rawManifest, &idx); err != nil {
 				logrus.Warnf("failed to parse manifest list %s: %v", ref, err)
+
 				continue
 			}
 
@@ -231,6 +238,7 @@ func removeChildDigests(
 
 	// Filter out tagless children
 	filtered := make(registry.RegInvImage)
+
 	for imageName, digestTags := range rii {
 		for digest, tagSlice := range digestTags {
 			// If this digest is a child of a manifest list and has no tags,
@@ -242,6 +250,7 @@ func removeChildDigests(
 			if filtered[imageName] == nil {
 				filtered[imageName] = make(registry.DigestTags)
 			}
+
 			filtered[imageName][digest] = tagSlice
 		}
 	}

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,5 +1,3 @@
-// +build tools
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -15,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+//go:build tools
 
 // This is used to import things required by build scripts, to force `go mod` to see them as dependencies
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -67,6 +67,7 @@ func (i *Info) String() string {
 	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
 
 	w.Flush()
+
 	return b.String()
 }
 
@@ -74,7 +75,8 @@ func (i *Info) String() string {
 func (i *Info) JSONString() (string, error) {
 	b, err := json.MarshalIndent(i, "", "  ")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("marshalling version info: %w", err)
 	}
+
 	return string(b), nil
 }

--- a/promobot/hash.go
+++ b/promobot/hash.go
@@ -65,6 +65,7 @@ func GenerateManifest(_ context.Context, options GenerateManifestOptions) (*api.
 		if err != nil {
 			return err
 		}
+
 		if !strings.HasPrefix(p, basedir) {
 			return fmt.Errorf("expected path %q to have prefix %q", p, basedir)
 		}
@@ -75,15 +76,18 @@ func GenerateManifest(_ context.Context, options GenerateManifestOptions) (*api.
 
 		if !d.IsDir() {
 			relativePath := strings.TrimPrefix(p, basedir)
+
 			sha256, err := hash.SHA256ForFile(p)
 			if err != nil {
 				return fmt.Errorf("error hashing file %q: %w", p, err)
 			}
+
 			manifest.Files = append(manifest.Files, api.File{
 				Name:   relativePath,
 				SHA256: sha256,
 			})
 		}
+
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("error walking path %q: %w", options.BaseDir, err)

--- a/promobot/hash_test.go
+++ b/promobot/hash_test.go
@@ -57,6 +57,8 @@ func TestHash(t *testing.T) {
 //	tests is to make the changes explicit, particularly in code
 //	review, not to force manual updates.
 func AssertMatchesFile(t *testing.T, actual, p string) {
+	t.Helper()
+
 	b, err := os.ReadFile(p)
 	if err != nil {
 		if os.Getenv("UPDATE_EXPECTED_OUTPUT") == "" {
@@ -68,10 +70,11 @@ func AssertMatchesFile(t *testing.T, actual, p string) {
 
 	if actual != expected {
 		if os.Getenv("UPDATE_EXPECTED_OUTPUT") != "" {
-			if err := os.WriteFile(p, []byte(actual), 0o644); err != nil { //nolint: gosec
+			if err := os.WriteFile(p, []byte(actual), 0o644); err != nil { //nolint:gosec // test file permissions
 				t.Fatalf("error writing file %q: %v", p, err)
 			}
 		}
+
 		t.Errorf("actual did not match expected; diff=%s", diff.StringDiff(actual, expected))
 	}
 }

--- a/promobot/promotefiles.go
+++ b/promobot/promotefiles.go
@@ -100,6 +100,7 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	}
 
 	var ops []file.SyncFileOp
+
 	for _, manifest := range manifests {
 		promoter := &file.ManifestPromoter{
 			Manifest:          manifest,
@@ -109,7 +110,7 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 
 		o, err := promoter.BuildOperations(ctx)
 		if err != nil {
-			return fmt.Errorf("error building operations: %v", err)
+			return fmt.Errorf("error building operations: %w", err)
 		}
 
 		ops = append(ops, o...)
@@ -119,11 +120,12 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	// in one operation does not prevent us attempting the
 	// remaining operations
 	var errs []error
+
 	for _, op := range ops {
 		if _, err := fmt.Fprintf(options.Out, "%v\n", op); err != nil {
 			errs = append(
 				errs,
-				fmt.Errorf("error writing to output: %v", err),
+				fmt.Errorf("error writing to output: %w", err),
 			)
 		}
 
@@ -139,6 +141,7 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 		fmt.Fprintf(
 			options.Out,
 			"********** FINISHED WITH ERRORS **********\n")
+
 		for _, err := range errs {
 			fmt.Fprintf(options.Out, "%v\n", err)
 		}
@@ -164,6 +167,7 @@ func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 // ReadManifests reads a set of manifests.
 func ReadManifests(options PromoteFilesOptions) ([]*api.Manifest, error) {
 	manifests := make([]*api.Manifest, 0)
+
 	mPath := options.ManifestsPath
 	if mPath == "" {
 		m, err := ReadManifest(options)
@@ -172,6 +176,7 @@ func ReadManifests(options PromoteFilesOptions) ([]*api.Manifest, error) {
 		}
 
 		manifests = append(manifests, m)
+
 		return manifests, nil
 	}
 
@@ -192,6 +197,7 @@ func ReadManifests(options PromoteFilesOptions) ([]*api.Manifest, error) {
 			}
 
 			projects = append(projects, d.Name())
+
 			return nil
 		},
 	); err != nil {
@@ -237,17 +243,19 @@ func ReadManifest(options PromoteFilesOptions) (*api.Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	merged.Filestores = filestores
 
 	files, err := readFiles(options.FilesPath)
 	if err != nil {
 		return nil, err
 	}
+
 	merged.Files = files
 
 	// Validate the merged manifest
 	if err := merged.Validate(); err != nil {
-		return nil, fmt.Errorf("error validating merged manifest: %v", err)
+		return nil, fmt.Errorf("error validating merged manifest: %w", err)
 	}
 
 	return merged, nil
@@ -261,12 +269,12 @@ func readFilestores(p string) ([]api.Filestore, error) {
 
 	b, err := os.ReadFile(p)
 	if err != nil {
-		return nil, fmt.Errorf("error reading manifest %q: %v", p, err)
+		return nil, fmt.Errorf("error reading manifest %q: %w", p, err)
 	}
 
 	manifest, err := api.ParseManifest(b)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing manifest %q: %v", p, err)
+		return nil, fmt.Errorf("error parsing manifest %q: %w", p, err)
 	}
 
 	if len(manifest.Files) != 0 {
@@ -282,6 +290,7 @@ func readFilestores(p string) ([]api.Filestore, error) {
 func readFiles(filesPath string) ([]api.File, error) {
 	// We first list and sort the paths, for a consistent ordering
 	var paths []string
+
 	err := filepath.WalkDir(filesPath, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -292,6 +301,7 @@ func readFiles(filesPath string) ([]api.File, error) {
 		}
 
 		paths = append(paths, p)
+
 		return nil
 	})
 	if err != nil {
@@ -301,6 +311,7 @@ func readFiles(filesPath string) ([]api.File, error) {
 	sort.Strings(paths)
 
 	var files []api.File
+
 	for _, p := range paths {
 		b, err := os.ReadFile(p)
 		if err != nil {
@@ -309,7 +320,7 @@ func readFiles(filesPath string) ([]api.File, error) {
 
 		manifest, err := api.ParseManifest(b)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing manifest %q: %v", p, err)
+			return nil, fmt.Errorf("error parsing manifest %q: %w", p, err)
 		}
 
 		if len(manifest.Filestores) != 0 {

--- a/promoter/file/file.go
+++ b/promoter/file/file.go
@@ -56,8 +56,9 @@ func (o *copyFileOp) Run(ctx context.Context) error {
 	// Download to our temp file
 	f, err := os.CreateTemp("", "promoter")
 	if err != nil {
-		return fmt.Errorf("error creating temp file: %v", err)
+		return fmt.Errorf("error creating temp file: %w", err)
 	}
+
 	tempFilename := f.Name()
 
 	defer func() {
@@ -78,26 +79,28 @@ func (o *copyFileOp) Run(ctx context.Context) error {
 
 	in, err := o.Source.filestore.OpenReader(ctx, o.Source.RelativePath)
 	if err != nil {
-		return fmt.Errorf("error reading %q: %v", o.Source.AbsolutePath, err)
+		return fmt.Errorf("error reading %q: %w", o.Source.AbsolutePath, err)
 	}
 	defer in.Close()
 
 	if _, err := io.Copy(f, in); err != nil {
 		return fmt.Errorf(
-			"error downloading %s: %v",
+			"error downloading %s: %w",
 			o.Source.AbsolutePath, err)
 	}
 	// We close the file to be sure it is fully written
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("error writing temp file %q: %v", tempFilename, err)
+		return fmt.Errorf("error writing temp file %q: %w", tempFilename, err)
 	}
+
 	f = nil
 
 	// Verify the source hash
 	sha256, err := hash.SHA256ForFile(tempFilename)
 	if err != nil {
-		return err
+		return fmt.Errorf("computing SHA256 for %s: %w", tempFilename, err)
 	}
+
 	if sha256 != o.ManifestFile.SHA256 {
 		return fmt.Errorf(
 			"sha256 did not match for file %q: actual=%q expected=%q",
@@ -105,7 +108,11 @@ func (o *copyFileOp) Run(ctx context.Context) error {
 	}
 
 	// Upload to the destination
-	return o.Dest.filestore.UploadFile(ctx, o.Dest.RelativePath, tempFilename)
+	if err := o.Dest.filestore.UploadFile(ctx, o.Dest.RelativePath, tempFilename); err != nil {
+		return fmt.Errorf("uploading file to %s: %w", o.Dest.AbsolutePath, err)
+	}
+
+	return nil
 }
 
 // String is the pretty-printer for an operation, as used by dry-run.

--- a/promoter/file/filestore.go
+++ b/promoter/file/filestore.go
@@ -64,6 +64,7 @@ var supportedProviders = []Provider{
 	S3Storage,
 }
 
+//nolint:ireturn
 func openFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,
@@ -72,7 +73,12 @@ func openFilestore(
 	for _, provider := range supportedProviders {
 		scheme := provider.Scheme()
 		if strings.HasPrefix(filestore.Base, scheme+api.Backslash) {
-			return provider.OpenFilestore(ctx, filestore, useServiceAccount, confirm)
+			fs, err := provider.OpenFilestore(ctx, filestore, useServiceAccount, confirm)
+			if err != nil {
+				return nil, fmt.Errorf("opening filestore %s: %w", filestore.Base, err)
+			}
+
+			return fs, nil
 		}
 	}
 
@@ -80,7 +86,9 @@ func openFilestore(
 	for _, provider := range supportedProviders {
 		expected = append(expected, provider.Scheme())
 	}
+
 	sort.Strings(expected)
+
 	return nil, fmt.Errorf(
 		"unrecognized scheme %q (supported schemes: %s)",
 		filestore.Base,
@@ -89,6 +97,8 @@ func openFilestore(
 }
 
 // openGCSFilestore opens a filestore backed by Google Cloud Storage (GCS).
+//
+//nolint:ireturn
 func (p *gcsProvider) OpenFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,
@@ -97,7 +107,7 @@ func (p *gcsProvider) OpenFilestore(
 	u, err := url.Parse(filestore.Base)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error parsing filestore base %q: %v",
+			"error parsing filestore base %q: %w",
 			filestore.Base,
 			err,
 		)
@@ -113,6 +123,7 @@ func (p *gcsProvider) OpenFilestore(
 	}
 
 	var opts []option.ClientOption
+
 	if withAuth {
 		logrus.Infof(
 			"requesting an authenticated storage client for %s",
@@ -132,7 +143,7 @@ func (p *gcsProvider) OpenFilestore(
 
 	client, err := storage.NewClient(ctx, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("error building GCS client: %v", err)
+		return nil, fmt.Errorf("error building GCS client: %w", err)
 	}
 
 	prefix := strings.TrimPrefix(u.Path, "/")
@@ -149,6 +160,7 @@ func (p *gcsProvider) OpenFilestore(
 		bucket:    bucket,
 		prefix:    prefix,
 	}
+
 	return s, nil
 }
 
@@ -181,6 +193,52 @@ func useStorageClientAuth(
 	return withAuth, nil
 }
 
+// BuildOperations builds the required operations to sync from the
+// Source Filestore to the Dest Filestore.
+func (p *FilestorePromoter) BuildOperations(
+	ctx context.Context,
+) ([]SyncFileOp, error) {
+	sourceFilestore, err := openFilestore(
+		ctx,
+		p.Source,
+		p.UseServiceAccount,
+		p.Confirm,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if sourceFilestore == nil {
+		return nil, errors.New("source filestore cannot be nil")
+	}
+
+	destFilestore, err := openFilestore(
+		ctx,
+		p.Dest,
+		p.UseServiceAccount,
+		p.Confirm,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if destFilestore == nil {
+		return nil, errors.New("destination filestore cannot be nil")
+	}
+
+	sourceFiles, err := sourceFilestore.ListFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing source files: %w", err)
+	}
+
+	destFiles, err := destFilestore.ListFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing destination files: %w", err)
+	}
+
+	return p.computeNeededOperations(sourceFiles, destFiles, destFilestore)
+}
+
 // computeNeededOperations determines the list of files that need to be copied.
 func (p *FilestorePromoter) computeNeededOperations(
 	source, dest map[string]*SyncFileInfo,
@@ -191,6 +249,7 @@ func (p *FilestorePromoter) computeNeededOperations(
 	for i := range p.Files {
 		f := &p.Files[i]
 		relativePath := f.Name
+
 		sourceFile := source[relativePath]
 		if sourceFile == nil {
 			absolutePath := joinFilepath(p.Source, relativePath)
@@ -216,16 +275,19 @@ func (p *FilestorePromoter) computeNeededOperations(
 				Dest:         destFile,
 				ManifestFile: f,
 			})
+
 			continue
 		}
 
 		changed := false
+
 		if destFile.MD5 != sourceFile.MD5 {
 			logrus.Warnf("MD5 mismatch on source %q vs dest %q: %q vs %q",
 				sourceFile.AbsolutePath,
 				destFile.AbsolutePath,
 				sourceFile.MD5,
 				destFile.MD5)
+
 			changed = true
 		}
 
@@ -235,13 +297,16 @@ func (p *FilestorePromoter) computeNeededOperations(
 				destFile.AbsolutePath,
 				sourceFile.Size,
 				destFile.Size)
+
 			changed = true
 		}
 
 		if !changed {
 			logrus.Infof("metadata match for %q", destFile.AbsolutePath)
+
 			continue
 		}
+
 		ops = append(ops, &copyFileOp{
 			Source:       sourceFile,
 			Dest:         destFile,
@@ -256,49 +321,6 @@ func joinFilepath(filestore *api.Filestore, relativePath string) string {
 	s := strings.TrimSuffix(filestore.Base, "/")
 	s += "/"
 	s += strings.TrimPrefix(relativePath, "/")
+
 	return s
-}
-
-// BuildOperations builds the required operations to sync from the
-// Source Filestore to the Dest Filestore.
-func (p *FilestorePromoter) BuildOperations(
-	ctx context.Context,
-) ([]SyncFileOp, error) {
-	sourceFilestore, err := openFilestore(
-		ctx,
-		p.Source,
-		p.UseServiceAccount,
-		p.Confirm,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if sourceFilestore == nil {
-		return nil, errors.New("source filestore cannot be nil")
-	}
-
-	destFilestore, err := openFilestore(
-		ctx,
-		p.Dest,
-		p.UseServiceAccount,
-		p.Confirm,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if destFilestore == nil {
-		return nil, errors.New("destination filestore cannot be nil")
-	}
-
-	sourceFiles, err := sourceFilestore.ListFiles(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	destFiles, err := destFilestore.ListFiles(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return p.computeNeededOperations(sourceFiles, destFiles, destFilestore)
 }

--- a/promoter/file/filestore_test.go
+++ b/promoter/file/filestore_test.go
@@ -30,6 +30,7 @@ func Test_useStorageClientAuth(t *testing.T) {
 		useServiceAccount bool
 		confirm           bool
 	}
+
 	tests := []struct {
 		name    string
 		args    args

--- a/promoter/file/gcs.go
+++ b/promoter/file/gcs.go
@@ -19,6 +19,7 @@ package file
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -57,7 +58,13 @@ func (s *gcsSyncFilestore) OpenReader(
 	name string,
 ) (io.ReadCloser, error) {
 	absolutePath := s.prefix + name
-	return s.client.Bucket(s.bucket).Object(absolutePath).NewReader(ctx)
+
+	reader, err := s.client.Bucket(s.bucket).Object(absolutePath).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("opening GCS reader for %s: %w", absolutePath, err)
+	}
+
+	return reader, nil
 }
 
 // UploadFile uploads a local file to the specified destination.
@@ -68,8 +75,9 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 
 	in, err := os.Open(localFile)
 	if err != nil {
-		return fmt.Errorf("error opening %q: %v", localFile, err)
+		return fmt.Errorf("error opening %q: %w", localFile, err)
 	}
+
 	defer func() {
 		if err := in.Close(); err != nil {
 			logrus.Warnf("error closing %q: %v", localFile, err)
@@ -81,12 +89,13 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 	{
 		hasher := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 		if _, err := io.Copy(hasher, in); err != nil {
-			return fmt.Errorf("error computing crc32 checksum: %v", err)
+			return fmt.Errorf("error computing crc32 checksum: %w", err)
 		}
+
 		fileCRC32C = hasher.Sum32()
 
 		if _, err := in.Seek(0, 0); err != nil {
-			return fmt.Errorf("error rewinding in file: %v", err)
+			return fmt.Errorf("error rewinding in file: %w", err)
 		}
 	}
 
@@ -105,11 +114,12 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 			logrus.Warnf("error closing upload stream: %v", err2)
 			// TODO: Try to delete the possibly partially written file?
 		}
-		return fmt.Errorf("error uploading to %q: %v", gcsURL, err)
+
+		return fmt.Errorf("error uploading to %q: %w", gcsURL, err)
 	}
 
 	if err := w.Close(); err != nil {
-		return fmt.Errorf("error uploading to %q: %v", gcsURL, err)
+		return fmt.Errorf("error uploading to %q: %w", gcsURL, err)
 	}
 
 	return nil
@@ -123,17 +133,20 @@ func (s *gcsSyncFilestore) ListFiles(
 
 	q := &storage.Query{Prefix: s.prefix}
 	logrus.Infof("listing files in bucket %s with prefix %q", s.bucket, s.prefix)
+
 	it := s.client.Bucket(s.bucket).Objects(ctx, q)
 	for {
 		obj, err := it.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
+
 		if err != nil {
 			return nil, fmt.Errorf(
-				"error listing objects in %q: %v",
+				"error listing objects in %q: %w",
 				s.filestore.Base, err)
 		}
+
 		name := obj.Name
 		if !strings.HasPrefix(name, s.prefix) {
 			return nil, fmt.Errorf(
@@ -143,6 +156,7 @@ func (s *gcsSyncFilestore) ListFiles(
 
 		file := &SyncFileInfo{}
 		file.AbsolutePath = s.provider.Scheme() + api.Backslash + s.bucket + "/" + obj.Name
+
 		file.RelativePath = strings.TrimPrefix(name, s.prefix)
 		if obj.MD5 == nil {
 			return nil, fmt.Errorf("MD5 not set on file %q", file.AbsolutePath)

--- a/promoter/file/manifest.go
+++ b/promoter/file/manifest.go
@@ -55,6 +55,7 @@ func (p *ManifestPromoter) BuildOperations(
 		if filestore.Src {
 			continue
 		}
+
 		logrus.Infof("processing destination %q", filestore.Base)
 		fp := &FilestorePromoter{
 			Source:            source,
@@ -63,12 +64,14 @@ func (p *ManifestPromoter) BuildOperations(
 			Confirm:           p.Confirm,
 			UseServiceAccount: p.UseServiceAccount,
 		}
+
 		ops, err := fp.BuildOperations(ctx)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"error building promotion operations for %q: %v",
+				"error building promotion operations for %q: %w",
 				filestore.Base, err)
 		}
+
 		operations = append(operations, ops...)
 	}
 
@@ -80,17 +83,21 @@ func (p *ManifestPromoter) BuildOperations(
 // multiple filestores are marked as the source.
 func getSourceFilestore(manifest *api.Manifest) (*api.Filestore, error) {
 	var source *api.Filestore
+
 	for i := range manifest.Filestores {
 		filestore := &manifest.Filestores[i]
 		if filestore.Src {
 			if source != nil {
 				return nil, errors.New("found multiple source filestores")
 			}
+
 			source = filestore
 		}
 	}
+
 	if source == nil {
 		return nil, errors.New("source filestore not found")
 	}
+
 	return source, nil
 }

--- a/promoter/file/s3.go
+++ b/promoter/file/s3.go
@@ -18,7 +18,7 @@ package file
 
 import (
 	"context"
-	"crypto/md5" //nolint: gosec
+	"crypto/md5" //nolint:gosec // MD5 required by S3 API
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
@@ -56,13 +56,14 @@ type s3SyncFilestore struct {
 	prefix    string
 }
 
-// openS3Filestore opens a filestore backed by Amazon S3 (S3)
-
+// openS3Filestore opens a filestore backed by Amazon S3 (S3).
+//
+//nolint:ireturn
 func (p *s3Provider) OpenFilestore(ctx context.Context, filestore *api.Filestore, useServiceAccount, confirm bool) (syncFilestore, error) {
 	u, err := url.Parse(filestore.Base)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error parsing filestore base %q: %v",
+			"error parsing filestore base %q: %w",
 			filestore.Base,
 			err,
 		)
@@ -101,6 +102,7 @@ func (p *s3Provider) OpenFilestore(ctx context.Context, filestore *api.Filestore
 		bucket:    bucket,
 		prefix:    prefix,
 	}
+
 	return s, nil
 }
 
@@ -121,6 +123,7 @@ func (p *s3Provider) findRegionForBucket(ctx context.Context, bucket string) (st
 	}
 
 	client := s3.NewFromConfig(cfg)
+
 	bucketRegion, err := s3manager.GetBucketRegion(ctx, client, bucket)
 	if err != nil {
 		return "", fmt.Errorf("error finding s3 region for bucket %q: %w", bucket, err)
@@ -139,10 +142,12 @@ func (s *s3SyncFilestore) OpenReader(
 		Bucket: &s.bucket,
 		Key:    &key,
 	}
+
 	obj, err := s.client.GetObject(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("error reading object %q: %w", key, err)
 	}
+
 	return obj.Body, nil
 }
 
@@ -161,6 +166,7 @@ func (s *s3SyncFilestore) UploadFile(ctx context.Context, dest, localFile string
 	if err != nil {
 		return fmt.Errorf("error opening %q: %w", localFile, err)
 	}
+
 	defer func() {
 		if err := f.Close(); err != nil {
 			logrus.Warnf("error closing %q: %v", localFile, err)
@@ -192,6 +198,7 @@ func (s *s3SyncFilestore) UploadFile(ctx context.Context, dest, localFile string
 	if _, err := f.Seek(0, 0); err != nil {
 		return fmt.Errorf("error rewinding file: %w", err)
 	}
+
 	req.Body = f
 
 	logrus.Infof("uploading to %s", s3URL)
@@ -245,6 +252,7 @@ func (s *s3SyncFilestore) ListFiles(
 		file.RelativePath = strings.TrimPrefix(name, s.prefix)
 
 		md5 := aws.ToString(obj.ETag)
+
 		md5 = strings.Trim(md5, "\"")
 		if md5 == "" {
 			return fmt.Errorf("MD5 not set on file %q", file.AbsolutePath)
@@ -260,6 +268,7 @@ func (s *s3SyncFilestore) ListFiles(
 		file.filestore = s
 
 		files[file.RelativePath] = file
+
 		return nil
 	}
 
@@ -289,7 +298,7 @@ type Hashes struct {
 func computeHashes(in io.ReadSeeker) (*Hashes, error) {
 	hasherSHA256 := sha256.New()
 	hasherSHA512 := sha512.New()
-	hasherMD5 := md5.New() //nolint: gosec
+	hasherMD5 := md5.New() //nolint:gosec // MD5 required by S3 API
 
 	hasher := io.MultiWriter(hasherMD5, hasherSHA256, hasherSHA512)
 
@@ -301,6 +310,7 @@ func computeHashes(in io.ReadSeeker) (*Hashes, error) {
 	if _, err := in.Seek(0, 0); err != nil {
 		return nil, fmt.Errorf("error rewinding file: %w", err)
 	}
+
 	return &Hashes{
 		SHA256: hasherSHA256.Sum(nil),
 		SHA512: hasherSHA512.Sum(nil),

--- a/promoter/file/token.go
+++ b/promoter/file/token.go
@@ -17,6 +17,7 @@ limitations under the License.
 package file
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 
@@ -47,11 +48,13 @@ func (s *gcloudTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	cmd := command.New("gcloud", args...)
+
 	std, err := cmd.RunSilentSuccessOutput()
 	if err != nil {
 		logrus.Warnf("failed to get service-account-token for %q: %v",
 			s.ServiceAccount, err)
-		return nil, err
+
+		return nil, fmt.Errorf("getting access token for %q: %w", s.ServiceAccount, err)
 	}
 
 	return &oauth2.Token{

--- a/promoter/image/auth/auth_test.go
+++ b/promoter/image/auth/auth_test.go
@@ -29,6 +29,7 @@ func TestStaticIdentityTokenProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetIdentityToken() error = %v", err)
 	}
+
 	if tok != "oidc-token" {
 		t.Errorf("GetIdentityToken() = %q, want %q", tok, "oidc-token")
 	}

--- a/promoter/image/auth/gcp.go
+++ b/promoter/image/auth/gcp.go
@@ -45,6 +45,7 @@ func (g *GCPIdentityTokenProvider) GetIdentityToken(
 	ctx context.Context, serviceAccount, audience string,
 ) (string, error) {
 	var clientOpts []gopts.ClientOption
+
 	if g.CredentialsFile != "" {
 		logrus.Infof("Using credentials from %s", g.CredentialsFile)
 		//nolint:staticcheck // Credentials file is user-provided for service account impersonation.
@@ -87,6 +88,7 @@ func (g *GCPServiceActivator) ActivateServiceAccounts(_ context.Context, keyFile
 		if errors.Is(err, io.EOF) {
 			break
 		}
+
 		if err != nil {
 			return fmt.Errorf("reading key file paths: %w", err)
 		}
@@ -103,5 +105,6 @@ func (g *GCPServiceActivator) ActivateServiceAccounts(_ context.Context, keyFile
 			}
 		}
 	}
+
 	return nil
 }

--- a/promoter/image/auth/static.go
+++ b/promoter/image/auth/static.go
@@ -35,6 +35,7 @@ func (s *StaticIdentityTokenProvider) GetIdentityToken(_ context.Context, _, _ s
 	if s.Err != nil {
 		return "", fmt.Errorf("static identity token error: %w", s.Err)
 	}
+
 	return s.Token, nil
 }
 
@@ -50,5 +51,6 @@ func (n *NoopServiceActivator) ActivateServiceAccounts(_ context.Context, _ stri
 	if n.Err != nil {
 		return fmt.Errorf("noop activator error: %w", n.Err)
 	}
+
 	return nil
 }

--- a/promoter/image/checkresults/checkresults.go
+++ b/promoter/image/checkresults/checkresults.go
@@ -25,20 +25,24 @@ type Signature map[string]CheckList
 
 func (s *Signature) TotalPartial() int {
 	total := 0
+
 	for _, list := range *s {
 		if len(list.Signed) > 0 && len(list.Missing) > 0 {
 			total++
 		}
 	}
+
 	return total
 }
 
 func (s *Signature) TotalUnsigned() int {
 	total := 0
+
 	for _, list := range *s {
 		if len(list.Missing) > 0 && len(list.Signed) == 0 {
 			total++
 		}
 	}
+
 	return total
 }

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -54,17 +54,17 @@ type FakePromoterImplementation struct {
 		result1 []schema.Manifest
 		result2 error
 	}
-	EdgesFromManifestsStub        func([]schema.Manifest) (map[promotion.Edge]interface{}, error)
+	EdgesFromManifestsStub        func([]schema.Manifest) (map[promotion.Edge]any, error)
 	edgesFromManifestsMutex       sync.RWMutex
 	edgesFromManifestsArgsForCall []struct {
 		arg1 []schema.Manifest
 	}
 	edgesFromManifestsReturns struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}
 	edgesFromManifestsReturnsOnCall map[int]struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}
 	FixMissingSignaturesStub        func(*imagepromotera.Options, checkresults.Signature) error
@@ -104,18 +104,18 @@ type FakePromoterImplementation struct {
 		result1 []string
 		result2 error
 	}
-	GetPromotionEdgesStub        func(*imagepromotera.Options, []schema.Manifest) (map[promotion.Edge]interface{}, error)
+	GetPromotionEdgesStub        func(*imagepromotera.Options, []schema.Manifest) (map[promotion.Edge]any, error)
 	getPromotionEdgesMutex       sync.RWMutex
 	getPromotionEdgesArgsForCall []struct {
 		arg1 *imagepromotera.Options
 		arg2 []schema.Manifest
 	}
 	getPromotionEdgesReturns struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}
 	getPromotionEdgesReturnsOnCall map[int]struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}
 	GetRegistryImageInventoryStub        func(*imagepromotera.Options, []schema.Manifest) (registry.RegInvImage, error)
@@ -203,11 +203,11 @@ type FakePromoterImplementation struct {
 	printVersionMutex       sync.RWMutex
 	printVersionArgsForCall []struct {
 	}
-	PromoteImagesStub        func(*imagepromotera.Options, map[promotion.Edge]interface{}) error
+	PromoteImagesStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
 	promoteImagesMutex       sync.RWMutex
 	promoteImagesArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}
 	promoteImagesReturns struct {
 		result1 error
@@ -215,11 +215,11 @@ type FakePromoterImplementation struct {
 	promoteImagesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ReplicateSignaturesStub        func(*imagepromotera.Options, map[promotion.Edge]interface{}) error
+	ReplicateSignaturesStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
 	replicateSignaturesMutex       sync.RWMutex
 	replicateSignaturesArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}
 	replicateSignaturesReturns struct {
 		result1 error
@@ -227,11 +227,11 @@ type FakePromoterImplementation struct {
 	replicateSignaturesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ScanEdgesStub        func(*imagepromotera.Options, map[promotion.Edge]interface{}) error
+	ScanEdgesStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
 	scanEdgesMutex       sync.RWMutex
 	scanEdgesArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}
 	scanEdgesReturns struct {
 		result1 error
@@ -239,11 +239,11 @@ type FakePromoterImplementation struct {
 	scanEdgesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SignImagesStub        func(*imagepromotera.Options, map[promotion.Edge]interface{}) error
+	SignImagesStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
 	signImagesMutex       sync.RWMutex
 	signImagesArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}
 	signImagesReturns struct {
 		result1 error
@@ -274,24 +274,24 @@ type FakePromoterImplementation struct {
 	validateOptionsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ValidateStagingSignaturesStub        func(map[promotion.Edge]interface{}) (map[promotion.Edge]interface{}, error)
+	ValidateStagingSignaturesStub        func(map[promotion.Edge]any) (map[promotion.Edge]any, error)
 	validateStagingSignaturesMutex       sync.RWMutex
 	validateStagingSignaturesArgsForCall []struct {
-		arg1 map[promotion.Edge]interface{}
+		arg1 map[promotion.Edge]any
 	}
 	validateStagingSignaturesReturns struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}
 	validateStagingSignaturesReturnsOnCall map[int]struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}
-	WriteProvenanceAttestationsStub        func(*imagepromotera.Options, map[promotion.Edge]interface{}, provenance.Generator) error
+	WriteProvenanceAttestationsStub        func(*imagepromotera.Options, map[promotion.Edge]any, provenance.Generator) error
 	writeProvenanceAttestationsMutex       sync.RWMutex
 	writeProvenanceAttestationsArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 		arg3 provenance.Generator
 	}
 	writeProvenanceAttestationsReturns struct {
@@ -300,11 +300,11 @@ type FakePromoterImplementation struct {
 	writeProvenanceAttestationsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	WriteSBOMsStub        func(*imagepromotera.Options, map[promotion.Edge]interface{}) error
+	WriteSBOMsStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
 	writeSBOMsMutex       sync.RWMutex
 	writeSBOMsArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}
 	writeSBOMsReturns struct {
 		result1 error
@@ -447,7 +447,7 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i 
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) EdgesFromManifests(arg1 []schema.Manifest) (map[promotion.Edge]interface{}, error) {
+func (fake *FakePromoterImplementation) EdgesFromManifests(arg1 []schema.Manifest) (map[promotion.Edge]any, error) {
 	var arg1Copy []schema.Manifest
 	if arg1 != nil {
 		arg1Copy = make([]schema.Manifest, len(arg1))
@@ -477,7 +477,7 @@ func (fake *FakePromoterImplementation) EdgesFromManifestsCallCount() int {
 	return len(fake.edgesFromManifestsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) EdgesFromManifestsCalls(stub func([]schema.Manifest) (map[promotion.Edge]interface{}, error)) {
+func (fake *FakePromoterImplementation) EdgesFromManifestsCalls(stub func([]schema.Manifest) (map[promotion.Edge]any, error)) {
 	fake.edgesFromManifestsMutex.Lock()
 	defer fake.edgesFromManifestsMutex.Unlock()
 	fake.EdgesFromManifestsStub = stub
@@ -490,28 +490,28 @@ func (fake *FakePromoterImplementation) EdgesFromManifestsArgsForCall(i int) []s
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) EdgesFromManifestsReturns(result1 map[promotion.Edge]interface{}, result2 error) {
+func (fake *FakePromoterImplementation) EdgesFromManifestsReturns(result1 map[promotion.Edge]any, result2 error) {
 	fake.edgesFromManifestsMutex.Lock()
 	defer fake.edgesFromManifestsMutex.Unlock()
 	fake.EdgesFromManifestsStub = nil
 	fake.edgesFromManifestsReturns = struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) EdgesFromManifestsReturnsOnCall(i int, result1 map[promotion.Edge]interface{}, result2 error) {
+func (fake *FakePromoterImplementation) EdgesFromManifestsReturnsOnCall(i int, result1 map[promotion.Edge]any, result2 error) {
 	fake.edgesFromManifestsMutex.Lock()
 	defer fake.edgesFromManifestsMutex.Unlock()
 	fake.EdgesFromManifestsStub = nil
 	if fake.edgesFromManifestsReturnsOnCall == nil {
 		fake.edgesFromManifestsReturnsOnCall = make(map[int]struct {
-			result1 map[promotion.Edge]interface{}
+			result1 map[promotion.Edge]any
 			result2 error
 		})
 	}
 	fake.edgesFromManifestsReturnsOnCall[i] = struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}{result1, result2}
 }
@@ -704,7 +704,7 @@ func (fake *FakePromoterImplementation) GetLatestImagesReturnsOnCall(i int, resu
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *imagepromotera.Options, arg2 []schema.Manifest) (map[promotion.Edge]interface{}, error) {
+func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *imagepromotera.Options, arg2 []schema.Manifest) (map[promotion.Edge]any, error) {
 	var arg2Copy []schema.Manifest
 	if arg2 != nil {
 		arg2Copy = make([]schema.Manifest, len(arg2))
@@ -735,7 +735,7 @@ func (fake *FakePromoterImplementation) GetPromotionEdgesCallCount() int {
 	return len(fake.getPromotionEdgesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesCalls(stub func(*imagepromotera.Options, []schema.Manifest) (map[promotion.Edge]interface{}, error)) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesCalls(stub func(*imagepromotera.Options, []schema.Manifest) (map[promotion.Edge]any, error)) {
 	fake.getPromotionEdgesMutex.Lock()
 	defer fake.getPromotionEdgesMutex.Unlock()
 	fake.GetPromotionEdgesStub = stub
@@ -748,28 +748,28 @@ func (fake *FakePromoterImplementation) GetPromotionEdgesArgsForCall(i int) (*im
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesReturns(result1 map[promotion.Edge]interface{}, result2 error) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesReturns(result1 map[promotion.Edge]any, result2 error) {
 	fake.getPromotionEdgesMutex.Lock()
 	defer fake.getPromotionEdgesMutex.Unlock()
 	fake.GetPromotionEdgesStub = nil
 	fake.getPromotionEdgesReturns = struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesReturnsOnCall(i int, result1 map[promotion.Edge]interface{}, result2 error) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesReturnsOnCall(i int, result1 map[promotion.Edge]any, result2 error) {
 	fake.getPromotionEdgesMutex.Lock()
 	defer fake.getPromotionEdgesMutex.Unlock()
 	fake.GetPromotionEdgesStub = nil
 	if fake.getPromotionEdgesReturnsOnCall == nil {
 		fake.getPromotionEdgesReturnsOnCall = make(map[int]struct {
-			result1 map[promotion.Edge]interface{}
+			result1 map[promotion.Edge]any
 			result2 error
 		})
 	}
 	fake.getPromotionEdgesReturnsOnCall[i] = struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}{result1, result2}
 }
@@ -1207,12 +1207,12 @@ func (fake *FakePromoterImplementation) PrintVersionCalls(stub func()) {
 	fake.PrintVersionStub = stub
 }
 
-func (fake *FakePromoterImplementation) PromoteImages(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]interface{}) error {
+func (fake *FakePromoterImplementation) PromoteImages(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
 	fake.promoteImagesMutex.Lock()
 	ret, specificReturn := fake.promoteImagesReturnsOnCall[len(fake.promoteImagesArgsForCall)]
 	fake.promoteImagesArgsForCall = append(fake.promoteImagesArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}{arg1, arg2})
 	stub := fake.PromoteImagesStub
 	fakeReturns := fake.promoteImagesReturns
@@ -1233,13 +1233,13 @@ func (fake *FakePromoterImplementation) PromoteImagesCallCount() int {
 	return len(fake.promoteImagesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) PromoteImagesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]interface{}) error) {
+func (fake *FakePromoterImplementation) PromoteImagesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
 	fake.promoteImagesMutex.Lock()
 	defer fake.promoteImagesMutex.Unlock()
 	fake.PromoteImagesStub = stub
 }
 
-func (fake *FakePromoterImplementation) PromoteImagesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]interface{}) {
+func (fake *FakePromoterImplementation) PromoteImagesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
 	fake.promoteImagesMutex.RLock()
 	defer fake.promoteImagesMutex.RUnlock()
 	argsForCall := fake.promoteImagesArgsForCall[i]
@@ -1269,12 +1269,12 @@ func (fake *FakePromoterImplementation) PromoteImagesReturnsOnCall(i int, result
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) ReplicateSignatures(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]interface{}) error {
+func (fake *FakePromoterImplementation) ReplicateSignatures(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
 	fake.replicateSignaturesMutex.Lock()
 	ret, specificReturn := fake.replicateSignaturesReturnsOnCall[len(fake.replicateSignaturesArgsForCall)]
 	fake.replicateSignaturesArgsForCall = append(fake.replicateSignaturesArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}{arg1, arg2})
 	stub := fake.ReplicateSignaturesStub
 	fakeReturns := fake.replicateSignaturesReturns
@@ -1295,13 +1295,13 @@ func (fake *FakePromoterImplementation) ReplicateSignaturesCallCount() int {
 	return len(fake.replicateSignaturesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) ReplicateSignaturesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]interface{}) error) {
+func (fake *FakePromoterImplementation) ReplicateSignaturesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
 	fake.replicateSignaturesMutex.Lock()
 	defer fake.replicateSignaturesMutex.Unlock()
 	fake.ReplicateSignaturesStub = stub
 }
 
-func (fake *FakePromoterImplementation) ReplicateSignaturesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]interface{}) {
+func (fake *FakePromoterImplementation) ReplicateSignaturesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
 	fake.replicateSignaturesMutex.RLock()
 	defer fake.replicateSignaturesMutex.RUnlock()
 	argsForCall := fake.replicateSignaturesArgsForCall[i]
@@ -1331,12 +1331,12 @@ func (fake *FakePromoterImplementation) ReplicateSignaturesReturnsOnCall(i int, 
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) ScanEdges(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]interface{}) error {
+func (fake *FakePromoterImplementation) ScanEdges(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
 	fake.scanEdgesMutex.Lock()
 	ret, specificReturn := fake.scanEdgesReturnsOnCall[len(fake.scanEdgesArgsForCall)]
 	fake.scanEdgesArgsForCall = append(fake.scanEdgesArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}{arg1, arg2})
 	stub := fake.ScanEdgesStub
 	fakeReturns := fake.scanEdgesReturns
@@ -1357,13 +1357,13 @@ func (fake *FakePromoterImplementation) ScanEdgesCallCount() int {
 	return len(fake.scanEdgesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) ScanEdgesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]interface{}) error) {
+func (fake *FakePromoterImplementation) ScanEdgesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
 	fake.scanEdgesMutex.Lock()
 	defer fake.scanEdgesMutex.Unlock()
 	fake.ScanEdgesStub = stub
 }
 
-func (fake *FakePromoterImplementation) ScanEdgesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]interface{}) {
+func (fake *FakePromoterImplementation) ScanEdgesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
 	fake.scanEdgesMutex.RLock()
 	defer fake.scanEdgesMutex.RUnlock()
 	argsForCall := fake.scanEdgesArgsForCall[i]
@@ -1393,12 +1393,12 @@ func (fake *FakePromoterImplementation) ScanEdgesReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) SignImages(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]interface{}) error {
+func (fake *FakePromoterImplementation) SignImages(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
 	fake.signImagesMutex.Lock()
 	ret, specificReturn := fake.signImagesReturnsOnCall[len(fake.signImagesArgsForCall)]
 	fake.signImagesArgsForCall = append(fake.signImagesArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}{arg1, arg2})
 	stub := fake.SignImagesStub
 	fakeReturns := fake.signImagesReturns
@@ -1419,13 +1419,13 @@ func (fake *FakePromoterImplementation) SignImagesCallCount() int {
 	return len(fake.signImagesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) SignImagesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]interface{}) error) {
+func (fake *FakePromoterImplementation) SignImagesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
 	fake.signImagesMutex.Lock()
 	defer fake.signImagesMutex.Unlock()
 	fake.SignImagesStub = stub
 }
 
-func (fake *FakePromoterImplementation) SignImagesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]interface{}) {
+func (fake *FakePromoterImplementation) SignImagesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
 	fake.signImagesMutex.RLock()
 	defer fake.signImagesMutex.RUnlock()
 	argsForCall := fake.signImagesArgsForCall[i]
@@ -1578,11 +1578,11 @@ func (fake *FakePromoterImplementation) ValidateOptionsReturnsOnCall(i int, resu
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) ValidateStagingSignatures(arg1 map[promotion.Edge]interface{}) (map[promotion.Edge]interface{}, error) {
+func (fake *FakePromoterImplementation) ValidateStagingSignatures(arg1 map[promotion.Edge]any) (map[promotion.Edge]any, error) {
 	fake.validateStagingSignaturesMutex.Lock()
 	ret, specificReturn := fake.validateStagingSignaturesReturnsOnCall[len(fake.validateStagingSignaturesArgsForCall)]
 	fake.validateStagingSignaturesArgsForCall = append(fake.validateStagingSignaturesArgsForCall, struct {
-		arg1 map[promotion.Edge]interface{}
+		arg1 map[promotion.Edge]any
 	}{arg1})
 	stub := fake.ValidateStagingSignaturesStub
 	fakeReturns := fake.validateStagingSignaturesReturns
@@ -1603,51 +1603,51 @@ func (fake *FakePromoterImplementation) ValidateStagingSignaturesCallCount() int
 	return len(fake.validateStagingSignaturesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) ValidateStagingSignaturesCalls(stub func(map[promotion.Edge]interface{}) (map[promotion.Edge]interface{}, error)) {
+func (fake *FakePromoterImplementation) ValidateStagingSignaturesCalls(stub func(map[promotion.Edge]any) (map[promotion.Edge]any, error)) {
 	fake.validateStagingSignaturesMutex.Lock()
 	defer fake.validateStagingSignaturesMutex.Unlock()
 	fake.ValidateStagingSignaturesStub = stub
 }
 
-func (fake *FakePromoterImplementation) ValidateStagingSignaturesArgsForCall(i int) map[promotion.Edge]interface{} {
+func (fake *FakePromoterImplementation) ValidateStagingSignaturesArgsForCall(i int) map[promotion.Edge]any {
 	fake.validateStagingSignaturesMutex.RLock()
 	defer fake.validateStagingSignaturesMutex.RUnlock()
 	argsForCall := fake.validateStagingSignaturesArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) ValidateStagingSignaturesReturns(result1 map[promotion.Edge]interface{}, result2 error) {
+func (fake *FakePromoterImplementation) ValidateStagingSignaturesReturns(result1 map[promotion.Edge]any, result2 error) {
 	fake.validateStagingSignaturesMutex.Lock()
 	defer fake.validateStagingSignaturesMutex.Unlock()
 	fake.ValidateStagingSignaturesStub = nil
 	fake.validateStagingSignaturesReturns = struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) ValidateStagingSignaturesReturnsOnCall(i int, result1 map[promotion.Edge]interface{}, result2 error) {
+func (fake *FakePromoterImplementation) ValidateStagingSignaturesReturnsOnCall(i int, result1 map[promotion.Edge]any, result2 error) {
 	fake.validateStagingSignaturesMutex.Lock()
 	defer fake.validateStagingSignaturesMutex.Unlock()
 	fake.ValidateStagingSignaturesStub = nil
 	if fake.validateStagingSignaturesReturnsOnCall == nil {
 		fake.validateStagingSignaturesReturnsOnCall = make(map[int]struct {
-			result1 map[promotion.Edge]interface{}
+			result1 map[promotion.Edge]any
 			result2 error
 		})
 	}
 	fake.validateStagingSignaturesReturnsOnCall[i] = struct {
-		result1 map[promotion.Edge]interface{}
+		result1 map[promotion.Edge]any
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) WriteProvenanceAttestations(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]interface{}, arg3 provenance.Generator) error {
+func (fake *FakePromoterImplementation) WriteProvenanceAttestations(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any, arg3 provenance.Generator) error {
 	fake.writeProvenanceAttestationsMutex.Lock()
 	ret, specificReturn := fake.writeProvenanceAttestationsReturnsOnCall[len(fake.writeProvenanceAttestationsArgsForCall)]
 	fake.writeProvenanceAttestationsArgsForCall = append(fake.writeProvenanceAttestationsArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 		arg3 provenance.Generator
 	}{arg1, arg2, arg3})
 	stub := fake.WriteProvenanceAttestationsStub
@@ -1669,13 +1669,13 @@ func (fake *FakePromoterImplementation) WriteProvenanceAttestationsCallCount() i
 	return len(fake.writeProvenanceAttestationsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) WriteProvenanceAttestationsCalls(stub func(*imagepromotera.Options, map[promotion.Edge]interface{}, provenance.Generator) error) {
+func (fake *FakePromoterImplementation) WriteProvenanceAttestationsCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any, provenance.Generator) error) {
 	fake.writeProvenanceAttestationsMutex.Lock()
 	defer fake.writeProvenanceAttestationsMutex.Unlock()
 	fake.WriteProvenanceAttestationsStub = stub
 }
 
-func (fake *FakePromoterImplementation) WriteProvenanceAttestationsArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]interface{}, provenance.Generator) {
+func (fake *FakePromoterImplementation) WriteProvenanceAttestationsArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any, provenance.Generator) {
 	fake.writeProvenanceAttestationsMutex.RLock()
 	defer fake.writeProvenanceAttestationsMutex.RUnlock()
 	argsForCall := fake.writeProvenanceAttestationsArgsForCall[i]
@@ -1705,12 +1705,12 @@ func (fake *FakePromoterImplementation) WriteProvenanceAttestationsReturnsOnCall
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) WriteSBOMs(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]interface{}) error {
+func (fake *FakePromoterImplementation) WriteSBOMs(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
 	fake.writeSBOMsMutex.Lock()
 	ret, specificReturn := fake.writeSBOMsReturnsOnCall[len(fake.writeSBOMsArgsForCall)]
 	fake.writeSBOMsArgsForCall = append(fake.writeSBOMsArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]interface{}
+		arg2 map[promotion.Edge]any
 	}{arg1, arg2})
 	stub := fake.WriteSBOMsStub
 	fakeReturns := fake.writeSBOMsReturns
@@ -1731,13 +1731,13 @@ func (fake *FakePromoterImplementation) WriteSBOMsCallCount() int {
 	return len(fake.writeSBOMsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) WriteSBOMsCalls(stub func(*imagepromotera.Options, map[promotion.Edge]interface{}) error) {
+func (fake *FakePromoterImplementation) WriteSBOMsCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
 	fake.writeSBOMsMutex.Lock()
 	defer fake.writeSBOMsMutex.Unlock()
 	fake.WriteSBOMsStub = stub
 }
 
-func (fake *FakePromoterImplementation) WriteSBOMsArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]interface{}) {
+func (fake *FakePromoterImplementation) WriteSBOMsArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
 	fake.writeSBOMsMutex.RLock()
 	defer fake.writeSBOMsMutex.RUnlock()
 	argsForCall := fake.writeSBOMsArgsForCall[i]

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -169,6 +169,7 @@ func (o *Options) Validate() error {
 			return errors.New("at least a manifest file or thin manifest directory have to be specified")
 		}
 	}
+
 	return nil
 }
 

--- a/promoter/image/pipeline/pipeline.go
+++ b/promoter/image/pipeline/pipeline.go
@@ -73,6 +73,7 @@ func New() *Pipeline {
 // for chaining.
 func (p *Pipeline) AddPhase(phase Phase) *Pipeline {
 	p.phases = append(p.phases, phase)
+
 	return p
 }
 
@@ -80,6 +81,7 @@ func (p *Pipeline) AddPhase(phase Phase) *Pipeline {
 // stops and the error is returned.
 func (p *Pipeline) Run(ctx context.Context) error {
 	logrus.Infof("Pipeline starting with %d phases", len(p.phases))
+
 	start := time.Now()
 
 	for i, phase := range p.phases {
@@ -90,13 +92,16 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		}
 
 		logrus.Infof("Phase %d/%d: %s", i+1, len(p.phases), phase.Name())
+
 		phaseStart := time.Now()
 
 		if err := phase.Run(ctx); err != nil {
 			if errors.Is(err, ErrStopPipeline) {
 				logrus.Infof("Phase %q requested pipeline stop", phase.Name())
+
 				return nil
 			}
+
 			return fmt.Errorf("phase %q failed: %w", phase.Name(), err)
 		}
 
@@ -104,5 +109,6 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 
 	logrus.Infof("Pipeline completed in %s", time.Since(start))
+
 	return nil
 }

--- a/promoter/image/pipeline/pipeline_test.go
+++ b/promoter/image/pipeline/pipeline_test.go
@@ -35,14 +35,17 @@ func TestPipelineExecutesInOrder(t *testing.T) {
 	p := New()
 	p.AddPhase(NewPhase("first", func(_ context.Context) error {
 		order = append(order, "first")
+
 		return nil
 	}))
 	p.AddPhase(NewPhase("second", func(_ context.Context) error {
 		order = append(order, "second")
+
 		return nil
 	}))
 	p.AddPhase(NewPhase("third", func(_ context.Context) error {
 		order = append(order, "third")
+
 		return nil
 	}))
 
@@ -53,6 +56,7 @@ func TestPipelineExecutesInOrder(t *testing.T) {
 	if len(order) != 3 {
 		t.Fatalf("expected 3 phases, got %d", len(order))
 	}
+
 	for i, want := range []string{"first", "second", "third"} {
 		if order[i] != want {
 			t.Errorf("order[%d] = %q, want %q", i, order[i], want)
@@ -66,14 +70,17 @@ func TestPipelineStopsOnError(t *testing.T) {
 	p := New()
 	p.AddPhase(NewPhase("ok", func(_ context.Context) error {
 		executed = append(executed, "ok")
+
 		return nil
 	}))
 	p.AddPhase(NewPhase("fail", func(_ context.Context) error {
 		executed = append(executed, "fail")
+
 		return errors.New("boom")
 	}))
 	p.AddPhase(NewPhase("skipped", func(_ context.Context) error {
 		executed = append(executed, "skipped")
+
 		return nil
 	}))
 
@@ -81,9 +88,11 @@ func TestPipelineStopsOnError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+
 	if len(executed) != 2 {
 		t.Fatalf("expected 2 phases executed, got %d: %v", len(executed), executed)
 	}
+
 	if executed[0] != "ok" || executed[1] != "fail" {
 		t.Errorf("unexpected execution order: %v", executed)
 	}
@@ -96,6 +105,7 @@ func TestPipelineCancelledContext(t *testing.T) {
 	p := New()
 	p.AddPhase(NewPhase("should-not-run", func(_ context.Context) error {
 		t.Error("phase should not have run")
+
 		return nil
 	}))
 
@@ -124,6 +134,7 @@ func TestPhaseFuncName(t *testing.T) {
 
 func TestPipelinePassesContext(t *testing.T) {
 	type ctxKey string
+
 	key := ctxKey("test")
 
 	p := New()
@@ -132,6 +143,7 @@ func TestPipelinePassesContext(t *testing.T) {
 		if val != "hello" {
 			t.Errorf("context value = %v, want %q", val, "hello")
 		}
+
 		return nil
 	}))
 
@@ -147,14 +159,17 @@ func TestPipelineErrStopPipeline(t *testing.T) {
 	p := New()
 	p.AddPhase(NewPhase("runs", func(_ context.Context) error {
 		executed = append(executed, "runs")
+
 		return nil
 	}))
 	p.AddPhase(NewPhase("stops", func(_ context.Context) error {
 		executed = append(executed, "stops")
+
 		return ErrStopPipeline
 	}))
 	p.AddPhase(NewPhase("skipped", func(_ context.Context) error {
 		executed = append(executed, "skipped")
+
 		return nil
 	}))
 
@@ -162,9 +177,11 @@ func TestPipelineErrStopPipeline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ErrStopPipeline should result in nil error, got: %v", err)
 	}
+
 	if len(executed) != 2 {
 		t.Fatalf("expected 2 phases, got %d: %v", len(executed), executed)
 	}
+
 	if executed[0] != "runs" || executed[1] != "stops" {
 		t.Errorf("unexpected order: %v", executed)
 	}
@@ -177,12 +194,14 @@ func TestPipelineSharedState(t *testing.T) {
 	p := New()
 	p.AddPhase(NewPhase("produce", func(_ context.Context) error {
 		result = 42
+
 		return nil
 	}))
 	p.AddPhase(NewPhase("consume", func(_ context.Context) error {
 		if result != 42 {
 			t.Errorf("shared state = %d, want 42", result)
 		}
+
 		return nil
 	}))
 

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -108,9 +108,9 @@ type promoterImplementation interface {
 
 	// Methods for promotion mode:
 	ParseManifests(*options.Options) ([]schema.Manifest, error)
-	GetPromotionEdges(*options.Options, []schema.Manifest) (map[promotion.Edge]interface{}, error)
-	EdgesFromManifests([]schema.Manifest) (map[promotion.Edge]interface{}, error)
-	PromoteImages(*options.Options, map[promotion.Edge]interface{}) error
+	GetPromotionEdges(*options.Options, []schema.Manifest) (map[promotion.Edge]any, error)
+	EdgesFromManifests([]schema.Manifest) (map[promotion.Edge]any, error)
+	PromoteImages(*options.Options, map[promotion.Edge]any) error
 
 	// Methods for snapshot mode:
 	GetSnapshotSourceRegistry(*options.Options) (*registry.Context, error)
@@ -120,15 +120,15 @@ type promoterImplementation interface {
 	Snapshot(*options.Options, registry.RegInvImage) error
 
 	// Methods for image vulnerability scans:
-	ScanEdges(*options.Options, map[promotion.Edge]interface{}) error
+	ScanEdges(*options.Options, map[promotion.Edge]any) error
 
 	// Methods for image signing and replication
 	PrewarmTUFCache() error
-	ValidateStagingSignatures(map[promotion.Edge]interface{}) (map[promotion.Edge]interface{}, error)
-	SignImages(*options.Options, map[promotion.Edge]interface{}) error
-	ReplicateSignatures(*options.Options, map[promotion.Edge]interface{}) error
-	WriteSBOMs(*options.Options, map[promotion.Edge]interface{}) error
-	WriteProvenanceAttestations(*options.Options, map[promotion.Edge]interface{}, provenance.Generator) error
+	ValidateStagingSignatures(map[promotion.Edge]any) (map[promotion.Edge]any, error)
+	SignImages(*options.Options, map[promotion.Edge]any) error
+	ReplicateSignatures(*options.Options, map[promotion.Edge]any) error
+	WriteSBOMs(*options.Options, map[promotion.Edge]any) error
+	WriteProvenanceAttestations(*options.Options, map[promotion.Edge]any, provenance.Generator) error
 
 	// Methods for checking signatures
 	GetLatestImages(*options.Options) ([]string, error)
@@ -147,7 +147,7 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 	// Shared state between pipeline phases, captured by closures.
 	var (
 		mfests         []schema.Manifest
-		promotionEdges map[promotion.Edge]interface{}
+		promotionEdges map[promotion.Edge]any
 	)
 
 	pipe := pipeline.New()
@@ -157,18 +157,22 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 		if err := p.impl.ValidateOptions(opts); err != nil {
 			return fmt.Errorf("validating options: %w", err)
 		}
+
 		if err := p.impl.ActivateServiceAccounts(opts); err != nil {
 			return fmt.Errorf("activating service accounts: %w", err)
 		}
+
 		if err := p.impl.PrewarmTUFCache(); err != nil {
 			return fmt.Errorf("prewarming TUF cache: %w", err)
 		}
+
 		return nil
 	}))
 
 	// Plan phase: parse manifests and compute edges.
 	pipe.AddPhase(pipeline.NewPhase("plan", func(_ context.Context) error {
 		var err error
+
 		mfests, err = p.impl.ParseManifests(opts)
 		if err != nil {
 			return fmt.Errorf("parsing manifests: %w", err)
@@ -183,8 +187,10 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 
 		if opts.ParseOnly {
 			logrus.Info("Manifests parsed, exiting as ParseOnly is set")
+
 			return pipeline.ErrStopPipeline
 		}
+
 		return nil
 	}))
 
@@ -192,6 +198,7 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 	pipe.AddPhase(pipeline.NewPhase("provenance", func(ctx context.Context) error {
 		if !opts.RequireProvenance {
 			logrus.Debug("Provenance verification disabled (--require-provenance=false)")
+
 			return nil
 		}
 
@@ -205,15 +212,18 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 			if ref == "" {
 				continue
 			}
+
 			result, err := verifier.Verify(ctx, ref)
 			if err != nil {
 				return fmt.Errorf("verifying provenance for %s: %w", ref, err)
 			}
+
 			if !result.Verified {
 				return fmt.Errorf("provenance verification failed for %s: %v",
 					ref, result.Errors)
 			}
 		}
+
 		return nil
 	}))
 
@@ -225,8 +235,10 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 
 		if !opts.Confirm {
 			logrus.Info("Dry run complete, exiting before promotion")
+
 			return pipeline.ErrStopPipeline
 		}
+
 		return nil
 	}))
 
@@ -242,6 +254,7 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 				logrus.WithError(err).Warn("Failed to rebalance rate limit budget")
 			}
 		}
+
 		return nil
 	}))
 
@@ -250,6 +263,7 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 		if err := p.impl.SignImages(opts, promotionEdges); err != nil {
 			return fmt.Errorf("signing images: %w", err)
 		}
+
 		return nil
 	}))
 
@@ -258,6 +272,7 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 		if err := p.impl.ReplicateSignatures(opts, promotionEdges); err != nil {
 			return fmt.Errorf("replicating signatures: %w", err)
 		}
+
 		return nil
 	}))
 
@@ -272,14 +287,19 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 				return fmt.Errorf("writing provenance attestations: %w", err)
 			}
 		}
+
 		return nil
 	}))
 
-	return pipe.Run(ctx)
+	if err := pipe.Run(ctx); err != nil {
+		return fmt.Errorf("running promotion pipeline: %w", err)
+	}
+
+	return nil
 }
 
 // Snapshot runs the steps to output a representation in json or yaml of a registry.
-func (p *Promoter) Snapshot(opts *options.Options) (err error) {
+func (p *Promoter) Snapshot(opts *options.Options) error {
 	if err := p.impl.ValidateOptions(opts); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
@@ -308,6 +328,7 @@ func (p *Promoter) Snapshot(opts *options.Options) (err error) {
 	if err := p.impl.Snapshot(opts, rii); err != nil {
 		return fmt.Errorf("generating snapshot: %w", err)
 	}
+
 	return nil
 }
 
@@ -339,29 +360,34 @@ func (p *Promoter) SecurityScan(opts *options.Options) error {
 	// TODO: Let's rethink this option
 	if opts.ParseOnly {
 		logrus.Info("Manifests parsed, exiting as ParseOnly is set")
+
 		return nil
 	}
 
 	if !opts.Confirm {
 		logrus.Info("Dry run complete, exiting before vulnerability scan")
+
 		return nil
 	}
 
 	if err := p.impl.ScanEdges(opts, promotionEdges); err != nil {
 		return fmt.Errorf("running vulnerability scan: %w", err)
 	}
+
 	return nil
 }
 
 // CheckSignatures checks the consistency of a set of images.
 func (p *Promoter) CheckSignatures(opts *options.Options) error {
 	logrus.Info("Fetching latest promoted images")
+
 	images, err := p.impl.GetLatestImages(opts)
 	if err != nil {
 		return fmt.Errorf("getting latest promoted images: %w", err)
 	}
 
 	logrus.Info("Checking signatures")
+
 	results, err := p.impl.GetSignatureStatus(opts, images)
 	if err != nil {
 		return fmt.Errorf("checking signature status in images: %w", err)
@@ -369,15 +395,18 @@ func (p *Promoter) CheckSignatures(opts *options.Options) error {
 
 	if results.TotalPartial() == 0 && results.TotalUnsigned() == 0 {
 		logrus.Info("Signature consistency OK!")
+
 		return nil
 	}
 
 	logrus.Infof("Fixing %d unsigned images", results.TotalUnsigned())
+
 	if err := p.impl.FixMissingSignatures(opts, results); err != nil {
 		return fmt.Errorf("fixing missing signatures: %w", err)
 	}
 
 	logrus.Infof("Fixing %d images with partial signatures", results.TotalPartial())
+
 	if err := p.impl.FixPartialSignatures(opts, results); err != nil {
 		return fmt.Errorf("fixing partial signatures: %w", err)
 	}
@@ -391,7 +420,7 @@ func (p *Promoter) CheckSignatures(opts *options.Options) error {
 // ALL edges from manifests (not just unsynced ones) so it can run
 // independently of the promotion job.
 func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Options) error {
-	var promotionEdges map[promotion.Edge]interface{}
+	var promotionEdges map[promotion.Edge]any
 
 	// Give the signing transport the full rate limit budget since
 	// standalone replication has no promotion or signing workload.
@@ -408,12 +437,15 @@ func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Option
 		if err := p.impl.ValidateOptions(opts); err != nil {
 			return fmt.Errorf("validating options: %w", err)
 		}
+
 		if err := p.impl.ActivateServiceAccounts(opts); err != nil {
 			return fmt.Errorf("activating service accounts: %w", err)
 		}
+
 		if err := p.impl.PrewarmTUFCache(); err != nil {
 			return fmt.Errorf("prewarming TUF cache: %w", err)
 		}
+
 		return nil
 	}))
 
@@ -433,8 +465,10 @@ func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Option
 
 		if !opts.Confirm {
 			logrus.Info("Dry run complete (use --confirm to replicate)")
+
 			return pipeline.ErrStopPipeline
 		}
+
 		return nil
 	}))
 
@@ -443,8 +477,13 @@ func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Option
 		if err := p.impl.ReplicateSignatures(opts, promotionEdges); err != nil {
 			return fmt.Errorf("replicating signatures: %w", err)
 		}
+
 		return nil
 	}))
 
-	return pipe.Run(ctx)
+	if err := pipe.Run(ctx); err != nil {
+		return fmt.Errorf("running replication pipeline: %w", err)
+	}
+
+	return nil
 }

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -35,6 +35,7 @@ import (
 func TestPromoteImages(t *testing.T) {
 	sut := imagepromoter.Promoter{}
 	testErr := errors.New("synthetic error")
+
 	for _, tc := range []struct {
 		shouldErr bool
 		msg       string
@@ -122,6 +123,7 @@ func TestPromoteImages(t *testing.T) {
 		mock := imagefakes.FakePromoterImplementation{}
 		tc.prepare(&mock)
 		sut.SetImplementation(&mock)
+
 		if tc.shouldErr {
 			require.Error(t, sut.PromoteImages(context.Background(), &options.Options{Confirm: true}), tc.msg)
 		} else {
@@ -208,7 +210,7 @@ func TestPromoteImagesProvenanceFails(t *testing.T) {
 	sut := imagepromoter.Promoter{}
 	mock := imagefakes.FakePromoterImplementation{}
 	// Return a non-empty edge set so provenance has something to check
-	mock.GetPromotionEdgesReturns(map[promotion.Edge]interface{}{
+	mock.GetPromotionEdgesReturns(map[promotion.Edge]any{
 		testEdge(): nil,
 	}, nil)
 	sut.SetImplementation(&mock)
@@ -231,7 +233,7 @@ func TestPromoteImagesProvenanceFails(t *testing.T) {
 func TestPromoteImagesProvenanceVerifierError(t *testing.T) {
 	sut := imagepromoter.Promoter{}
 	mock := imagefakes.FakePromoterImplementation{}
-	mock.GetPromotionEdgesReturns(map[promotion.Edge]interface{}{
+	mock.GetPromotionEdgesReturns(map[promotion.Edge]any{
 		testEdge(): nil,
 	}, nil)
 	sut.SetImplementation(&mock)
@@ -246,6 +248,7 @@ func TestPromoteImagesProvenanceVerifierError(t *testing.T) {
 
 func TestReplicateSignatures(t *testing.T) {
 	testErr := errors.New("synthetic error")
+
 	for _, tc := range []struct {
 		shouldErr bool
 		msg       string
@@ -304,6 +307,7 @@ func TestReplicateSignatures(t *testing.T) {
 			mock := imagefakes.FakePromoterImplementation{}
 			tc.prepare(&mock)
 			sut.SetImplementation(&mock)
+
 			err := sut.ReplicateSignatures(context.Background(), &options.Options{Confirm: true})
 			if tc.shouldErr {
 				require.Error(t, err, tc.msg)

--- a/promoter/image/promotion/edge.go
+++ b/promoter/image/promotion/edge.go
@@ -88,8 +88,9 @@ func ToPQIN(registryName image.Registry, imageName image.Name, tag image.Tag) st
 
 // ToEdges converts a list of manifests to a set of edges we want to
 // try promoting.
-func ToEdges(mfests []schema.Manifest) (map[Edge]interface{}, error) {
-	edges := make(map[Edge]interface{})
+func ToEdges(mfests []schema.Manifest) (map[Edge]any, error) {
+	edges := make(map[Edge]any)
+
 	for _, mfest := range mfests {
 		for _, img := range mfest.Images {
 			for digest, tagArray := range img.Dmap {
@@ -151,13 +152,15 @@ func mkEdge(
 // CheckOverlappingEdges checks for conflicting promotion edges (different
 // digests targeting the same destination tag).
 func CheckOverlappingEdges(
-	edges map[Edge]interface{},
-) (map[Edge]interface{}, error) {
+	edges map[Edge]any,
+) (map[Edge]any, error) {
 	promotionIntent := make(map[string]map[image.Digest][]Edge)
-	checked := make(map[Edge]interface{})
+	checked := make(map[Edge]any)
+
 	for edge := range edges {
 		if edge.DstImageTag.Tag == "" {
 			checked[edge] = nil
+
 			continue
 		}
 
@@ -180,32 +183,39 @@ func CheckOverlappingEdges(
 
 	overlapError := false
 	emptyEdgeListError := false
+
 	for pqin, digestToEdges := range promotionIntent {
 		if len(digestToEdges) < 2 {
 			for _, edgeList := range digestToEdges {
 				switch len(edgeList) {
 				case 0:
 					logrus.Errorf("no edges for %v", pqin)
+
 					emptyEdgeListError = true
 				case 1:
 					checked[edgeList[0]] = nil
 				default:
 					logrus.Infof("redundant promotion: multiple edges want to promote the same digest to the same destination endpoint %v:", pqin)
+
 					for i := range edgeList {
 						logrus.Infof("%v", edgeList[i])
 					}
+
 					logrus.Infof("using the first one: %v", edgeList[0])
 					checked[edgeList[0]] = nil
 				}
 			}
 		} else {
 			logrus.Errorf("multiple edges want to promote *different* images (digests) to the same destination endpoint %v:", pqin)
+
 			for digest, edgeList := range digestToEdges {
 				logrus.Errorf("  for digest %v:\n", digest)
+
 				for i := range edgeList {
 					logrus.Errorf("%v\n", edgeList[i])
 				}
 			}
+
 			overlapError = true
 		}
 	}
@@ -225,7 +235,7 @@ func CheckOverlappingEdges(
 // their information to a RegInvImage type. It uses only those edges that are
 // trying to promote to the given destination registry.
 func EdgesToRegInvImage(
-	edges map[Edge]interface{},
+	edges map[Edge]any,
 	destRegistry string,
 ) registry.RegInvImage {
 	rii := make(registry.RegInvImage)
@@ -238,10 +248,8 @@ func EdgesToRegInvImage(
 			prefix  string
 		)
 
-		if strings.HasPrefix(string(edge.DstRegistry.Name), destRegistry) {
-			prefix = strings.TrimPrefix(
-				string(edge.DstRegistry.Name),
-				destRegistry)
+		if after, ok := strings.CutPrefix(string(edge.DstRegistry.Name), destRegistry); ok {
+			prefix = after
 
 			if prefix != "" {
 				imgName = prefix + "/" + string(edge.DstImageTag.Name)
@@ -275,8 +283,8 @@ func EdgesToRegInvImage(
 // suffixes) from the edges. These are used by ReadRegistries to correctly
 // key the inventory so that vertexPropsFor can look up digests by the
 // original registry name from the edge.
-func GetBaseRegistries(edges map[Edge]interface{}) []registry.Context {
-	rcs := make(map[registry.Context]interface{})
+func GetBaseRegistries(edges map[Edge]any) []registry.Context {
+	rcs := make(map[registry.Context]any)
 
 	for edge := range edges {
 		rcs[edge.SrcRegistry] = nil
@@ -294,8 +302,8 @@ func GetBaseRegistries(edges map[Edge]interface{}) []registry.Context {
 // GetRegistriesToRead collects all unique Docker repositories we want to read
 // from. This way, we don't have to read the entire Docker registry, but only
 // those paths that we are thinking of modifying.
-func GetRegistriesToRead(edges map[Edge]interface{}) []registry.Context {
-	rcs := make(map[registry.Context]interface{})
+func GetRegistriesToRead(edges map[Edge]any) []registry.Context {
+	rcs := make(map[registry.Context]any)
 
 	for edge := range edges {
 		srcReg := edge.SrcRegistry
@@ -323,6 +331,7 @@ func GetRegistriesToRead(edges map[Edge]interface{}) []registry.Context {
 // have the given tag.
 func FilterByTag(rii registry.RegInvImage, tag string) registry.RegInvImage {
 	filtered := make(registry.RegInvImage)
+
 	for imgName, digestTags := range rii {
 		for digest, tagSlice := range digestTags {
 			for _, t := range tagSlice {
@@ -330,12 +339,15 @@ func FilterByTag(rii registry.RegInvImage, tag string) registry.RegInvImage {
 					if filtered[imgName] == nil {
 						filtered[imgName] = make(registry.DigestTags)
 					}
+
 					filtered[imgName][digest] = tagSlice
+
 					break
 				}
 			}
 		}
 	}
+
 	return filtered
 }
 
@@ -358,7 +370,7 @@ type VertexProperty struct {
 // edge, depending on the state of the world in the inventory.
 func (edge *Edge) VertexProps(
 	inv map[image.Registry]registry.RegInvImage,
-) (srcProps, dstProps VertexProperty) {
+) (VertexProperty, VertexProperty) {
 	return edge.vertexPropsFor(&edge.SrcRegistry, &edge.SrcImageTag, inv),
 		edge.vertexPropsFor(&edge.DstRegistry, &edge.DstImageTag, inv)
 }
@@ -375,6 +387,7 @@ func (edge *Edge) vertexPropsFor(
 	if !ok {
 		return p
 	}
+
 	digestTags, ok := rii[imageTag.Name]
 	if !ok {
 		return p
@@ -405,18 +418,20 @@ func (edge *Edge) vertexPropsFor(
 // GetPromotionCandidates filters edges to only those that need promotion,
 // removing already-promoted edges and detecting errors like tag moves.
 func GetPromotionCandidates(
-	edges map[Edge]interface{},
+	edges map[Edge]any,
 	inv map[image.Registry]registry.RegInvImage,
-) (map[Edge]interface{}, bool) {
+) (map[Edge]any, bool) {
 	clean := true
 
-	toPromote := make(map[Edge]interface{})
+	toPromote := make(map[Edge]any)
+
 	for edge := range edges {
 		sp, dp := edge.VertexProps(inv)
 
 		// If dst vertex already matches, NOP.
 		if dp.PqinDigestMatch {
 			logrus.Debugf("edge %v: skipping because it was already promoted (case 1)", edge)
+
 			continue
 		}
 
@@ -427,6 +442,7 @@ func GetPromotionCandidates(
 				logrus.Errorf("edge %v: skipping %s/%s@%s because it was already promoted, but it is still _LOST_ (can't find it in src registry! please backfill it!)",
 					edge, edge.SrcRegistry.Name, edge.SrcImageTag.Name, edge.Digest)
 			}
+
 			continue
 		}
 
@@ -434,6 +450,7 @@ func GetPromotionCandidates(
 		if !sp.DigestExists {
 			logrus.Errorf("edge %v: skipping %s/%s@%s because it is _LOST_ (can't find it in src registry!)",
 				edge, edge.SrcRegistry.Name, edge.SrcImageTag.Name, edge.Digest)
+
 			continue
 		}
 
@@ -442,19 +459,24 @@ func GetPromotionCandidates(
 				if dp.PqinDigestMatch {
 					// NOP (already promoted).
 					logrus.Debugf("edge %v: skipping because it was already promoted (case 2)", edge)
+
 					continue
 				}
 				// Tag exists pointing to a different digest, and the target
 				// digest also exists separately — this is an error.
 				logrus.Errorf("edge %v: tag %s: tag move detected", edge, edge.DstImageTag.Tag)
+
 				clean = false
+
 				continue
 			}
 			// Tag exists pointing to wrong digest, target digest doesn't
 			// exist — tag move attempt, which is not supported.
 			logrus.Errorf("edge %v: tag '%s' in dest points to %s, not %s; tag moves are not supported",
 				edge, edge.DstImageTag.Tag, dp.BadDigest, edge.Digest)
+
 			clean = false
+
 			continue
 		}
 

--- a/promoter/image/promotion/edge_test.go
+++ b/promoter/image/promotion/edge_test.go
@@ -134,7 +134,7 @@ func TestToEdgesTagless(t *testing.T) {
 }
 
 func TestCheckOverlappingEdgesClean(t *testing.T) {
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
 			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
@@ -150,7 +150,7 @@ func TestCheckOverlappingEdgesClean(t *testing.T) {
 
 func TestCheckOverlappingEdgesConflict(t *testing.T) {
 	// Two different digests targeting the same destination tag.
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
 			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
@@ -172,7 +172,7 @@ func TestCheckOverlappingEdgesConflict(t *testing.T) {
 }
 
 func TestGetPromotionCandidates(t *testing.T) {
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
 			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
@@ -217,7 +217,7 @@ func TestGetPromotionCandidatesTagMove(t *testing.T) {
 		DstRegistry: testDstRC1,
 		DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
 	}
-	edges := map[Edge]interface{}{edge: nil}
+	edges := map[Edge]any{edge: nil}
 
 	// Tag "v1" in dst points to a different digest — tag move.
 	inv := map[image.Registry]registry.RegInvImage{
@@ -282,7 +282,7 @@ func TestVertexPropsNotPromoted(t *testing.T) {
 }
 
 func TestEdgesToRegInvImage(t *testing.T) {
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			DstRegistry: testDstRC1,
 			DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
@@ -333,7 +333,7 @@ func TestFilterByTagNoMatch(t *testing.T) {
 }
 
 func TestGetRegistriesToRead(t *testing.T) {
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
 			SrcImageTag: ImageTag{Name: "foo"},
@@ -349,12 +349,13 @@ func TestGetRegistriesToRead(t *testing.T) {
 	for _, rc := range rcs {
 		names[rc.Name] = true
 	}
+
 	require.True(t, names["gcr.io/staging/foo"])
 	require.True(t, names["us.gcr.io/prod/foo"])
 }
 
 func TestGetBaseRegistries(t *testing.T) {
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
 			SrcImageTag: ImageTag{Name: "foo"},
@@ -394,7 +395,7 @@ func TestGetPromotionCandidatesWithBaseRegistries(t *testing.T) {
 		Name: "us-docker.pkg.dev/k8s-artifacts-prod/images/foo",
 	}
 
-	edges := map[Edge]interface{}{
+	edges := map[Edge]any{
 		{
 			SrcRegistry: srcReg,
 			SrcImageTag: ImageTag{Name: "myimage", Tag: "v1.0"},

--- a/promoter/image/provenance/cosign.go
+++ b/promoter/image/provenance/cosign.go
@@ -85,13 +85,17 @@ func (v *CosignVerifier) Verify(ctx context.Context, ref string) (*Result, error
 			result.Verified = false
 			result.Errors = append(result.Errors,
 				"no attestation found for "+ref)
+
 			return result, nil
 		}
+
 		return nil, fmt.Errorf("checking attestation for %s: %w", ref, err)
 	}
 
 	result.Verified = true
+
 	logrus.Debugf("Attestation found for %s", ref)
+
 	return result, nil
 }
 

--- a/promoter/image/provenance/promotion.go
+++ b/promoter/image/provenance/promotion.go
@@ -72,6 +72,7 @@ func (g *PromotionGenerator) Generate(_ context.Context, record *PromotionRecord
 	if err != nil {
 		return nil, fmt.Errorf("marshaling provenance statement: %w", err)
 	}
+
 	return data, nil
 }
 
@@ -82,7 +83,7 @@ func trimDigestPrefix(digest string) string {
 
 // intotoStatement is a minimal in-toto v1 statement.
 type intotoStatement struct {
-	Type          string        `json:"_type"`
+	Type          string        `json:"_type"` //nolint:tagliatelle // in-toto spec field
 	PredicateType string        `json:"predicateType"`
 	Subject       []subject     `json:"subject"`
 	Predicate     slsaPredicate `json:"predicate"`

--- a/promoter/image/provenance/provenance_test.go
+++ b/promoter/image/provenance/provenance_test.go
@@ -25,10 +25,12 @@ import (
 
 func TestNoopVerifier(t *testing.T) {
 	v := &NoopVerifier{}
+
 	result, err := v.Verify(context.Background(), "gcr.io/test/image@sha256:abc")
 	if err != nil {
 		t.Fatalf("Verify() error = %v", err)
 	}
+
 	if !result.Verified {
 		t.Error("NoopVerifier should always return Verified=true")
 	}

--- a/promoter/image/ratelimit/budget.go
+++ b/promoter/image/ratelimit/budget.go
@@ -81,6 +81,7 @@ func (b *BudgetAllocator) Get(name string) (*RoundTripper, error) {
 	if !ok {
 		return nil, fmt.Errorf("no rate limiter allocated with name %q", name)
 	}
+
 	return alloc.limiter, nil
 }
 
@@ -95,6 +96,7 @@ func (b *BudgetAllocator) Rebalance(from, to string, fraction float64) error {
 	if !ok {
 		return fmt.Errorf("source allocation %q not found", from)
 	}
+
 	toAlloc, ok := b.allocations[to]
 	if !ok {
 		return fmt.Errorf("destination allocation %q not found", to)
@@ -104,6 +106,7 @@ func (b *BudgetAllocator) Rebalance(from, to string, fraction float64) error {
 	if fromAlloc.fraction < 0 {
 		fromAlloc.fraction = 0
 	}
+
 	toAlloc.fraction += fraction
 
 	fromAlloc.limiter.SetLimit(rate.Limit(float64(b.total) * fromAlloc.fraction))
@@ -159,6 +162,7 @@ func (b *BudgetAllocator) Stats() map[string]struct {
 		Requests int64
 		Waited   string
 	})
+
 	for name, alloc := range b.allocations {
 		reqs, waited := alloc.limiter.Stats()
 		stats[name] = struct {
@@ -166,5 +170,6 @@ func (b *BudgetAllocator) Stats() map[string]struct {
 			Waited   string
 		}{reqs, waited.String()}
 	}
+
 	return stats
 }

--- a/promoter/image/ratelimit/budget_test.go
+++ b/promoter/image/ratelimit/budget_test.go
@@ -40,6 +40,7 @@ func TestBudgetAllocatorAllocate(t *testing.T) {
 	if math.Abs(float64(promoLimit)-70.0) > 0.1 {
 		t.Errorf("expected promotion limit ~70, got %v", promoLimit)
 	}
+
 	if math.Abs(float64(signLimit)-30.0) > 0.1 {
 		t.Errorf("expected signing limit ~30, got %v", signLimit)
 	}
@@ -53,6 +54,7 @@ func TestBudgetAllocatorGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
+
 	if rt.Name() != "test" {
 		t.Errorf("expected name 'test', got %q", rt.Name())
 	}
@@ -79,6 +81,7 @@ func TestBudgetAllocatorRebalance(t *testing.T) {
 	if math.Abs(float64(promoLimit)-50.0) > 0.1 {
 		t.Errorf("after rebalance, expected promotion limit ~50, got %v", promoLimit)
 	}
+
 	if math.Abs(float64(signLimit)-50.0) > 0.1 {
 		t.Errorf("after rebalance, expected signing limit ~50, got %v", signLimit)
 	}
@@ -91,6 +94,7 @@ func TestBudgetAllocatorRebalanceErrors(t *testing.T) {
 	if err := ba.Rebalance("nonexistent", "a", 0.1); err == nil {
 		t.Error("expected error for nonexistent source")
 	}
+
 	if err := ba.Rebalance("a", "nonexistent", 0.1); err == nil {
 		t.Error("expected error for nonexistent destination")
 	}
@@ -111,6 +115,7 @@ func TestBudgetAllocatorGiveAll(t *testing.T) {
 	if promoLimit != rate.Limit(0) {
 		t.Errorf("expected promotion limit 0 after GiveAll, got %v", promoLimit)
 	}
+
 	if math.Abs(float64(signLimit)-100.0) > 0.1 {
 		t.Errorf("expected signing limit ~100 after GiveAll, got %v", signLimit)
 	}
@@ -137,6 +142,7 @@ func TestBudgetAllocatorRebalanceClampToZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
+
 	if a.rateLimiter.Limit() != 0 {
 		t.Errorf("expected clamped limit 0, got %v", a.rateLimiter.Limit())
 	}
@@ -151,9 +157,11 @@ func TestBudgetAllocatorStats(t *testing.T) {
 	if len(stats) != 2 {
 		t.Errorf("expected 2 stats entries, got %d", len(stats))
 	}
+
 	if _, ok := stats["a"]; !ok {
 		t.Error("expected stats for 'a'")
 	}
+
 	if _, ok := stats["b"]; !ok {
 		t.Error("expected stats for 'b'")
 	}

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -18,6 +18,7 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -88,7 +89,7 @@ func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	// Wait for rate limiter token.
 	if err := rt.rateLimiter.Wait(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("waiting for rate limiter: %w", err)
 	}
 
 	rt.mu.Lock()
@@ -97,7 +98,7 @@ func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	resp, err := rt.roundTripper.RoundTrip(r)
 	if err != nil {
-		return resp, err
+		return resp, fmt.Errorf("round trip: %w", err)
 	}
 
 	// Adaptive backoff: if we get a 429, temporarily pause all requests
@@ -124,9 +125,10 @@ func (rt *RoundTripper) SetBurst(newBurst int) {
 }
 
 // Stats returns observability data about this rate limiter.
-func (rt *RoundTripper) Stats() (totalRequests int64, totalWaited time.Duration) {
+func (rt *RoundTripper) Stats() (int64, time.Duration) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+
 	return rt.totalRequests, rt.totalWaited
 }
 

--- a/promoter/image/ratelimit/roundtripper_test.go
+++ b/promoter/image/ratelimit/roundtripper_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ratelimit
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -31,6 +32,7 @@ func TestNewRoundTripper(t *testing.T) {
 	if rt == nil {
 		t.Fatal("NewRoundTripper returned nil")
 	}
+
 	if rt.name != "default" {
 		t.Errorf("expected name 'default', got %q", rt.name)
 	}
@@ -46,6 +48,7 @@ func TestNewNamedRoundTripper(t *testing.T) {
 func TestRoundTripRateLimitsAllMethods(t *testing.T) {
 	// Verify that all HTTP methods are rate-limited, not just GET/HEAD.
 	var requestCount atomic.Int64
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
 		w.WriteHeader(http.StatusOK)
@@ -58,14 +61,16 @@ func TestRoundTripRateLimitsAllMethods(t *testing.T) {
 
 	methods := []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost, http.MethodPatch}
 	for _, method := range methods {
-		req, err := http.NewRequest(method, server.URL, http.NoBody)
+		req, err := http.NewRequestWithContext(context.Background(), method, server.URL, http.NoBody)
 		if err != nil {
 			t.Fatalf("creating %s request: %v", method, err)
 		}
-		resp, err := client.Do(req)
+
+		resp, err := client.Do(req) //nolint:gosec // httptest URL
 		if err != nil {
 			t.Fatalf("%s request failed: %v", method, err)
 		}
+
 		resp.Body.Close()
 	}
 
@@ -76,12 +81,15 @@ func TestRoundTripRateLimitsAllMethods(t *testing.T) {
 
 func TestAdaptiveBackoffOn429(t *testing.T) {
 	callCount := 0
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if callCount == 1 {
 			w.WriteHeader(http.StatusTooManyRequests)
+
 			return
 		}
+
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -91,15 +99,18 @@ func TestAdaptiveBackoffOn429(t *testing.T) {
 	client := &http.Client{Transport: rt}
 
 	// First request triggers 429 and backoff.
-	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
 	if err != nil {
 		t.Fatalf("creating request: %v", err)
 	}
-	resp, reqErr := client.Do(req)
+
+	resp, reqErr := client.Do(req) //nolint:gosec // httptest URL
 	if reqErr != nil {
 		t.Fatalf("first request failed: %v", reqErr)
 	}
+
 	resp.Body.Close()
+
 	if resp.StatusCode != http.StatusTooManyRequests {
 		t.Errorf("expected 429, got %d", resp.StatusCode)
 	}
@@ -108,6 +119,7 @@ func TestAdaptiveBackoffOn429(t *testing.T) {
 	rt.mu.Lock()
 	hasBackoff := !rt.backoffUntil.IsZero()
 	rt.mu.Unlock()
+
 	if !hasBackoff {
 		t.Error("expected backoff to be triggered after 429")
 	}
@@ -123,14 +135,16 @@ func TestStatsTracking(t *testing.T) {
 	client := &http.Client{Transport: rt}
 
 	for range 5 {
-		req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
 		if err != nil {
 			t.Fatalf("creating request: %v", err)
 		}
-		resp, err := client.Do(req)
+
+		resp, err := client.Do(req) //nolint:gosec // httptest URL
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
 		}
+
 		resp.Body.Close()
 	}
 
@@ -184,12 +198,13 @@ func TestWaitForBackoffRespectsContext(t *testing.T) {
 	defer server.Close()
 
 	// Use a context with a short timeout.
-	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
 	if err != nil {
 		t.Fatalf("creating request: %v", err)
 	}
 
 	done := make(chan struct{})
+
 	go func() {
 		rt.waitForBackoff(req.Context())
 		close(done)

--- a/promoter/image/registry/context.go
+++ b/promoter/image/registry/context.go
@@ -26,7 +26,7 @@ import (
 // manifest file.
 type Context struct {
 	Name           image.Registry `yaml:"name,omitempty"`
-	ServiceAccount string         `yaml:"service-account,omitempty"`
+	ServiceAccount string         `yaml:"service-account,omitempty"` //nolint:tagliatelle // API field
 	Token          string         `yaml:"-"`
 	Src            bool           `yaml:"src,omitempty"`
 }

--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -61,6 +61,7 @@ func NewCraneProvider(opts ...CraneOption) *CraneProvider {
 	for _, o := range opts {
 		o(p)
 	}
+
 	return p
 }
 
@@ -76,6 +77,7 @@ func (p *CraneProvider) ReadRegistries(
 	logrus.Infof("Reading %d registries (recursive: %v)", len(registries), recurse)
 
 	inv := NewInventory()
+
 	var mu sync.Mutex
 
 	// Use base registries for splitting repo paths into registry+image
@@ -86,6 +88,7 @@ func (p *CraneProvider) ReadRegistries(
 	}
 
 	total := len(registries)
+
 	var completed atomic.Int64
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -102,6 +105,7 @@ func (p *CraneProvider) ReadRegistries(
 				ggcrV1Google.WithAuthFromKeychain(gcrane.Keychain),
 				ggcrV1Google.WithContext(gctx),
 			}
+
 			recordTags := makeTagRecorder(inv, &mu, splitRegs)
 
 			if recurse {
@@ -113,19 +117,22 @@ func (p *CraneProvider) ReadRegistries(
 				if err != nil {
 					return fmt.Errorf("listing repo %s: %w", r.Name, err)
 				}
+
 				if err := recordTags(repo, tags, nil); err != nil {
 					return fmt.Errorf("recording tags for %s: %w", r.Name, err)
 				}
 			}
 
 			logrus.Infof("Read registry %d/%d: %s", completed.Add(1), total, r.Name)
+
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading registries: %w", err)
 	}
+
 	return inv, nil
 }
 
@@ -138,7 +145,12 @@ func (p *CraneProvider) CopyImage(_ context.Context, src, dst string) error {
 	if p.transport != nil {
 		opts = append(opts, crane.WithTransport(p.transport))
 	}
-	return crane.Copy(src, dst, opts...)
+
+	if err := crane.Copy(src, dst, opts...); err != nil {
+		return fmt.Errorf("copying image %s to %s: %w", src, dst, err)
+	}
+
+	return nil
 }
 
 // makeTagRecorder creates a callback function for google.Walk that records
@@ -161,12 +173,14 @@ func makeTagRecorder(
 		logrus.Debugf("Registry: %s Image: %s Got: %s", regName, imageName, repo.Name())
 
 		digestTags := make(DigestTags)
+
 		if tags != nil && tags.Manifests != nil {
 			for digest, manifest := range tags.Manifests {
 				tagSlice := TagSlice{}
 				for _, tag := range manifest.Tags {
 					tagSlice = append(tagSlice, image.Tag(tag))
 				}
+
 				digestTags[image.Digest(digest)] = tagSlice
 
 				mediaType, err := supportedMediaType(manifest.MediaType)
@@ -186,6 +200,7 @@ func makeTagRecorder(
 		if _, ok := inv.Images[regName]; !ok {
 			inv.Images[regName] = make(RegInvImage)
 		}
+
 		if len(digestTags) > 0 {
 			inv.Images[regName][imageName] = digestTags
 		}
@@ -202,14 +217,17 @@ func splitByKnownRegistries(
 ) (image.Registry, image.Name, error) {
 	for _, r := range registries {
 		rn := string(r.Name)
+
 		fn := string(fullName)
 		if len(fn) > len(rn) && fn[:len(rn)] == rn && fn[len(rn)] == '/' {
 			return r.Name, image.Name(fn[len(rn)+1:]), nil
 		}
+
 		if fn == rn {
 			return r.Name, "", nil
 		}
 	}
+
 	return "", "", fmt.Errorf("could not determine registry for %s", fullName)
 }
 
@@ -232,6 +250,7 @@ func supportedMediaType(mediaType string) (cr.MediaType, error) {
 		if mediaType == "" {
 			return cr.DockerManifestSchema2, nil
 		}
+
 		return cr.MediaType(mediaType),
 			fmt.Errorf("unsupported media type %q", mediaType)
 	}

--- a/promoter/image/registry/fake.go
+++ b/promoter/image/registry/fake.go
@@ -64,9 +64,11 @@ func (f *FakeProvider) AddImage(
 	if _, ok := f.Inventory.Images[reg]; !ok {
 		f.Inventory.Images[reg] = make(RegInvImage)
 	}
+
 	if _, ok := f.Inventory.Images[reg][name]; !ok {
 		f.Inventory.Images[reg][name] = make(DigestTags)
 	}
+
 	f.Inventory.Images[reg][name][digest] = tags
 }
 
@@ -77,6 +79,7 @@ func (f *FakeProvider) ReadRegistries(
 	if f.ReadRegistriesErr != nil {
 		return nil, f.ReadRegistriesErr
 	}
+
 	return f.Inventory, nil
 }
 
@@ -89,5 +92,6 @@ func (f *FakeProvider) CopyImage(_ context.Context, src, dst string) error {
 	if f.CopyImageErr != nil {
 		return fmt.Errorf("fake copy error: %w", f.CopyImageErr)
 	}
+
 	return nil
 }

--- a/promoter/image/registry/provider.go
+++ b/promoter/image/registry/provider.go
@@ -69,6 +69,7 @@ func RegistryConfigsFromContexts(rcs []Context) []RegistryConfig {
 	for i, rc := range rcs {
 		configs[i] = RegistryConfigFromContext(rc)
 	}
+
 	return configs
 }
 

--- a/promoter/image/registry/provider_test.go
+++ b/promoter/image/registry/provider_test.go
@@ -36,9 +36,11 @@ func TestRegistryConfigFromContext(t *testing.T) {
 	if config.Name != rc.Name {
 		t.Errorf("Name = %q, want %q", config.Name, rc.Name)
 	}
+
 	if config.ServiceAccount != rc.ServiceAccount {
 		t.Errorf("ServiceAccount = %q, want %q", config.ServiceAccount, rc.ServiceAccount)
 	}
+
 	if config.Src != rc.Src {
 		t.Errorf("Src = %v, want %v", config.Src, rc.Src)
 	}
@@ -55,12 +57,15 @@ func TestRegistryConfigsFromContexts(t *testing.T) {
 	if len(configs) != 2 {
 		t.Fatalf("len(configs) = %d, want 2", len(configs))
 	}
+
 	if configs[0].Name != "gcr.io/staging" {
 		t.Errorf("configs[0].Name = %q, want %q", configs[0].Name, "gcr.io/staging")
 	}
+
 	if !configs[0].Src {
 		t.Error("configs[0].Src = false, want true")
 	}
+
 	if configs[1].Name != "us-docker.pkg.dev/prod/images" {
 		t.Errorf("configs[1].Name = %q", configs[1].Name)
 	}
@@ -72,6 +77,7 @@ func TestNewInventory(t *testing.T) {
 	if inv.Images == nil {
 		t.Error("Images map is nil")
 	}
+
 	if inv.MediaTypes == nil {
 		t.Error("MediaTypes map is nil")
 	}
@@ -90,9 +96,11 @@ func TestFakeProviderAddImage(t *testing.T) {
 	if _, ok := f.Inventory.Images[reg]; !ok {
 		t.Fatal("registry not found in inventory")
 	}
+
 	if _, ok := f.Inventory.Images[reg][name]; !ok {
 		t.Fatal("image not found in inventory")
 	}
+
 	storedTags := f.Inventory.Images[reg][name][digest]
 	if len(storedTags) != 2 {
 		t.Fatalf("len(tags) = %d, want 2", len(storedTags))
@@ -107,6 +115,7 @@ func TestFakeProviderReadRegistries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadRegistries() error = %v", err)
 	}
+
 	if len(inv.Images) != 1 {
 		t.Errorf("len(Images) = %d, want 1", len(inv.Images))
 	}
@@ -129,9 +138,11 @@ func TestFakeProviderCopyImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CopyImage() error = %v", err)
 	}
+
 	if len(f.CopiedImages) != 1 {
 		t.Fatalf("len(CopiedImages) = %d, want 1", len(f.CopiedImages))
 	}
+
 	if f.CopiedImages[0].Src != "src:tag" || f.CopiedImages[0].Dst != "dst:tag" {
 		t.Errorf("CopiedImages[0] = %+v", f.CopiedImages[0])
 	}
@@ -187,14 +198,18 @@ func TestSplitByKnownRegistries(t *testing.T) {
 				if err == nil {
 					t.Error("expected error")
 				}
+
 				return
 			}
+
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+
 			if reg != tt.wantReg {
 				t.Errorf("reg = %q, want %q", reg, tt.wantReg)
 			}
+
 			if img != tt.wantImg {
 				t.Errorf("img = %q, want %q", img, tt.wantImg)
 			}
@@ -223,6 +238,7 @@ func TestSupportedMediaType(t *testing.T) {
 			if tt.expectErr && err == nil {
 				t.Error("expected error")
 			}
+
 			if !tt.expectErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/promoter/image/registry/set.go
+++ b/promoter/image/registry/set.go
@@ -29,6 +29,7 @@ func (a TagSlice) ToTagSet() TagSet {
 	for _, tag := range a {
 		s[tag] = struct{}{}
 	}
+
 	return s
 }
 
@@ -37,11 +38,13 @@ func (a TagSlice) Minus(b TagSlice) TagSet {
 	aSet := a.ToTagSet()
 	bSet := b.ToTagSet()
 	result := make(TagSet)
+
 	for k := range aSet {
 		if _, ok := bSet[k]; !ok {
 			result[k] = struct{}{}
 		}
 	}
+
 	return result
 }
 
@@ -51,9 +54,11 @@ func (a TagSlice) Union(b TagSlice) TagSet {
 	for _, tag := range a {
 		result[tag] = struct{}{}
 	}
+
 	for _, tag := range b {
 		result[tag] = struct{}{}
 	}
+
 	return result
 }
 
@@ -62,10 +67,12 @@ func (a TagSlice) Intersection(b TagSlice) TagSet {
 	aSet := a.ToTagSet()
 	bSet := b.ToTagSet()
 	result := make(TagSet)
+
 	for k := range aSet {
 		if _, ok := bSet[k]; ok {
 			result[k] = struct{}{}
 		}
 	}
+
 	return result
 }

--- a/promoter/image/registry/types.go
+++ b/promoter/image/registry/types.go
@@ -63,6 +63,7 @@ func (a *RegInvImage) ToYAML(o YamlMarshalingOpts) string {
 	for _, image := range images {
 		fmt.Fprintf(&b, "- name: %s\n", image.Name)
 		fmt.Fprintf(&b, "  dmap:\n")
+
 		for _, digestEntry := range image.Digests {
 			if o.BareDigest {
 				fmt.Fprintf(&b, "    %s:", digestEntry.Hash)
@@ -76,11 +77,13 @@ func (a *RegInvImage) ToYAML(o YamlMarshalingOpts) string {
 			default:
 				if o.SplitTagsOverMultipleLines {
 					fmt.Fprintf(&b, "\n")
+
 					for _, tag := range digestEntry.Tags {
 						fmt.Fprintf(&b, "    - %s\n", tag)
 					}
 				} else {
 					fmt.Fprintf(&b, " [")
+
 					for i, tag := range digestEntry.Tags {
 						if i == len(digestEntry.Tags)-1 {
 							fmt.Fprintf(&b, "%q", tag)
@@ -88,6 +91,7 @@ func (a *RegInvImage) ToYAML(o YamlMarshalingOpts) string {
 							fmt.Fprintf(&b, "%q, ", tag)
 						}
 					}
+
 					fmt.Fprintf(&b, "]\n")
 				}
 			}
@@ -109,6 +113,7 @@ func (a *RegInvImage) ToCSV() string {
 	images := a.ToSorted()
 
 	var b strings.Builder
+
 	for _, image := range images {
 		for _, digestEntry := range image.Digests {
 			if len(digestEntry.Tags) > 0 {
@@ -147,6 +152,7 @@ func (a *RegInvImage) ToSorted() []ImageWithDigestSlice {
 				Tags: tags,
 			})
 		}
+
 		sort.Slice(digests, func(i, j int) bool {
 			return digests[i].Hash < digests[j].Hash
 		})

--- a/promoter/image/schema/manifest.go
+++ b/promoter/image/schema/manifest.go
@@ -105,14 +105,15 @@ const (
 
 // Validate checks for semantic errors in the yaml fields (the structure of the
 // yaml is checked during unmarshaling).
-func (m Manifest) Validate() error {
+func (m *Manifest) Validate() error {
 	if err := validateRequiredComponents(m); err != nil {
 		return err
 	}
+
 	return validateImages(m.Images)
 }
 
-func validateRequiredComponents(m Manifest) error {
+func validateRequiredComponents(m *Manifest) error {
 	// TODO: Should we return []error here instead?
 	errs := make([]string, 0)
 
@@ -162,27 +163,6 @@ func validateRequiredComponents(m Manifest) error {
 	return errors.New(strings.Join(errs, "\n"))
 }
 
-func (m Manifest) srcRegistryCount() int {
-	var count int
-	for _, registry := range m.Registries {
-		if registry.Src {
-			count++
-		}
-	}
-
-	return count
-}
-
-func (m Manifest) srcRegistryName() image.Registry {
-	for _, registry := range m.Registries {
-		if registry.Src {
-			return registry.Name
-		}
-	}
-
-	return image.Registry("")
-}
-
 func validateImages(images []registry.Image) error {
 	for _, image := range images {
 		for digest, tagSlice := range image.Dmap {
@@ -197,6 +177,7 @@ func validateImages(images []registry.Image) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -225,8 +206,9 @@ func (m *Manifest) Finalize() error {
 	// Perform semantic checks (beyond just YAML validation).
 	srcRegistry, err := registry.GetSrcRegistry(m.Registries)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting source registry: %w", err)
 	}
+
 	m.SrcRegistry = srcRegistry
 
 	return nil
@@ -238,7 +220,30 @@ func (m *Manifest) ToRegInvImage() registry.RegInvImage {
 	for _, img := range m.Images {
 		rii[img.Name] = img.Dmap
 	}
+
 	return rii
+}
+
+func (m *Manifest) srcRegistryCount() int {
+	var count int
+
+	for _, registry := range m.Registries {
+		if registry.Src {
+			count++
+		}
+	}
+
+	return count
+}
+
+func (m *Manifest) srcRegistryName() image.Registry {
+	for _, registry := range m.Registries {
+		if registry.Src {
+			return registry.Name
+		}
+	}
+
+	return image.Registry("")
 }
 
 // Parsers
@@ -248,9 +253,14 @@ func (m *Manifest) ToRegInvImage() registry.RegInvImage {
 // registry (there can only be 1 source registry).
 func ParseThinManifestsFromDir(
 	dir string, onlyProwDiff bool,
-) (mfests []Manifest, err error) {
+) ([]Manifest, error) {
+	var mfests []Manifest
+
 	digestsToCheck := []string{}
+
 	if onlyProwDiff {
+		var err error
+
 		digestsToCheck, err = diffProwFiles(dir)
 		if err != nil {
 			return nil, fmt.Errorf("get prow diff files: %w", err)
@@ -290,6 +300,7 @@ func ParseThinManifestsFromDir(
 		// inside a subfolder within "manifests/<dir>" --- any other paths are
 		// forbidden.
 		shortened := strings.TrimPrefix(path, dir)
+
 		shortenedList := strings.Split(shortened, "/")
 		if len(shortenedList) != ThinManifestDepth {
 			return fmt.Errorf("unexpected manifest path %q",
@@ -299,6 +310,7 @@ func ParseThinManifestsFromDir(
 		mfest, errParse := ParseThinManifestFromFile(path, digestsToCheck)
 		if errParse != nil {
 			logrus.Errorf("could not parse manifest file '%s'\n", path)
+
 			return errParse
 		}
 
@@ -311,7 +323,7 @@ func ParseThinManifestsFromDir(
 	// Only look at manifests starting with the "manifests" subfolder (no need
 	// to walk any other toplevel subfolder).
 	if err := filepath.Walk(filepath.Join(dir, "manifests"), parseAsManifest); err != nil {
-		return mfests, err
+		return mfests, fmt.Errorf("walking manifests directory: %w", err)
 	}
 
 	if len(mfests) == 0 {
@@ -323,8 +335,9 @@ func ParseThinManifestsFromDir(
 
 var digestRe = regexp.MustCompile(`"(sha256:[0-9a-f]{64})"`)
 
-func diffProwFiles(dir string) (digests []string, err error) {
+func diffProwFiles(dir string) ([]string, error) {
 	logrus.Info("Using prow diff")
+
 	const (
 		git               = "git"
 		pullBaseSHAEnv    = "PULL_BASE_SHA"
@@ -340,12 +353,14 @@ func diffProwFiles(dir string) (digests []string, err error) {
 	}
 
 	var base string
+
 	switch jobType {
 	case jobTypePresubmit, jobTypeBatch:
 		pullBaseSHA := os.Getenv(pullBaseSHAEnv)
 		if pullBaseSHA == "" {
 			return nil, fmt.Errorf("%s not set", pullBaseSHAEnv)
 		}
+
 		base = pullBaseSHA
 	case jobTypePostsubmit:
 		base = "HEAD^"
@@ -359,6 +374,7 @@ func diffProwFiles(dir string) (digests []string, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("running git rev-parse: %w", err)
 	}
+
 	workdir := workdirRes.OutputTrimNL()
 
 	diff, err := command.NewWithWorkDir(
@@ -369,26 +385,32 @@ func diffProwFiles(dir string) (digests []string, err error) {
 	}
 
 	// Normalize the digests
-	for _, line := range strings.Split(diff.OutputTrimNL(), "\n") {
+	var digests []string
+
+	for line := range strings.SplitSeq(diff.OutputTrimNL(), "\n") {
 		matches := digestRe.FindAllStringSubmatch(line, -1)
 		if len(matches) != 1 || len(matches[0]) != 2 {
 			continue
 		}
+
 		digests = append(digests, matches[0][1])
 	}
 
 	logrus.Infof("Found %d digests to process in diff", len(digests))
+
 	return digests, nil
 }
 
 // ParseManifestFromFile parses a Manifest from a filepath.
 func ParseManifestFromFile(filePath string) (Manifest, error) {
-	var mfest Manifest
-	var empty Manifest
+	var (
+		mfest Manifest
+		empty Manifest
+	)
 
 	b, err := os.ReadFile(filePath)
 	if err != nil {
-		return empty, err
+		return empty, fmt.Errorf("reading manifest file %s: %w", filePath, err)
 	}
 
 	mfest, err = ParseManifestYAML(b)
@@ -409,13 +431,15 @@ func ParseManifestFromFile(filePath string) (Manifest, error) {
 // ParseThinManifestFromFile parses a ThinManifest from a filepath and generates
 // a Manifest.
 func ParseThinManifestFromFile(filePath string, digestsToCheck []string) (Manifest, error) {
-	var thinManifest ThinManifest
-	var mfest Manifest
-	var empty Manifest
+	var (
+		thinManifest ThinManifest
+		mfest        Manifest
+		empty        Manifest
+	)
 
 	b, err := os.ReadFile(filePath)
 	if err != nil {
-		return empty, err
+		return empty, fmt.Errorf("reading thin manifest file %s: %w", filePath, err)
 	}
 
 	thinManifest, err = ParseThinManifestYAML(b)
@@ -473,17 +497,21 @@ func ParseThinManifestFromFile(filePath string, digestsToCheck []string) (Manife
 func ParseManifestYAML(b []byte) (Manifest, error) {
 	var m Manifest
 	if err := yaml.UnmarshalStrict(b, &m); err != nil {
+		return m, fmt.Errorf("unmarshalling manifest YAML: %w", err)
+	}
+
+	if err := m.Validate(); err != nil {
 		return m, err
 	}
 
-	return m, m.Validate()
+	return m, nil
 }
 
 // ParseThinManifestYAML parses a ThinManifest from a byteslice.
 func ParseThinManifestYAML(b []byte) (ThinManifest, error) {
 	var m ThinManifest
 	if err := yaml.UnmarshalStrict(b, &m); err != nil {
-		return m, err
+		return m, fmt.Errorf("unmarshalling thin manifest YAML: %w", err)
 	}
 
 	return m, nil
@@ -493,7 +521,7 @@ func ParseThinManifestYAML(b []byte) (ThinManifest, error) {
 func ParseImagesYAML(b []byte) (registry.Images, error) {
 	var images registry.Images
 	if err := yaml.UnmarshalStrict(b, &images); err != nil {
-		return images, err
+		return images, fmt.Errorf("unmarshalling images YAML: %w", err)
 	}
 
 	return images, nil
@@ -521,14 +549,15 @@ func ValidateThinManifestDirectoryStructure(
 	// exists in the "images" folder.
 	files, err := os.ReadDir(manifestDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("reading manifest directory %s: %w", manifestDir, err)
 	}
 
 	logrus.Infof("*looking at %q", dir)
+
 	for _, file := range files {
 		p, err := os.Stat(filepath.Join(manifestDir, file.Name()))
 		if err != nil {
-			return err
+			return fmt.Errorf("stat %s: %w", file.Name(), err)
 		}
 
 		// Skip non-directory sub-paths.
@@ -543,10 +572,13 @@ func ValidateThinManifestDirectoryStructure(
 				"promoter-manifest.yaml"))
 		if err != nil {
 			logrus.Warningln(err)
+
 			continue
 		}
+
 		if !manifestInfo.Mode().IsRegular() {
 			logrus.Warnf("ignoring irregular file %q", manifestInfo)
+
 			continue
 		}
 
@@ -557,13 +589,15 @@ func ValidateThinManifestDirectoryStructure(
 			"images",
 			file.Name(),
 			"images.yaml")
+
 		imagesInfo, err := os.Stat(imagesPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("corresponding file %q does not exist",
 					imagesPath)
 			}
-			return err
+
+			return fmt.Errorf("stat images file %s: %w", imagesPath, err)
 		}
 
 		if !imagesInfo.Mode().IsRegular() {
@@ -577,12 +611,14 @@ func ValidateThinManifestDirectoryStructure(
 
 // ParseImagesFromFile parses an Images type from a file.
 func ParseImagesFromFile(filePath string) (registry.Images, error) {
-	var images registry.Images
-	var empty registry.Images
+	var (
+		images registry.Images
+		empty  registry.Images
+	)
 
 	b, err := os.ReadFile(filePath)
 	if err != nil {
-		return empty, err
+		return empty, fmt.Errorf("reading images file %s: %w", filePath, err)
 	}
 
 	images, err = ParseImagesYAML(b)
@@ -597,10 +633,12 @@ func ParseImagesFromFile(filePath string) (registry.Images, error) {
 func validateIsDirectory(dir string) error {
 	p, err := os.Stat(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("stat directory %s: %w", dir, err)
 	}
+
 	if !p.IsDir() {
 		return fmt.Errorf("%q is not a directory", dir)
 	}
+
 	return nil
 }

--- a/promoter/image/schema/manifest_test.go
+++ b/promoter/image/schema/manifest_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package schema
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,10 +28,8 @@ import (
 func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
 	t.Setenv("JOB_TYPE", "postsubmit")
 
-	tmpDir, err := os.MkdirTemp("", "k8s.io-")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	testDir := filepath.Join(tmpDir, "test")
-	defer os.RemoveAll(tmpDir)
 
 	const (
 		repo   = "https://github.com/kubernetes/k8s.io"
@@ -63,6 +60,7 @@ func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
 		if onlyProwDiff {
 			expectedDigestCount = 1
 		}
+
 		assert.Equal(t, expectedDigestCount, digestCount)
 		assert.Equal(t, 623, imageCount)
 	}

--- a/promoter/image/vuln/grafeas.go
+++ b/promoter/image/vuln/grafeas.go
@@ -18,6 +18,7 @@ package vuln
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -62,12 +63,14 @@ func (s *GrafeasScanner) Scan(ctx context.Context, ref string) (*ScanResult, err
 	}
 
 	result := &ScanResult{Reference: ref}
+
 	it := client.GetGrafeasClient().ListOccurrences(ctx, req)
 	for {
 		occ, err := it.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
+
 		if err != nil {
 			return nil, fmt.Errorf("listing occurrences: %w", err)
 		}
@@ -92,10 +95,12 @@ func (s *GrafeasScanner) Scan(ctx context.Context, ref string) (*ScanResult, err
 		// Extract package info from the first affected package, if available.
 		if pkgs := vuln.GetPackageIssue(); len(pkgs) > 0 {
 			pkg := pkgs[0]
+
 			v.Package = pkg.GetAffectedPackage()
 			if affected := pkg.GetAffectedVersion(); affected != nil {
 				v.InstalledVersion = affected.GetFullName()
 			}
+
 			if fixed := pkg.GetFixedVersion(); fixed != nil {
 				v.FixedVersion = fixed.GetFullName()
 			}
@@ -118,10 +123,10 @@ func (s *GrafeasScanner) Scan(ctx context.Context, ref string) (*ScanResult, err
 func parseProjectID(ref string) (string, error) {
 	// Strip digest or tag
 	refBase := ref
-	if idx := strings.Index(ref, "@"); idx != -1 {
-		refBase = ref[:idx]
-	} else if idx := strings.Index(ref, ":"); idx != -1 {
-		refBase = ref[:idx]
+	if before, _, ok := strings.Cut(ref, "@"); ok {
+		refBase = before
+	} else if before, _, ok := strings.Cut(ref, ":"); ok {
+		refBase = before
 	}
 
 	parts := strings.Split(refBase, "/")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update golangci-lint from v2.6.1 to v2.10.1
- Simplify gocritic config by using `enabled-all: true`
- Enable additional linters and fix all lint reports
- No functional changes

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Newly enabled linters: arangolint, containedctx, cyclop, embeddedstructfieldcheck, errorlint, exhaustive, exptostd, forcetypeassert, funcorder, funlen, gocognit, godoclint, iface, interfacebloat, iotamixing, ireturn, maintidx, modernize, musttag, nestif, nilerr, nilnesserr, nilnil, nlreturn, noctx, nonamedreturns, recvcheck, tagliatelle, thelper, unqueryvet, usetesting, wrapcheck, wsl_v5.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```