### PR TITLE
Add local registry integration tests for image promoter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -161,6 +161,9 @@ linters:
           - dupl
           - gocritic
         path: fake_.*\.go
+      - linters:
+          - ireturn
+        path: promoter/file/
     paths:
       - third_party$
       - builtin$

--- a/internal/promoter/image/sign_integration_test.go
+++ b/internal/promoter/image/sign_integration_test.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagepromoter
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+
+	options "sigs.k8s.io/promo-tools/v4/promoter/image/options"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/promotion"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/provenance"
+	"sigs.k8s.io/promo-tools/v4/promoter/image/ratelimit"
+	reg "sigs.k8s.io/promo-tools/v4/promoter/image/registry"
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+// newTLSTestRegistry starts an in-process OCI registry over TLS and returns
+// the host:port address and a DefaultPromoterImplementation configured with
+// a transport that trusts the test server's certificate.
+func newTLSTestRegistry(t *testing.T) (string, *DefaultPromoterImplementation) {
+	t.Helper()
+
+	s := httptest.NewTLSServer(registry.New())
+	t.Cleanup(s.Close)
+
+	host := s.Listener.Addr().String()
+
+	// Create a rate-limited transport wrapping the TLS-aware client transport.
+	rt := ratelimit.NewRoundTripperWithBase(ratelimit.MaxEvents, s.Client().Transport)
+
+	di := &DefaultPromoterImplementation{
+		transport: rt,
+	}
+
+	return host, di
+}
+
+// pushTestImage creates a random image and pushes it to the given reference
+// using the TLS-aware transport. Returns the image digest.
+func pushTestImage(t *testing.T, di *DefaultPromoterImplementation, ref string) string {
+	t.Helper()
+
+	img, err := random.Image(1024, 1)
+	require.NoError(t, err)
+
+	r, err := name.ParseReference(ref)
+	require.NoError(t, err)
+
+	err = remote.Write(r, img, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err)
+
+	d, err := img.Digest()
+	require.NoError(t, err)
+
+	return d.String()
+}
+
+// testEdgeForHost constructs a promotion edge suitable for local registry tests.
+func testEdgeForHost(host, dstPath string, digest image.Digest) promotion.Edge {
+	return promotion.Edge{
+		SrcRegistry: reg.Context{Name: image.Registry(host + "/staging"), Src: true},
+		SrcImageTag: promotion.ImageTag{Name: "myimage", Tag: "v1.0"},
+		Digest:      digest,
+		DstRegistry: reg.Context{Name: image.Registry(host + "/" + dstPath)},
+		DstImageTag: promotion.ImageTag{Name: "myimage", Tag: "v1.0"},
+	}
+}
+
+// --- copyAttachedObjects tests ---
+
+func TestCopyAttachedObjectsSignatureExists(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	// Push a "real" image to staging.
+	imgRef := host + "/staging/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	// Push a fake signature artifact to the staging registry using the
+	// cosign tag convention: sha256-<hash>.sig
+	sigTag := digestToSignatureTag(image.Digest(digest))
+	sigRef := fmt.Sprintf("%s/staging/myimage:%s", host, sigTag)
+	pushTestImage(t, di, sigRef)
+
+	edge := testEdgeForHost(host, "production", image.Digest(digest))
+
+	err := di.copyAttachedObjects(&edge)
+	require.NoError(t, err)
+
+	// Verify the signature landed in the production registry.
+	dstSigRef := fmt.Sprintf("%s/production/myimage:%s", host, sigTag)
+	ref, err := name.ParseReference(dstSigRef)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err, "signature should exist in production")
+}
+
+func TestCopyAttachedObjectsSignatureMissing(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	// Push a "real" image but no signature.
+	imgRef := host + "/staging/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	edge := testEdgeForHost(host, "production", image.Digest(digest))
+
+	// Should gracefully succeed when no signature exists (404 is not an error).
+	err := di.copyAttachedObjects(&edge)
+	require.NoError(t, err)
+}
+
+// --- copySBOM tests ---
+
+func TestCopySBOMExists(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	imgRef := host + "/staging/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	// Push a fake SBOM to staging.
+	sbomTag := digestToSBOMTag(image.Digest(digest))
+	sbomRef := fmt.Sprintf("%s/staging/myimage:%s", host, sbomTag)
+	pushTestImage(t, di, sbomRef)
+
+	edge := testEdgeForHost(host, "production", image.Digest(digest))
+
+	err := di.copySBOM(&edge)
+	require.NoError(t, err)
+
+	// Verify the SBOM landed in production.
+	dstSBOMRef := fmt.Sprintf("%s/production/myimage:%s", host, sbomTag)
+	ref, err := name.ParseReference(dstSBOMRef)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err, "SBOM should exist in production")
+}
+
+func TestCopySBOMMissing(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	imgRef := host + "/staging/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	edge := testEdgeForHost(host, "production", image.Digest(digest))
+
+	// Should gracefully succeed when no SBOM exists.
+	err := di.copySBOM(&edge)
+	require.NoError(t, err)
+}
+
+// --- replicateSignatures tests ---
+
+func TestReplicateSignaturesExists(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	imgRef := host + "/primary/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	// Push a signature to the primary destination.
+	sigTag := digestToSignatureTag(image.Digest(digest))
+	sigRef := fmt.Sprintf("%s/primary/myimage:%s", host, sigTag)
+	pushTestImage(t, di, sigRef)
+
+	// Source edge (primary destination where signature already exists).
+	srcEdge := testEdgeForHost(host, "primary", image.Digest(digest))
+
+	// Destination edges (mirrors).
+	dstEdge := testEdgeForHost(host, "mirror", image.Digest(digest))
+
+	err := di.replicateSignatures(&srcEdge, []promotion.Edge{dstEdge})
+	require.NoError(t, err)
+
+	// Verify the signature was replicated to the mirror.
+	mirrorSigRef := fmt.Sprintf("%s/mirror/myimage:%s", host, sigTag)
+	ref, err := name.ParseReference(mirrorSigRef)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err, "signature should exist in mirror")
+}
+
+func TestReplicateSignaturesMissing(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	// No signature exists at all — replication should gracefully skip.
+	digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	srcEdge := testEdgeForHost(host, "primary", image.Digest(digest))
+	dstEdge := testEdgeForHost(host, "mirror", image.Digest(digest))
+
+	err := di.replicateSignatures(&srcEdge, []promotion.Edge{dstEdge})
+	require.NoError(t, err)
+}
+
+func TestReplicateSignaturesAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	imgRef := host + "/primary/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	// Push signature to both primary and mirror.
+	sigTag := digestToSignatureTag(image.Digest(digest))
+	pushTestImage(t, di, fmt.Sprintf("%s/primary/myimage:%s", host, sigTag))
+	pushTestImage(t, di, fmt.Sprintf("%s/mirror/myimage:%s", host, sigTag))
+
+	srcEdge := testEdgeForHost(host, "primary", image.Digest(digest))
+	dstEdge := testEdgeForHost(host, "mirror", image.Digest(digest))
+
+	// Should succeed without error (signature already present).
+	err := di.replicateSignatures(&srcEdge, []promotion.Edge{dstEdge})
+	require.NoError(t, err)
+}
+
+// --- pushAttestation tests ---
+
+// fakeGenerator is a provenance.Generator that returns a fixed attestation.
+type fakeGenerator struct {
+	data []byte
+}
+
+func (f *fakeGenerator) Generate(_ context.Context, _ *provenance.PromotionRecord) ([]byte, error) {
+	return f.data, nil
+}
+
+func TestPushAttestation(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	imgRef := host + "/production/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	record := &provenance.PromotionRecord{
+		SrcRef:    edge.SrcReference(),
+		DstRef:    edge.DstReference(),
+		Digest:    string(edge.Digest),
+		BuilderID: "https://k8s.io/promo-tools@test",
+	}
+
+	gen := &fakeGenerator{data: []byte(`{"test": "attestation"}`)}
+
+	err := di.pushAttestation(context.Background(), &edge, gen, record)
+	require.NoError(t, err)
+
+	// Verify the attestation landed.
+	attTag := digestToAttestationTag(image.Digest(digest))
+	attRef := fmt.Sprintf("%s/production/myimage:%s", host, attTag)
+	ref, err := name.ParseReference(attRef)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err, "attestation should exist in production")
+}
+
+func TestPushAttestationIdempotent(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	imgRef := host + "/production/myimage:v1.0"
+	digest := pushTestImage(t, di, imgRef)
+
+	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	record := &provenance.PromotionRecord{
+		SrcRef:    edge.SrcReference(),
+		DstRef:    edge.DstReference(),
+		Digest:    string(edge.Digest),
+		BuilderID: "https://k8s.io/promo-tools@test",
+	}
+
+	gen := &fakeGenerator{data: []byte(`{"test": "attestation"}`)}
+
+	// Push twice — second push should skip because attestation already exists.
+	for i := range 2 {
+		err := di.pushAttestation(context.Background(), &edge, gen, record)
+		require.NoError(t, err, "push attempt %d", i+1)
+	}
+}
+
+// --- Tag convention tests ---
+
+func TestDigestToAttestationTag(t *testing.T) {
+	t.Parallel()
+
+	tag := digestToAttestationTag("sha256:abc123")
+	require.Equal(t, "sha256-abc123.att", tag)
+	require.True(t, strings.HasSuffix(tag, attestationTagSuffix))
+}
+
+// --- copyWithRetry / headWithRetry are exercised by the above tests
+// through replicateSignatures and copyAttachedObjects. ---
+
+// --- Integration test for the full promotion flow with CraneProvider ---
+
+func TestPromoteImagesCraneProvider(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	// Set up the CraneProvider to use the TLS-aware transport.
+	di.SetRegistryProvider(reg.NewCraneProvider(
+		reg.WithTransport(di.getTransport()),
+	))
+
+	srcRegistry := image.Registry(host + "/staging")
+	dstRegistry := image.Registry(host + "/production")
+
+	type entry struct {
+		imgName image.Name
+		tag     image.Tag
+		digest  string
+	}
+
+	entries := []entry{
+		{imgName: "app", tag: "v1.0"},
+		{imgName: "app", tag: "v2.0"},
+		{imgName: "web", tag: "latest"},
+	}
+
+	// Push test images to staging.
+	for i, e := range entries {
+		ref := fmt.Sprintf("%s/%s:%s", srcRegistry, e.imgName, e.tag)
+		entries[i].digest = pushTestImage(t, di, ref)
+	}
+
+	// Build promotion edges.
+	edges := make(map[promotion.Edge]any)
+
+	for _, e := range entries {
+		edge := promotion.Edge{
+			SrcRegistry: reg.Context{Name: srcRegistry, Src: true},
+			SrcImageTag: promotion.ImageTag{Name: e.imgName, Tag: e.tag},
+			Digest:      image.Digest(e.digest),
+			DstRegistry: reg.Context{Name: dstRegistry},
+			DstImageTag: promotion.ImageTag{Name: e.imgName, Tag: e.tag},
+		}
+		edges[edge] = nil
+	}
+
+	// Run promotion.
+	opts := &options.Options{Threads: 4}
+	err := di.PromoteImages(opts, edges)
+	require.NoError(t, err)
+
+	// Verify all images landed.
+	for _, e := range entries {
+		dstRef := fmt.Sprintf("%s/%s:%s", dstRegistry, e.imgName, e.tag)
+		ref, err := name.ParseReference(dstRef)
+		require.NoError(t, err)
+
+		desc, err := remote.Head(ref, remote.WithTransport(di.getTransport()))
+		require.NoError(t, err, "image %s should exist", dstRef)
+		require.Equal(t, e.digest, desc.Digest.String())
+	}
+
+	// Verify tag listing.
+	repo, err := name.NewRepository(fmt.Sprintf("%s/app", dstRegistry))
+	require.NoError(t, err)
+
+	tags, err := remote.List(repo, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"v1.0", "v2.0"}, tags)
+}

--- a/internal/promoter/image/sign_test.go
+++ b/internal/promoter/image/sign_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -226,4 +227,59 @@ func TestTargetIdentity(t *testing.T) {
 			assert(res)
 		})
 	}
+}
+
+func TestGroupEdgesByIdentityDigest(t *testing.T) {
+	t.Parallel()
+
+	digest1 := image.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	digest2 := image.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	// Use production-style registry names so targetIdentity normalizes them
+	// to the same identity (registry.k8s.io/app), allowing edges with
+	// different registries to be grouped together.
+	mkEdge := func(dstReg string, imgName string, digest image.Digest, tag image.Tag) promotion.Edge {
+		return promotion.Edge{
+			SrcRegistry: registry.Context{Name: "staging", Src: true},
+			SrcImageTag: promotion.ImageTag{Name: image.Name(imgName), Tag: tag},
+			Digest:      digest,
+			DstRegistry: registry.Context{Name: image.Registry(dstReg)},
+			DstImageTag: promotion.ImageTag{Name: image.Name(imgName), Tag: tag},
+		}
+	}
+
+	edges := map[promotion.Edge]any{
+		// Same normalized identity + digest, different registries → same group.
+		mkEdge("us-central1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest1, "v1.0"): nil,
+		mkEdge("us-east1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest1, "v1.0"):    nil,
+		mkEdge("us-west1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest1, "v1.0"):    nil,
+		// Different digest → different group.
+		mkEdge("us-central1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest2, "v2.0"): nil,
+		// Metadata layers should be skipped.
+		mkEdge("us-central1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest1, "sha256-aaa.sig"): nil,
+		mkEdge("us-central1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest1, "sha256-aaa.att"): nil,
+		// Tagless edge should be skipped.
+		mkEdge("us-central1-docker.pkg.dev/k8s-artifacts-prod/images", "app", digest1, ""): nil,
+	}
+
+	groups := groupEdgesByIdentityDigest(edges)
+
+	// Should have 2 groups (digest1 and digest2), metadata/tagless skipped.
+	require.Len(t, groups, 2)
+
+	// Sort groups by digest for deterministic assertion.
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i][0].Digest < groups[j][0].Digest
+	})
+
+	// Group 1: digest1 with 3 edges (us-central1, us-east1, us-west1).
+	require.Len(t, groups[0], 3)
+	// Edges should be sorted by destination registry name.
+	require.Equal(t, image.Registry("us-central1-docker.pkg.dev/k8s-artifacts-prod/images"), groups[0][0].DstRegistry.Name)
+	require.Equal(t, image.Registry("us-east1-docker.pkg.dev/k8s-artifacts-prod/images"), groups[0][1].DstRegistry.Name)
+	require.Equal(t, image.Registry("us-west1-docker.pkg.dev/k8s-artifacts-prod/images"), groups[0][2].DstRegistry.Name)
+
+	// Group 2: digest2 with 1 edge.
+	require.Len(t, groups[1], 1)
+	require.Equal(t, digest2, groups[1][0].Digest)
 }

--- a/promoter/file/filestore.go
+++ b/promoter/file/filestore.go
@@ -64,7 +64,6 @@ var supportedProviders = []Provider{
 	S3Storage,
 }
 
-//nolint:ireturn
 func openFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,
@@ -97,8 +96,6 @@ func openFilestore(
 }
 
 // openGCSFilestore opens a filestore backed by Google Cloud Storage (GCS).
-//
-//nolint:ireturn
 func (p *gcsProvider) OpenFilestore(
 	ctx context.Context,
 	filestore *api.Filestore,

--- a/promoter/file/s3.go
+++ b/promoter/file/s3.go
@@ -57,8 +57,6 @@ type s3SyncFilestore struct {
 }
 
 // openS3Filestore opens a filestore backed by Amazon S3 (S3).
-//
-//nolint:ireturn
 func (p *s3Provider) OpenFilestore(ctx context.Context, filestore *api.Filestore, useServiceAccount, confirm bool) (syncFilestore, error) {
 	u, err := url.Parse(filestore.Base)
 	if err != nil {

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -78,6 +78,16 @@ func NewNamedRoundTripper(name string, limit rate.Limit, burst int) *RoundTrippe
 	}
 }
 
+// NewRoundTripperWithBase creates a rate-limited HTTP transport that wraps
+// the given base transport instead of http.DefaultTransport.
+func NewRoundTripperWithBase(limit rate.Limit, base http.RoundTripper) *RoundTripper {
+	return &RoundTripper{
+		name:         "default",
+		rateLimiter:  rate.NewLimiter(limit, DefaultBurst),
+		roundTripper: base,
+	}
+}
+
 // RoundTrip executes the HTTP request with rate limiting. All HTTP methods are
 // rate-limited because Artifact Registry quotas apply to both reads and writes.
 // If a 429 response is received, an adaptive backoff pauses future requests.

--- a/promoter/image/registry/crane.go
+++ b/promoter/image/registry/crane.go
@@ -44,6 +44,7 @@ const readRegistryConcurrency = 20
 // Google-specific extensions for optimized registry walking.
 type CraneProvider struct {
 	transport http.RoundTripper
+	craneOpts []crane.Option
 }
 
 // CraneOption configures a CraneProvider.
@@ -53,6 +54,14 @@ type CraneOption func(*CraneProvider)
 func WithTransport(rt http.RoundTripper) CraneOption {
 	return func(p *CraneProvider) {
 		p.transport = rt
+	}
+}
+
+// WithCraneOptions sets additional crane options for registry operations.
+// This can be used to pass options like crane.Insecure for non-TLS registries.
+func WithCraneOptions(opts ...crane.Option) CraneOption {
+	return func(p *CraneProvider) {
+		p.craneOpts = opts
 	}
 }
 
@@ -158,6 +167,8 @@ func (p *CraneProvider) CopyImage(_ context.Context, src, dst string) error {
 	if p.transport != nil {
 		opts = append(opts, crane.WithTransport(p.transport))
 	}
+
+	opts = append(opts, p.craneOpts...)
 
 	if err := crane.Copy(src, dst, opts...); err != nil {
 		return fmt.Errorf("copying image %s to %s: %w", src, dst, err)

--- a/promoter/image/registry/crane_integration_test.go
+++ b/promoter/image/registry/crane_integration_test.go
@@ -1,0 +1,372 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/promo-tools/v4/types/image"
+)
+
+// newTestRegistry starts an in-process OCI registry and returns its
+// host:port address along with a cleanup function.
+func newTestRegistry(t *testing.T) string {
+	t.Helper()
+
+	s := httptest.NewServer(registry.New())
+	t.Cleanup(s.Close)
+
+	return s.Listener.Addr().String()
+}
+
+// pushRandomImage creates a minimal random image and pushes it to the
+// given reference on the local registry. It returns the pushed image digest.
+func pushRandomImage(t *testing.T, ref string) string {
+	t.Helper()
+
+	img, err := random.Image(1024, 1)
+	require.NoError(t, err)
+
+	err = crane.Push(img, ref, crane.Insecure)
+	require.NoError(t, err)
+
+	digest, err := crane.Digest(ref, crane.Insecure)
+	require.NoError(t, err)
+
+	return digest
+}
+
+// newInsecureCraneProvider creates a CraneProvider configured for plain HTTP
+// registries.
+func newInsecureCraneProvider() *CraneProvider {
+	return NewCraneProvider(WithCraneOptions(crane.Insecure))
+}
+
+func TestCraneProviderCopyImageByTag(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	srcRef := host + "/staging/myimage:v1.0"
+	srcDigest := pushRandomImage(t, srcRef)
+
+	p := newInsecureCraneProvider()
+	dstRef := host + "/production/myimage:v1.0"
+	err := p.CopyImage(context.Background(), srcRef, dstRef)
+	require.NoError(t, err)
+
+	// Verify the destination image exists and has the same digest.
+	dstDigest, err := crane.Digest(dstRef, crane.Insecure)
+	require.NoError(t, err)
+	require.Equal(t, srcDigest, dstDigest)
+}
+
+func TestCraneProviderCopyByDigest(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	// Push an image by tag so it has a manifest in the registry.
+	tagRef := host + "/staging/myimage:v1.0"
+	digest := pushRandomImage(t, tagRef)
+
+	// Copy using a digest reference (FQIN → FQIN).
+	// This is also the tagless promotion code path when edge.DstImageTag.Tag == "".
+	p := newInsecureCraneProvider()
+	srcByDigest := host + "/staging/myimage@" + digest
+	dstByDigest := host + "/production/myimage@" + digest
+	err := p.CopyImage(context.Background(), srcByDigest, dstByDigest)
+	require.NoError(t, err)
+
+	// Verify the destination digest matches.
+	gotDigest, err := crane.Digest(dstByDigest, crane.Insecure)
+	require.NoError(t, err)
+	require.Equal(t, digest, gotDigest)
+}
+
+func TestCraneProviderCopyMultipleTagsSameDigest(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	// Push one image and tag it.
+	srcRef := host + "/staging/myimage:v1.0"
+	digest := pushRandomImage(t, srcRef)
+
+	p := newInsecureCraneProvider()
+
+	// Promote the same digest to multiple tags in destination, simulating
+	// a manifest with dmap: {"sha256:...": ["v1.0", "latest"]}.
+	srcVertex := host + "/staging/myimage@" + digest
+	for _, tag := range []string{"v1.0", "latest"} {
+		dstVertex := fmt.Sprintf("%s/production/myimage:%s", host, tag)
+		err := p.CopyImage(context.Background(), srcVertex, dstVertex)
+		require.NoError(t, err)
+	}
+
+	// Both tags should resolve to the same digest.
+	for _, tag := range []string{"v1.0", "latest"} {
+		ref := fmt.Sprintf("%s/production/myimage:%s", host, tag)
+		gotDigest, err := crane.Digest(ref, crane.Insecure)
+		require.NoError(t, err)
+		require.Equal(t, digest, gotDigest, "tag %s has wrong digest", tag)
+	}
+
+	tags, err := crane.ListTags(host+"/production/myimage", crane.Insecure)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"v1.0", "latest"}, tags)
+}
+
+func TestCraneProviderCopyNonexistentSource(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	p := newInsecureCraneProvider()
+	err := p.CopyImage(
+		context.Background(),
+		host+"/staging/doesnotexist:v1.0",
+		host+"/production/doesnotexist:v1.0",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "copying image")
+}
+
+func TestCraneProviderCopyIdempotent(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	srcRef := host + "/staging/myimage:v1.0"
+	digest := pushRandomImage(t, srcRef)
+
+	p := newInsecureCraneProvider()
+	dstRef := host + "/production/myimage:v1.0"
+
+	// Copy twice — the second copy should also succeed.
+	for i := range 2 {
+		err := p.CopyImage(context.Background(), srcRef, dstRef)
+		require.NoError(t, err, "copy attempt %d", i+1)
+	}
+
+	gotDigest, err := crane.Digest(dstRef, crane.Insecure)
+	require.NoError(t, err)
+	require.Equal(t, digest, gotDigest)
+}
+
+func TestCraneProviderCopyPreservesContent(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	// Push a random image and record its layers.
+	srcImg, err := random.Image(1024, 2)
+	require.NoError(t, err)
+
+	srcRef := host + "/staging/myimage:v1.0"
+	err = crane.Push(srcImg, srcRef, crane.Insecure)
+	require.NoError(t, err)
+
+	srcLayers, err := srcImg.Layers()
+	require.NoError(t, err)
+
+	// Copy with CraneProvider.
+	p := newInsecureCraneProvider()
+	dstRef := host + "/production/myimage:v1.0"
+	err = p.CopyImage(context.Background(), srcRef, dstRef)
+	require.NoError(t, err)
+
+	// Pull the destination image and verify layer digests match.
+	dstImg, err := crane.Pull(dstRef, crane.Insecure)
+	require.NoError(t, err)
+
+	dstLayers, err := dstImg.Layers()
+	require.NoError(t, err)
+	require.Len(t, dstLayers, len(srcLayers), "layer count mismatch")
+
+	for i := range srcLayers {
+		srcDg, err := srcLayers[i].Digest()
+		require.NoError(t, err)
+
+		dstDg, err := dstLayers[i].Digest()
+		require.NoError(t, err)
+
+		require.Equal(t, srcDg, dstDg, "layer %d digest mismatch", i)
+	}
+
+	// Verify config digest matches.
+	srcCfgHash, err := srcImg.ConfigName()
+	require.NoError(t, err)
+
+	dstCfgHash, err := dstImg.ConfigName()
+	require.NoError(t, err)
+
+	require.Equal(t, srcCfgHash, dstCfgHash)
+}
+
+func TestCraneProviderWithTransport(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	srcRef := host + "/staging/myimage:v1.0"
+	srcDigest := pushRandomImage(t, srcRef)
+
+	// Use a counting transport to verify it is actually used.
+	counter := &countingTransport{base: http.DefaultTransport}
+	p := NewCraneProvider(
+		WithTransport(counter),
+		WithCraneOptions(crane.Insecure),
+	)
+
+	dstRef := host + "/production/myimage:v1.0"
+	err := p.CopyImage(context.Background(), srcRef, dstRef)
+	require.NoError(t, err)
+
+	require.Positive(t, counter.count, "custom transport was not used")
+
+	gotDigest, err := crane.Digest(dstRef, crane.Insecure)
+	require.NoError(t, err)
+	require.Equal(t, srcDigest, gotDigest)
+}
+
+func TestCraneProviderCopyNestedImagePath(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	// Test with a nested sub-path image (e.g., "staging/kubernetes/apiserver").
+	srcRef := host + "/staging/kubernetes/apiserver:v1.30.0"
+	digest := pushRandomImage(t, srcRef)
+
+	p := newInsecureCraneProvider()
+	dstRef := host + "/production/kubernetes/apiserver:v1.30.0"
+	err := p.CopyImage(context.Background(), srcRef, dstRef)
+	require.NoError(t, err)
+
+	gotDigest, err := crane.Digest(dstRef, crane.Insecure)
+	require.NoError(t, err)
+	require.Equal(t, digest, gotDigest)
+}
+
+func TestCraneProviderPromoteImages(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+	srcRegistry := image.Registry(host + "/staging")
+	dstRegistry := image.Registry(host + "/production")
+
+	type imageEntry struct {
+		name   image.Name
+		tag    image.Tag
+		digest string // filled after push
+	}
+
+	entries := []imageEntry{
+		{name: "app", tag: "v1.0"},
+		{name: "app", tag: "v2.0"},
+		{name: "web", tag: "latest"},
+	}
+
+	// Push all test images to the staging registry.
+	for i, e := range entries {
+		ref := fmt.Sprintf("%s/%s:%s", srcRegistry, e.name, e.tag)
+		entries[i].digest = pushRandomImage(t, ref)
+	}
+
+	// Simulate the promotion flow: for each image, copy from staging
+	// to production using FQIN (source by digest) and PQIN (destination by tag),
+	// exactly as PromoteImages does.
+	p := newInsecureCraneProvider()
+
+	for _, e := range entries {
+		srcVertex := fmt.Sprintf("%s/%s@%s", srcRegistry, e.name, e.digest)
+		dstVertex := fmt.Sprintf("%s/%s:%s", dstRegistry, e.name, e.tag)
+
+		err := p.CopyImage(context.Background(), srcVertex, dstVertex)
+		require.NoError(t, err, "promoting %s to %s", srcVertex, dstVertex)
+	}
+
+	// Verify all images landed in production with correct tags and digests.
+	for _, e := range entries {
+		dstRef := fmt.Sprintf("%s/%s:%s", dstRegistry, e.name, e.tag)
+		gotDigest, err := crane.Digest(dstRef, crane.Insecure)
+		require.NoError(t, err, "verifying %s", dstRef)
+		require.Equal(t, e.digest, gotDigest, "digest mismatch for %s", dstRef)
+	}
+
+	// Verify tag listing for a multi-tag image.
+	tags, err := crane.ListTags(fmt.Sprintf("%s/app", dstRegistry), crane.Insecure)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"v1.0", "v2.0"}, tags)
+}
+
+func TestCraneProviderCopyImageIndex(t *testing.T) {
+	t.Parallel()
+
+	host := newTestRegistry(t)
+
+	// Create a random image index (multi-arch manifest list).
+	idx, err := random.Index(1024, 1, 2)
+	require.NoError(t, err)
+
+	srcRef := host + "/staging/multiarch:v1.0"
+	ref, err := name.ParseReference(srcRef, name.Insecure)
+	require.NoError(t, err)
+	err = remote.WriteIndex(ref, idx, remote.WithTransport(http.DefaultTransport))
+	require.NoError(t, err)
+
+	srcDigest, err := crane.Digest(srcRef, crane.Insecure)
+	require.NoError(t, err)
+
+	p := newInsecureCraneProvider()
+	dstRef := host + "/production/multiarch:v1.0"
+	err = p.CopyImage(context.Background(), srcRef, dstRef)
+	require.NoError(t, err)
+
+	dstDigest, err := crane.Digest(dstRef, crane.Insecure)
+	require.NoError(t, err)
+	require.Equal(t, srcDigest, dstDigest)
+}
+
+// countingTransport wraps an http.RoundTripper and counts requests.
+type countingTransport struct {
+	base  http.RoundTripper
+	count int
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.count++
+
+	resp, err := c.base.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("round trip: %w", err)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds lightweight integration tests using an in-process OCI registry to cover the CraneProvider and sign/replicate/attest phases without GCP dependencies.

#### Which issue(s) this PR fixes:

Fixes #1717

#### Special notes for your reviewer:

- `ReadRegistries` uses Google-specific APIs (`google.Walk`/`google.List`) and cannot be tested with a local registry
- CraneProvider tests use `httptest.NewServer` with plain HTTP
- Sign/replicate/attest tests use `httptest.NewTLSServer` with a rate-limited transport
- Also cleans up stale `nolint:ireturn` directives in `promoter/file/`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```