### PR TITLE
Add retry logic for all pipeline network operations

### DIFF
--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -28,6 +28,7 @@ import (
 
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/promotion"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/registry"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/schema"
 )
@@ -173,7 +174,7 @@ func (di *DefaultPromoterImplementation) PromoteImages(
 
 			start := time.Now()
 
-			if err := withRetry(func() error {
+			if err := ratelimit.WithRetry(func() error {
 				return di.registryProvider.CopyImage(ctx, srcVertex, dstVertex)
 			}); err != nil {
 				return fmt.Errorf("copying %s to %s: %w", srcVertex, dstVertex, err)

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -38,7 +38,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/tuf"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/release-sdk/sign"
 	"sigs.k8s.io/release-utils/version"
 
@@ -47,6 +46,7 @@ import (
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/promotion"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/provenance"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
@@ -331,7 +331,9 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *promotion.Edg
 		crane.WithTransport(di.getTransport()),
 	}
 
-	if err := crane.Copy(srcRef.String(), dstRef.String(), craneOpts...); err != nil {
+	if err := ratelimit.WithRetry(func() error {
+		return crane.Copy(srcRef.String(), dstRef.String(), craneOpts...)
+	}); err != nil {
 		// If the signature layer does not exist it means that the src image
 		// is not signed, so we catch the error and return nil
 		var terr *transport.Error
@@ -444,74 +446,34 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	return nil
 }
 
-// retryBackoff defines the exponential backoff for transient registry errors.
-var retryBackoff = wait.Backoff{
-	Duration: 30 * time.Second,
-	Factor:   2,
-	Jitter:   0.1,
-	Steps:    3,
-}
-
-// isTransient returns true for HTTP status codes that indicate a temporary
-// failure worth retrying (429 Too Many Requests and 5xx server errors).
-func isTransient(err error) bool {
-	var terr *transport.Error
-	if errors.As(err, &terr) {
-		return terr.StatusCode == http.StatusTooManyRequests ||
-			terr.StatusCode >= http.StatusInternalServerError
-	}
-
-	return false
-}
-
-// withRetry calls fn with exponential backoff on transient registry errors.
-// Non-transient errors are returned immediately.
-func withRetry(fn func() error) error {
-	var lastErr error
-
-	err := wait.ExponentialBackoff(retryBackoff, func() (bool, error) {
-		lastErr = fn()
-		if lastErr == nil {
-			return true, nil // success, stop retrying
-		}
-
-		if !isTransient(lastErr) {
-			return false, lastErr // permanent error, stop retrying
-		}
-
-		return false, nil // transient error, keep retrying
-	})
-	if wait.Interrupted(err) {
-		return lastErr // retries exhausted, return the last transient error
-	}
-
-	if err != nil {
-		return fmt.Errorf("exponential backoff: %w", err)
-	}
-
-	return nil
-}
-
 // headWithRetry performs a remote.Head with retries on transient errors.
 func (di *DefaultPromoterImplementation) headWithRetry(ref name.Reference) error {
-	return withRetry(func() error {
+	if err := ratelimit.WithRetry(func() error {
 		_, err := remote.Head(ref,
 			remote.WithAuthFromKeychain(gcrane.Keychain),
 			remote.WithTransport(di.getTransport()),
 		)
 		if err != nil {
-			return fmt.Errorf("remote head %s: %w", ref.String(), err)
+			return fmt.Errorf("head: %w", err)
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return fmt.Errorf("remote head %s: %w", ref.String(), err)
+	}
+
+	return nil
 }
 
 // copyWithRetry performs a crane.Copy with retries on transient errors.
 func (di *DefaultPromoterImplementation) copyWithRetry(src, dst string, opts []crane.Option) error {
-	return withRetry(func() error {
+	if err := ratelimit.WithRetry(func() error {
 		return crane.Copy(src, dst, opts...)
-	})
+	}); err != nil {
+		return fmt.Errorf("copying %s to %s: %w", src, dst, err)
+	}
+
+	return nil
 }
 
 // WriteSBOMs copies pre-generated SBOMs from the staging registry to each
@@ -574,7 +536,9 @@ func (di *DefaultPromoterImplementation) copySBOM(edge *promotion.Edge) error {
 
 	logrus.Infof("SBOM copy: %s to %s", srcRefString, dstRefString)
 
-	if err := crane.Copy(srcRefString, dstRefString, craneOpts...); err != nil {
+	if err := ratelimit.WithRetry(func() error {
+		return crane.Copy(srcRefString, dstRefString, craneOpts...)
+	}); err != nil {
 		// If the SBOM does not exist in staging, skip silently
 		var terr *transport.Error
 		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
@@ -708,11 +672,13 @@ func (di *DefaultPromoterImplementation) pushAttestation(
 
 	logrus.Infof("Provenance attestation: pushing %s", dstRefString)
 
-	if err := remote.Write(ref, img,
-		remote.WithAuthFromKeychain(gcrane.Keychain),
-		remote.WithUserAgent(image.UserAgent),
-		remote.WithTransport(di.getTransport()),
-	); err != nil {
+	if err := ratelimit.WithRetry(func() error {
+		return remote.Write(ref, img,
+			remote.WithAuthFromKeychain(gcrane.Keychain),
+			remote.WithUserAgent(image.UserAgent),
+			remote.WithTransport(di.getTransport()),
+		)
+	}); err != nil {
 		return fmt.Errorf("pushing attestation %s: %w", dstRefString, err)
 	}
 

--- a/internal/promoter/image/sign_test.go
+++ b/internal/promoter/image/sign_test.go
@@ -29,6 +29,7 @@ import (
 
 	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/promotion"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/registry"
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
@@ -168,7 +169,7 @@ func TestIsTransient(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tc.want, isTransient(tc.err))
+			require.Equal(t, tc.want, ratelimit.IsTransient(tc.err))
 		})
 	}
 }

--- a/promoter/image/ratelimit/retry.go
+++ b/promoter/image/ratelimit/retry.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// retryBackoff defines the exponential backoff for transient registry errors.
+var retryBackoff = wait.Backoff{
+	Duration: 30 * time.Second,
+	Factor:   2,
+	Jitter:   0.1,
+	Steps:    3,
+}
+
+// IsTransient returns true for HTTP status codes that indicate a temporary
+// failure worth retrying (429 Too Many Requests and 5xx server errors).
+func IsTransient(err error) bool {
+	var terr *transport.Error
+	if errors.As(err, &terr) {
+		return terr.StatusCode == http.StatusTooManyRequests ||
+			terr.StatusCode >= http.StatusInternalServerError
+	}
+
+	return false
+}
+
+// WithRetry calls fn with exponential backoff on transient registry errors.
+// Non-transient errors (including 404 Not Found) are returned immediately.
+func WithRetry(fn func() error) error {
+	var lastErr error
+
+	err := wait.ExponentialBackoff(retryBackoff, func() (bool, error) {
+		lastErr = fn()
+		if lastErr == nil {
+			return true, nil // success, stop retrying
+		}
+
+		if !IsTransient(lastErr) {
+			return false, lastErr // permanent error, stop retrying
+		}
+
+		logrus.Warnf("Transient error (will retry): %v", lastErr)
+
+		return false, nil // transient error, keep retrying
+	})
+	if wait.Interrupted(err) {
+		return lastErr // retries exhausted, return the last transient error
+	}
+
+	if err != nil {
+		return fmt.Errorf("exponential backoff: %w", err)
+	}
+
+	return nil
+}

--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
@@ -109,12 +110,24 @@ func (p *CraneProvider) ReadRegistries(
 			recordTags := makeTagRecorder(inv, &mu, splitRegs)
 
 			if recurse {
-				if err := ggcrV1Google.Walk(repo, recordTags, walkOpts...); err != nil {
+				if err := ratelimit.WithRetry(func() error {
+					return ggcrV1Google.Walk(repo, recordTags, walkOpts...)
+				}); err != nil {
 					return fmt.Errorf("walking repo %s: %w", r.Name, err)
 				}
 			} else {
-				tags, err := ggcrV1Google.List(repo, walkOpts...)
-				if err != nil {
+				var tags *ggcrV1Google.Tags
+
+				if err := ratelimit.WithRetry(func() error {
+					var listErr error
+
+					tags, listErr = ggcrV1Google.List(repo, walkOpts...)
+					if listErr != nil {
+						return fmt.Errorf("listing: %w", listErr)
+					}
+
+					return nil
+				}); err != nil {
 					return fmt.Errorf("listing repo %s: %w", r.Name, err)
 				}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Moves the retry helpers (`WithRetry`, `IsTransient`) to the `ratelimit` package so they can be shared across packages, and adds retry logic to all remaining unprotected network operations in the main promotion pipeline:

- **plan phase**: `google.List`/`google.Walk` registry reads
- **sign phase**: `crane.Copy` for signature pre-copy
- **attest phase**: `crane.Copy` for SBOMs, `remote.Write` for provenance attestations

Non-transient errors (e.g. 404 for missing signatures/SBOMs/attestations) are returned immediately without retrying.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add retry logic for all pipeline network operations including registry reads, signature/SBOM copies, and attestation writes
```