### PR TITLE
Retry image promotion on transient errors

### DIFF
--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -173,7 +173,9 @@ func (di *DefaultPromoterImplementation) PromoteImages(
 
 			start := time.Now()
 
-			if err := di.registryProvider.CopyImage(ctx, srcVertex, dstVertex); err != nil {
+			if err := withRetry(func() error {
+				return di.registryProvider.CopyImage(ctx, srcVertex, dstVertex)
+			}); err != nil {
 				return fmt.Errorf("copying %s to %s: %w", srcVertex, dstVertex, err)
 			}
 

--- a/promoter/image/pipeline/pipeline.go
+++ b/promoter/image/pipeline/pipeline.go
@@ -105,10 +105,10 @@ func (p *Pipeline) Run(ctx context.Context) error {
 			return fmt.Errorf("phase %q failed: %w", phase.Name(), err)
 		}
 
-		logrus.Infof("Phase %q completed in %s", phase.Name(), time.Since(phaseStart))
+		logrus.Infof("Phase %q completed in %s", phase.Name(), time.Since(phaseStart).Round(time.Millisecond))
 	}
 
-	logrus.Infof("Pipeline completed in %s", time.Since(start))
+	logrus.Infof("Pipeline completed in %s", time.Since(start).Round(time.Millisecond))
 
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The image promotion phase was missing retry logic for transient registry errors (429, 5xx), causing the entire promotion to abort on the first failure. This wraps `CopyImage` calls with the existing `withRetry` helper to match the signature replication behavior.

Also rounds pipeline phase durations to milliseconds for cleaner logs.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Retry image promotion on transient registry errors (429, 5xx) instead of aborting
```