### PR TITLE
Reduce rate limiter log spam during backoff

### DIFF
--- a/cmd/kpromo/cmd/cip/replicate.go
+++ b/cmd/kpromo/cmd/cip/replicate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	promoter "sigs.k8s.io/promo-tools/v4/promoter/image"
@@ -46,6 +47,12 @@ Example usage:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
+		logrus.SetFormatter(&logrus.TextFormatter{
+			DisableTimestamp: false,
+			FullTimestamp:    true,
+			TimestampFormat:  "15:04:05.000",
+		})
+
 		p := promoter.New(runOpts)
 		if err := p.ReplicateSignatures(context.Background(), runOpts); err != nil {
 			return fmt.Errorf("replicate signatures: %w", err)

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -435,6 +435,8 @@ func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Option
 			return fmt.Errorf("parsing manifests: %w", err)
 		}
 
+		p.impl.PrintVersion()
+
 		promotionEdges, err = p.impl.EdgesFromManifests(mfests)
 		if err != nil {
 			return fmt.Errorf("computing edges from manifests: %w", err)

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -114,9 +114,7 @@ func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 // to rebalance budgets between phases.
 func (rt *RoundTripper) SetLimit(newLimit rate.Limit) {
 	rt.rateLimiter.SetLimit(newLimit)
-	logrus.WithField("limiter", rt.name).Infof(
-		"Rate limit adjusted to %.1f req/sec", float64(newLimit),
-	)
+	logrus.Infof("Rate limit adjusted to %.1f req/sec", float64(newLimit))
 }
 
 // SetBurst changes the burst limit dynamically.
@@ -147,9 +145,6 @@ func (rt *RoundTripper) waitForBackoff(ctx context.Context) {
 	}
 
 	wait := time.Until(until)
-	logrus.WithField("limiter", rt.name).Warnf(
-		"Backoff active, waiting %s before next request", wait.Round(time.Millisecond),
-	)
 
 	select {
 	case <-time.After(wait):
@@ -172,7 +167,5 @@ func (rt *RoundTripper) triggerBackoff() {
 
 	rt.lastBackoff = now
 	rt.backoffUntil = now.Add(backoffDuration)
-	logrus.WithField("limiter", rt.name).Warnf(
-		"Received 429 Too Many Requests, backing off for %s", backoffDuration,
-	)
+	logrus.Warnf("Received 429 Too Many Requests, backing off for %s", backoffDuration)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Remove the per-request "Backoff active" warning that was logged by every goroutine entering the backoff wait, causing hundreds of near-identical log lines. The single "Received 429" log from `triggerBackoff` is sufficient.
- Remove the unused `limiter=default` log field.
- Add `PrintVersion` call and log formatter to the `ReplicateSignatures` pipeline to match the full promotion pipeline.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Reduce rate limiter log spam by removing per-request backoff warnings
```