### PR TITLE
Optimize signature replication with batch tag listing

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -197,9 +198,65 @@ func (di *DefaultPromoterImplementation) signFirst(signOpts *sign.Options, ident
 	return nil
 }
 
-// ReplicateSignatures copies signatures from the primary destination registry
-// to all additional destination registries for images that were promoted to
-// multiple registries.
+// CopyFreshSignatures copies freshly created signatures from the primary
+// destination registry to all mirror registries. It copies every signature
+// unconditionally, which is optimal during inline promotion where signatures
+// were just created and mirrors are known to be empty.
+func (di *DefaultPromoterImplementation) CopyFreshSignatures(
+	opts *options.Options, edges map[promotion.Edge]any,
+) error {
+	if !opts.SignImages {
+		logrus.Info("Signing disabled, skipping signature copy")
+
+		return nil
+	}
+
+	if len(edges) == 0 {
+		logrus.Info("No images were promoted. Nothing to copy.")
+
+		return nil
+	}
+
+	multiGroups := collectMultiRegistryGroups(edges)
+	if len(multiGroups) == 0 {
+		logrus.Info("No multi-registry groups to copy")
+
+		return nil
+	}
+
+	var copies []copyItem
+
+	seen := map[string]struct{}{}
+
+	for _, group := range multiGroups {
+		src := group[0]
+		sigTag := digestToSignatureTag(src.Digest)
+		srcRef := fmt.Sprintf("%s/%s:%s",
+			src.DstRegistry.Name, src.DstImageTag.Name, sigTag)
+
+		for _, dst := range group[1:] {
+			dstRef := fmt.Sprintf("%s/%s:%s",
+				dst.DstRegistry.Name, dst.DstImageTag.Name, sigTag)
+
+			if _, ok := seen[dstRef]; ok {
+				continue
+			}
+
+			seen[dstRef] = struct{}{}
+			copies = append(copies, copyItem{srcRef, dstRef})
+		}
+	}
+
+	logrus.Infof("Copying fresh signatures for %d groups (%d copies)",
+		len(multiGroups), len(copies))
+
+	return di.executeCopies(opts, copies)
+}
+
+// ReplicateSignatures batch-lists tags for all image repositories across all
+// registries in a single concurrent pass, then copies only the signatures
+// that are missing from the mirrors. This is used by the standalone
+// replication pipeline where most signatures already exist.
 func (di *DefaultPromoterImplementation) ReplicateSignatures(
 	opts *options.Options, edges map[promotion.Edge]any,
 ) error {
@@ -210,59 +267,223 @@ func (di *DefaultPromoterImplementation) ReplicateSignatures(
 	}
 
 	if len(edges) == 0 {
-		logrus.Info("No images were promoted. Nothing to replicate.")
+		logrus.Info("No edges. Nothing to replicate.")
 
 		return nil
 	}
 
-	grouped := groupEdgesByIdentityDigest(edges)
-
-	// Count groups that need replication (more than one destination).
-	var total int
-
-	for _, group := range grouped {
-		if len(group) > 1 {
-			total++
-		}
-	}
-
-	if total == 0 {
+	multiGroups := collectMultiRegistryGroups(edges)
+	if len(multiGroups) == 0 {
 		logrus.Info("No multi-registry groups to replicate")
 
 		return nil
 	}
 
-	logrus.Infof("Replicating signatures for %d groups", total)
+	copies, err := di.computeCopiesFromInventory(multiGroups)
+	if err != nil {
+		return fmt.Errorf("computing copies from inventory: %w", err)
+	}
+
+	if len(copies) == 0 {
+		logrus.Info("All signatures already replicated")
+
+		return nil
+	}
+
+	return di.executeCopies(opts, copies)
+}
+
+// collectMultiRegistryGroups groups edges by identity+digest, keeps only
+// groups with more than one registry, and sorts them deterministically.
+func collectMultiRegistryGroups(edges map[promotion.Edge]any) [][]promotion.Edge {
+	grouped := groupEdgesByIdentityDigest(edges)
+
+	multiGroups := make([][]promotion.Edge, 0, len(grouped))
+
+	for _, group := range grouped {
+		if len(group) > 1 {
+			multiGroups = append(multiGroups, group)
+		}
+	}
+
+	sort.Slice(multiGroups, func(i, j int) bool {
+		return multiGroups[i][0].DstReference() < multiGroups[j][0].DstReference()
+	})
+
+	return multiGroups
+}
+
+// executeCopies runs the given signature copies concurrently with bounded
+// parallelism and progress logging.
+func (di *DefaultPromoterImplementation) executeCopies(
+	opts *options.Options, copies []copyItem,
+) error {
+	logrus.Infof("Copying %d signatures", len(copies))
 
 	var completed atomic.Int64
+
+	total := int64(len(copies))
 
 	g := new(errgroup.Group)
 	g.SetLimit(opts.MaxSignatureCopies)
 
-	for _, group := range grouped {
-		if len(group) <= 1 {
-			continue
-		}
-
+	for _, c := range copies {
 		g.Go(func() error {
-			ref := group[0].DstReference()
-			if err := di.replicateSignatures(&group[0], group[1:]); err != nil {
-				return err
+			craneOpts := []crane.Option{
+				crane.WithAuthFromKeychain(gcrane.Keychain),
+				crane.WithUserAgent(image.UserAgent),
+				crane.WithTransport(di.getTransport()),
 			}
 
-			logrus.Infof("Replicated group %s (%d/%d)",
-				ref, completed.Add(1), total,
-			)
+			if err := di.copyWithRetry(c.src, c.dst, craneOpts); err != nil {
+				var terr *transport.Error
+				if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+					logrus.Debugf("Signature %s not found, skipping (%d/%d)",
+						c.src, completed.Add(1), total)
+
+					return nil
+				}
+
+				return fmt.Errorf("copying signature %s to %s: %w",
+					c.src, c.dst, err)
+			}
+
+			logrus.Infof("Copied signature %s (%d/%d)",
+				c.dst, completed.Add(1), total)
 
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("replicating signatures: %w", err)
+		return fmt.Errorf("copying signatures: %w", err)
 	}
 
 	return nil
+}
+
+type copyItem struct{ src, dst string }
+
+// computeCopiesFromInventory batch-lists tags for all repositories across
+// source and mirrors in a single concurrent pass, then returns only the
+// copies where the source has a signature tag that the mirror is missing.
+func (di *DefaultPromoterImplementation) computeCopiesFromInventory(
+	multiGroups [][]promotion.Edge,
+) ([]copyItem, error) {
+	type repoKey struct{ registry, image string }
+
+	type tagSet = map[string]struct{}
+
+	allRepos := map[repoKey]struct{}{}
+
+	for _, group := range multiGroups {
+		for _, edge := range group {
+			key := repoKey{string(edge.DstRegistry.Name), string(edge.DstImageTag.Name)}
+			allRepos[key] = struct{}{}
+		}
+	}
+
+	totalRepos := len(allRepos)
+
+	logrus.Infof("Listing tags for %d repositories across %d groups",
+		totalRepos, len(multiGroups))
+
+	// Temporarily increase the rate limit during read-only listing.
+	// The AR quota is ~83 req/sec; we use 80 for headroom. The normal
+	// limit (50) is restored after the batch completes.
+	rt := di.getTransport()
+	rt.SetLimit(ratelimit.ListingLimit)
+	rt.SetBurst(ratelimit.ListingBurst)
+
+	defer func() {
+		rt.SetLimit(ratelimit.MaxEvents)
+		rt.SetBurst(ratelimit.DefaultBurst)
+	}()
+
+	allTags := make(map[repoKey]tagSet, totalRepos)
+
+	var (
+		mu     sync.Mutex
+		listed atomic.Int64
+	)
+
+	g := new(errgroup.Group)
+	g.SetLimit(ratelimit.ListingConcurrency)
+
+	for key := range allRepos {
+		g.Go(func() error {
+			tags, err := di.listTagsWithRetry(
+				fmt.Sprintf("%s/%s", key.registry, key.image),
+			)
+			if err != nil {
+				return err
+			}
+
+			set := make(tagSet, len(tags))
+			for _, t := range tags {
+				set[t] = struct{}{}
+			}
+
+			mu.Lock()
+			allTags[key] = set
+			mu.Unlock()
+
+			if n := listed.Add(1); n%1000 == 0 {
+				logrus.Infof("Listed %d/%d repositories", n, totalRepos)
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("listing repositories: %w", err)
+	}
+
+	logrus.Infof("Listed %d repositories", totalRepos)
+
+	var (
+		copies      []copyItem
+		seen        = map[string]struct{}{}
+		signedCount int
+	)
+
+	for _, group := range multiGroups {
+		src := group[0]
+		srcKey := repoKey{string(src.DstRegistry.Name), string(src.DstImageTag.Name)}
+		sigTag := digestToSignatureTag(src.Digest)
+
+		if _, ok := allTags[srcKey][sigTag]; !ok {
+			continue
+		}
+
+		signedCount++
+
+		srcRef := fmt.Sprintf("%s/%s:%s",
+			src.DstRegistry.Name, src.DstImageTag.Name, sigTag)
+
+		for _, dst := range group[1:] {
+			dstRef := fmt.Sprintf("%s/%s:%s",
+				dst.DstRegistry.Name, dst.DstImageTag.Name, sigTag)
+
+			if _, ok := seen[dstRef]; ok {
+				continue
+			}
+
+			seen[dstRef] = struct{}{}
+
+			dstKey := repoKey{string(dst.DstRegistry.Name), string(dst.DstImageTag.Name)}
+
+			if _, ok := allTags[dstKey][sigTag]; !ok {
+				copies = append(copies, copyItem{srcRef, dstRef})
+			}
+		}
+	}
+
+	logrus.Infof("Signature status: %d/%d groups signed, %d copies needed",
+		signedCount, len(multiGroups), len(copies))
+
+	return copies, nil
 }
 
 // targetIdentity returns the production identity for a promotion edge.
@@ -385,117 +606,6 @@ func digestToSignatureTag(dg image.Digest) string {
 	return strings.ReplaceAll(string(dg), "sha256:", "sha256-") + signatureTagSuffix
 }
 
-// replicateSignatures takes a source edge (an image) and a list of destinations
-// and copies the signature to all of them.
-func (di *DefaultPromoterImplementation) replicateSignatures(
-	src *promotion.Edge, dsts []promotion.Edge,
-) error {
-	sigTag := digestToSignatureTag(src.Digest)
-	sourceRefStr := fmt.Sprintf(
-		"%s/%s:%s", src.DstRegistry.Name, src.DstImageTag.Name, sigTag,
-	)
-
-	srcRef, err := name.ParseReference(sourceRefStr)
-	if err != nil {
-		return fmt.Errorf("parsing reference %q: %w", sourceRefStr, err)
-	}
-
-	// Check if the source signature exists before iterating mirrors.
-	// This avoids 20+ unnecessary HEAD requests per unsigned image.
-	if err := di.headWithRetry(srcRef); err != nil {
-		var terr *transport.Error
-		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
-			logrus.WithField("src", sourceRefStr).Debug("Source signature not found, skipping group")
-
-			return nil
-		}
-
-		return fmt.Errorf("checking source signature %s: %w", sourceRefStr, err)
-	}
-
-	logrus.WithField("src", sourceRefStr).Infof("Replicating signature to %d images", len(dsts))
-
-	dstRefs := []name.Reference{}
-
-	for i := range dsts {
-		ref, err := name.ParseReference(fmt.Sprintf(
-			"%s/%s:%s", dsts[i].DstRegistry.Name, dsts[i].DstImageTag.Name, sigTag,
-		))
-		if err != nil {
-			return fmt.Errorf("parsing signature destination reference: %w", err)
-		}
-
-		dstRefs = append(dstRefs, ref)
-	}
-
-	// Copy the signatures to the missing registries in parallel.
-	// Limit concurrency to avoid overwhelming the shared rate limiter.
-	g := new(errgroup.Group)
-	g.SetLimit(10)
-
-	for _, dstRef := range dstRefs {
-		g.Go(func() error {
-			// Skip if the signature tag already exists at the destination.
-			if _, err := remote.Head(dstRef,
-				remote.WithAuthFromKeychain(gcrane.Keychain),
-				remote.WithTransport(di.getTransport()),
-			); err == nil {
-				logrus.WithField("dst", dstRef.String()).Debug("Signature already exists, skipping")
-
-				return nil
-			}
-
-			logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.String())
-
-			opts := []crane.Option{
-				crane.WithAuthFromKeychain(gcrane.Keychain),
-				crane.WithUserAgent(image.UserAgent),
-				crane.WithTransport(di.getTransport()),
-			}
-			if err := di.copyWithRetry(srcRef.String(), dstRef.String(), opts); err != nil {
-				var terr *transport.Error
-				if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
-					logrus.Debugf("Signature %s not found, skipping", srcRef.String())
-
-					return nil
-				}
-
-				return fmt.Errorf(
-					"copying signature %s to %s: %w",
-					srcRef.String(), dstRef.String(), err,
-				)
-			}
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("replicating signatures: %w", err)
-	}
-
-	return nil
-}
-
-// headWithRetry performs a remote.Head with retries on transient errors.
-func (di *DefaultPromoterImplementation) headWithRetry(ref name.Reference) error {
-	if err := ratelimit.WithRetry(func() error {
-		_, err := remote.Head(ref,
-			remote.WithAuthFromKeychain(gcrane.Keychain),
-			remote.WithTransport(di.getTransport()),
-		)
-		if err != nil {
-			return fmt.Errorf("head: %w", err)
-		}
-
-		return nil
-	}); err != nil {
-		return fmt.Errorf("remote head %s: %w", ref.String(), err)
-	}
-
-	return nil
-}
-
 // copyWithRetry performs a crane.Copy with retries on transient errors.
 func (di *DefaultPromoterImplementation) copyWithRetry(src, dst string, opts []crane.Option) error {
 	if err := ratelimit.WithRetry(func() error {
@@ -505,6 +615,35 @@ func (di *DefaultPromoterImplementation) copyWithRetry(src, dst string, opts []c
 	}
 
 	return nil
+}
+
+// listTagsWithRetry lists all tags for a repository with retries on transient
+// errors. Returns nil (not an error) if the repository does not exist.
+func (di *DefaultPromoterImplementation) listTagsWithRetry(repo string) ([]string, error) {
+	var tags []string
+
+	if err := ratelimit.WithRetry(func() error {
+		var err error
+
+		tags, err = crane.ListTags(repo,
+			crane.WithAuthFromKeychain(gcrane.Keychain),
+			crane.WithTransport(di.getTransport()),
+		)
+		if err != nil {
+			return fmt.Errorf("listing tags for %s: %w", repo, err)
+		}
+
+		return nil
+	}); err != nil {
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("with retry: %w", err)
+	}
+
+	return tags, nil
 }
 
 // WriteSBOMs copies pre-generated SBOMs from the staging registry to each

--- a/internal/promoter/image/sign_integration_test.go
+++ b/internal/promoter/image/sign_integration_test.go
@@ -79,12 +79,12 @@ func pushTestImage(t *testing.T, di *DefaultPromoterImplementation, ref string) 
 }
 
 // testEdgeForHost constructs a promotion edge suitable for local registry tests.
-func testEdgeForHost(host, dstPath string, digest image.Digest) promotion.Edge {
+func testEdgeForHost(host string, digest image.Digest) promotion.Edge {
 	return promotion.Edge{
 		SrcRegistry: reg.Context{Name: image.Registry(host + "/staging"), Src: true},
 		SrcImageTag: promotion.ImageTag{Name: "myimage", Tag: "v1.0"},
 		Digest:      digest,
-		DstRegistry: reg.Context{Name: image.Registry(host + "/" + dstPath)},
+		DstRegistry: reg.Context{Name: image.Registry(host + "/production")},
 		DstImageTag: promotion.ImageTag{Name: "myimage", Tag: "v1.0"},
 	}
 }
@@ -106,7 +106,7 @@ func TestCopyAttachedObjectsSignatureExists(t *testing.T) {
 	sigRef := fmt.Sprintf("%s/staging/myimage:%s", host, sigTag)
 	pushTestImage(t, di, sigRef)
 
-	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	edge := testEdgeForHost(host, image.Digest(digest))
 
 	err := di.copyAttachedObjects(&edge)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestCopyAttachedObjectsSignatureMissing(t *testing.T) {
 	imgRef := host + "/staging/myimage:v1.0"
 	digest := pushTestImage(t, di, imgRef)
 
-	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	edge := testEdgeForHost(host, image.Digest(digest))
 
 	// Should gracefully succeed when no signature exists (404 is not an error).
 	err := di.copyAttachedObjects(&edge)
@@ -151,7 +151,7 @@ func TestCopySBOMExists(t *testing.T) {
 	sbomRef := fmt.Sprintf("%s/staging/myimage:%s", host, sbomTag)
 	pushTestImage(t, di, sbomRef)
 
-	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	edge := testEdgeForHost(host, image.Digest(digest))
 
 	err := di.copySBOM(&edge)
 	require.NoError(t, err)
@@ -173,79 +173,10 @@ func TestCopySBOMMissing(t *testing.T) {
 	imgRef := host + "/staging/myimage:v1.0"
 	digest := pushTestImage(t, di, imgRef)
 
-	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	edge := testEdgeForHost(host, image.Digest(digest))
 
 	// Should gracefully succeed when no SBOM exists.
 	err := di.copySBOM(&edge)
-	require.NoError(t, err)
-}
-
-// --- replicateSignatures tests ---
-
-func TestReplicateSignaturesExists(t *testing.T) {
-	t.Parallel()
-
-	host, di := newTLSTestRegistry(t)
-
-	imgRef := host + "/primary/myimage:v1.0"
-	digest := pushTestImage(t, di, imgRef)
-
-	// Push a signature to the primary destination.
-	sigTag := digestToSignatureTag(image.Digest(digest))
-	sigRef := fmt.Sprintf("%s/primary/myimage:%s", host, sigTag)
-	pushTestImage(t, di, sigRef)
-
-	// Source edge (primary destination where signature already exists).
-	srcEdge := testEdgeForHost(host, "primary", image.Digest(digest))
-
-	// Destination edges (mirrors).
-	dstEdge := testEdgeForHost(host, "mirror", image.Digest(digest))
-
-	err := di.replicateSignatures(&srcEdge, []promotion.Edge{dstEdge})
-	require.NoError(t, err)
-
-	// Verify the signature was replicated to the mirror.
-	mirrorSigRef := fmt.Sprintf("%s/mirror/myimage:%s", host, sigTag)
-	ref, err := name.ParseReference(mirrorSigRef)
-	require.NoError(t, err)
-
-	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
-	require.NoError(t, err, "signature should exist in mirror")
-}
-
-func TestReplicateSignaturesMissing(t *testing.T) {
-	t.Parallel()
-
-	host, di := newTLSTestRegistry(t)
-
-	// No signature exists at all — replication should gracefully skip.
-	digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-
-	srcEdge := testEdgeForHost(host, "primary", image.Digest(digest))
-	dstEdge := testEdgeForHost(host, "mirror", image.Digest(digest))
-
-	err := di.replicateSignatures(&srcEdge, []promotion.Edge{dstEdge})
-	require.NoError(t, err)
-}
-
-func TestReplicateSignaturesAlreadyExists(t *testing.T) {
-	t.Parallel()
-
-	host, di := newTLSTestRegistry(t)
-
-	imgRef := host + "/primary/myimage:v1.0"
-	digest := pushTestImage(t, di, imgRef)
-
-	// Push signature to both primary and mirror.
-	sigTag := digestToSignatureTag(image.Digest(digest))
-	pushTestImage(t, di, fmt.Sprintf("%s/primary/myimage:%s", host, sigTag))
-	pushTestImage(t, di, fmt.Sprintf("%s/mirror/myimage:%s", host, sigTag))
-
-	srcEdge := testEdgeForHost(host, "primary", image.Digest(digest))
-	dstEdge := testEdgeForHost(host, "mirror", image.Digest(digest))
-
-	// Should succeed without error (signature already present).
-	err := di.replicateSignatures(&srcEdge, []promotion.Edge{dstEdge})
 	require.NoError(t, err)
 }
 
@@ -268,7 +199,7 @@ func TestPushAttestation(t *testing.T) {
 	imgRef := host + "/production/myimage:v1.0"
 	digest := pushTestImage(t, di, imgRef)
 
-	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	edge := testEdgeForHost(host, image.Digest(digest))
 	record := &provenance.PromotionRecord{
 		SrcRef:    edge.SrcReference(),
 		DstRef:    edge.DstReference(),
@@ -299,7 +230,7 @@ func TestPushAttestationIdempotent(t *testing.T) {
 	imgRef := host + "/production/myimage:v1.0"
 	digest := pushTestImage(t, di, imgRef)
 
-	edge := testEdgeForHost(host, "production", image.Digest(digest))
+	edge := testEdgeForHost(host, image.Digest(digest))
 	record := &provenance.PromotionRecord{
 		SrcRef:    edge.SrcReference(),
 		DstRef:    edge.DstReference(),
@@ -325,9 +256,6 @@ func TestDigestToAttestationTag(t *testing.T) {
 	require.Equal(t, "sha256-abc123.att", tag)
 	require.True(t, strings.HasSuffix(tag, attestationTagSuffix))
 }
-
-// --- copyWithRetry / headWithRetry are exercised by the above tests
-// through replicateSignatures and copyAttachedObjects. ---
 
 // --- Integration test for the full promotion flow with CraneProvider ---
 
@@ -399,4 +327,308 @@ func TestPromoteImagesCraneProvider(t *testing.T) {
 	tags, err := remote.List(repo, remote.WithTransport(di.getTransport()))
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"v1.0", "v2.0"}, tags)
+}
+
+// --- CopyFreshSignatures integration tests ---
+
+// TestCopyFreshSignaturesCopiesUnconditionally verifies that CopyFreshSignatures
+// copies signatures from the primary to all mirrors without checking whether
+// they already exist. This exercises the inline promotion path.
+func TestCopyFreshSignaturesCopiesUnconditionally(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror1 := prodPath("bb-mirror1")
+	mirror2 := prodPath("bb-mirror2")
+
+	// Push an image and its signature to the primary.
+	digest := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	sigTag := digestToSignatureTag(image.Digest(digest))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag))
+
+	// Push images to mirrors (no signatures).
+	pushTestImage(t, di, host+"/"+mirror1+"/app:v1.0")
+	pushTestImage(t, di, host+"/"+mirror2+"/app:v1.0")
+
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(digest)): nil,
+		makeProdEdge(host, "bb-mirror1", "app", "v1.0", image.Digest(digest)): nil,
+		makeProdEdge(host, "bb-mirror2", "app", "v1.0", image.Digest(digest)): nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	err := di.CopyFreshSignatures(opts, edges)
+	require.NoError(t, err)
+
+	// Verify signatures landed on both mirrors.
+	for _, m := range []string{mirror1, mirror2} {
+		refStr := fmt.Sprintf("%s/%s/app:%s", host, m, sigTag)
+		ref, err := name.ParseReference(refStr)
+		require.NoError(t, err)
+
+		_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+		require.NoError(t, err, "signature should exist on %s", m)
+	}
+}
+
+// --- ReplicateSignatures (batch-listing path) integration tests ---
+
+// prodPath returns a registry path that includes the production repository
+// path so that targetIdentity normalizes all mirrors to the same identity
+// (registry.k8s.io/<image>). This mirrors real-world registries like
+// "us-west2-docker.pkg.dev/k8s-artifacts-prod/images".
+func prodPath(prefix string) string {
+	return prefix + "/k8s-artifacts-prod/images"
+}
+
+// makeProdEdge constructs a promotion edge using production-like registry
+// paths so that edges across different registries share the same identity.
+func makeProdEdge(host, dstPrefix, imgName string, tag image.Tag, digest image.Digest) promotion.Edge {
+	return promotion.Edge{
+		SrcRegistry: reg.Context{Name: image.Registry(host + "/" + prodPath("staging")), Src: true},
+		SrcImageTag: promotion.ImageTag{Name: image.Name(imgName), Tag: tag},
+		Digest:      digest,
+		DstRegistry: reg.Context{Name: image.Registry(host + "/" + prodPath(dstPrefix))},
+		DstImageTag: promotion.ImageTag{Name: image.Name(imgName), Tag: tag},
+	}
+}
+
+// TestReplicateSignaturesBatchCopiesMissing verifies that the batch-listing
+// ReplicateSignatures method copies signatures that exist on the primary
+// registry but are missing from the mirrors.
+//
+// Registry prefixes are chosen so that "aa-primary" sorts alphabetically
+// before "bb-mirror*", matching the groupEdgesByIdentityDigest convention
+// where group[0] is the source (alphabetically first).
+func TestReplicateSignaturesBatchCopiesMissing(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror1 := prodPath("bb-mirror1")
+	mirror2 := prodPath("bb-mirror2")
+
+	// Push two images to the primary registry.
+	d1 := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	d2 := pushTestImage(t, di, host+"/"+primary+"/app:v2.0")
+
+	// Push signatures only to the primary.
+	sigTag1 := digestToSignatureTag(image.Digest(d1))
+	sigTag2 := digestToSignatureTag(image.Digest(d2))
+
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag1))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag2))
+
+	// Also push the images to the mirrors (but NOT the signatures).
+	pushTestImage(t, di, host+"/"+mirror1+"/app:v1.0")
+	pushTestImage(t, di, host+"/"+mirror1+"/app:v2.0")
+	pushTestImage(t, di, host+"/"+mirror2+"/app:v1.0")
+	pushTestImage(t, di, host+"/"+mirror2+"/app:v2.0")
+
+	// Build edges: each image exists in primary + 2 mirrors.
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(d1)): nil,
+		makeProdEdge(host, "bb-mirror1", "app", "v1.0", image.Digest(d1)): nil,
+		makeProdEdge(host, "bb-mirror2", "app", "v1.0", image.Digest(d1)): nil,
+		makeProdEdge(host, "aa-primary", "app", "v2.0", image.Digest(d2)): nil,
+		makeProdEdge(host, "bb-mirror1", "app", "v2.0", image.Digest(d2)): nil,
+		makeProdEdge(host, "bb-mirror2", "app", "v2.0", image.Digest(d2)): nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	err := di.ReplicateSignatures(opts, edges)
+	require.NoError(t, err)
+
+	// Verify signatures landed on both mirrors for both images.
+	for _, st := range []string{sigTag1, sigTag2} {
+		for _, m := range []string{mirror1, mirror2} {
+			refStr := fmt.Sprintf("%s/%s/app:%s", host, m, st)
+			ref, err := name.ParseReference(refStr)
+			require.NoError(t, err)
+
+			_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+			require.NoError(t, err, "signature %s should exist on %s", st, m)
+		}
+	}
+}
+
+// TestReplicateSignaturesBatchSkipsExisting verifies that the batch-listing
+// path correctly skips signatures that already exist on the mirrors.
+func TestReplicateSignaturesBatchSkipsExisting(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror := prodPath("bb-mirror")
+
+	digest := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	sigTag := digestToSignatureTag(image.Digest(digest))
+
+	// Push the signature to primary AND mirror (already replicated).
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, mirror, sigTag))
+
+	// Also push the images to the mirror.
+	pushTestImage(t, di, host+"/"+mirror+"/app:v1.0")
+
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(digest)): nil,
+		makeProdEdge(host, "bb-mirror", "app", "v1.0", image.Digest(digest)):  nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	// Should succeed and report "All signatures already replicated".
+	err := di.ReplicateSignatures(opts, edges)
+	require.NoError(t, err)
+}
+
+// TestReplicateSignaturesBatchNoSignature verifies that edges without a
+// signature on the primary are gracefully skipped.
+func TestReplicateSignaturesBatchNoSignature(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror := prodPath("bb-mirror")
+
+	// Push images but NO signatures.
+	digest := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	pushTestImage(t, di, host+"/"+mirror+"/app:v1.0")
+
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(digest)): nil,
+		makeProdEdge(host, "bb-mirror", "app", "v1.0", image.Digest(digest)):  nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	// Should succeed — no signatures to copy.
+	err := di.ReplicateSignatures(opts, edges)
+	require.NoError(t, err)
+
+	// Verify no signature appeared on the mirror.
+	sigTag := digestToSignatureTag(image.Digest(digest))
+	refStr := fmt.Sprintf("%s/%s/app:%s", host, mirror, sigTag)
+	ref, err := name.ParseReference(refStr)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.Error(t, err, "signature should NOT exist on mirror")
+}
+
+// TestReplicateSignaturesBatchMultipleImages verifies batch listing across
+// different image repositories within the same registries.
+func TestReplicateSignaturesBatchMultipleImages(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror := prodPath("bb-mirror")
+
+	// Two different images with different digests.
+	d1 := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	d2 := pushTestImage(t, di, host+"/"+primary+"/web:latest")
+
+	// Push signatures to primary only.
+	sigTag1 := digestToSignatureTag(image.Digest(d1))
+	sigTag2 := digestToSignatureTag(image.Digest(d2))
+
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag1))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/web:%s", host, primary, sigTag2))
+
+	// Push images to mirror (no signatures).
+	pushTestImage(t, di, host+"/"+mirror+"/app:v1.0")
+	pushTestImage(t, di, host+"/"+mirror+"/web:latest")
+
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(d1)):   nil,
+		makeProdEdge(host, "bb-mirror", "app", "v1.0", image.Digest(d1)):    nil,
+		makeProdEdge(host, "aa-primary", "web", "latest", image.Digest(d2)): nil,
+		makeProdEdge(host, "bb-mirror", "web", "latest", image.Digest(d2)):  nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	err := di.ReplicateSignatures(opts, edges)
+	require.NoError(t, err)
+
+	// Verify both signatures landed on the mirror.
+	for _, tc := range []struct {
+		img    string
+		sigTag string
+	}{
+		{"app", sigTag1},
+		{"web", sigTag2},
+	} {
+		refStr := fmt.Sprintf("%s/%s/%s:%s", host, mirror, tc.img, tc.sigTag)
+		ref, err := name.ParseReference(refStr)
+		require.NoError(t, err)
+
+		_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+		require.NoError(t, err, "signature for %s should exist on mirror", tc.img)
+	}
+}
+
+// TestReplicateSignaturesBatchIdempotent verifies that running
+// ReplicateSignatures twice produces the same result (idempotent).
+func TestReplicateSignaturesBatchIdempotent(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror := prodPath("bb-mirror")
+
+	digest := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	sigTag := digestToSignatureTag(image.Digest(digest))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag))
+	pushTestImage(t, di, host+"/"+mirror+"/app:v1.0")
+
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(digest)): nil,
+		makeProdEdge(host, "bb-mirror", "app", "v1.0", image.Digest(digest)):  nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	// Run twice — both should succeed.
+	for i := range 2 {
+		err := di.ReplicateSignatures(opts, edges)
+		require.NoError(t, err, "run %d", i+1)
+	}
+
+	// Verify signature exists on mirror.
+	refStr := fmt.Sprintf("%s/%s/app:%s", host, mirror, sigTag)
+	ref, err := name.ParseReference(refStr)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err, "signature should exist on mirror")
 }

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -54,6 +54,18 @@ type FakePromoterImplementation struct {
 		result1 []schema.Manifest
 		result2 error
 	}
+	CopyFreshSignaturesStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
+	copyFreshSignaturesMutex       sync.RWMutex
+	copyFreshSignaturesArgsForCall []struct {
+		arg1 *imagepromotera.Options
+		arg2 map[promotion.Edge]any
+	}
+	copyFreshSignaturesReturns struct {
+		result1 error
+	}
+	copyFreshSignaturesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	EdgesFromManifestsStub        func([]schema.Manifest) (map[promotion.Edge]any, error)
 	edgesFromManifestsMutex       sync.RWMutex
 	edgesFromManifestsArgsForCall []struct {
@@ -445,6 +457,68 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i 
 		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakePromoterImplementation) CopyFreshSignatures(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
+	fake.copyFreshSignaturesMutex.Lock()
+	ret, specificReturn := fake.copyFreshSignaturesReturnsOnCall[len(fake.copyFreshSignaturesArgsForCall)]
+	fake.copyFreshSignaturesArgsForCall = append(fake.copyFreshSignaturesArgsForCall, struct {
+		arg1 *imagepromotera.Options
+		arg2 map[promotion.Edge]any
+	}{arg1, arg2})
+	stub := fake.CopyFreshSignaturesStub
+	fakeReturns := fake.copyFreshSignaturesReturns
+	fake.recordInvocation("CopyFreshSignatures", []interface{}{arg1, arg2})
+	fake.copyFreshSignaturesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePromoterImplementation) CopyFreshSignaturesCallCount() int {
+	fake.copyFreshSignaturesMutex.RLock()
+	defer fake.copyFreshSignaturesMutex.RUnlock()
+	return len(fake.copyFreshSignaturesArgsForCall)
+}
+
+func (fake *FakePromoterImplementation) CopyFreshSignaturesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
+	fake.copyFreshSignaturesMutex.Lock()
+	defer fake.copyFreshSignaturesMutex.Unlock()
+	fake.CopyFreshSignaturesStub = stub
+}
+
+func (fake *FakePromoterImplementation) CopyFreshSignaturesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
+	fake.copyFreshSignaturesMutex.RLock()
+	defer fake.copyFreshSignaturesMutex.RUnlock()
+	argsForCall := fake.copyFreshSignaturesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePromoterImplementation) CopyFreshSignaturesReturns(result1 error) {
+	fake.copyFreshSignaturesMutex.Lock()
+	defer fake.copyFreshSignaturesMutex.Unlock()
+	fake.CopyFreshSignaturesStub = nil
+	fake.copyFreshSignaturesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePromoterImplementation) CopyFreshSignaturesReturnsOnCall(i int, result1 error) {
+	fake.copyFreshSignaturesMutex.Lock()
+	defer fake.copyFreshSignaturesMutex.Unlock()
+	fake.CopyFreshSignaturesStub = nil
+	if fake.copyFreshSignaturesReturnsOnCall == nil {
+		fake.copyFreshSignaturesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.copyFreshSignaturesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakePromoterImplementation) EdgesFromManifests(arg1 []schema.Manifest) (map[promotion.Edge]any, error) {

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -120,6 +120,7 @@ type promoterImplementation interface {
 	PrewarmTUFCache() error
 	ValidateStagingSignatures(map[promotion.Edge]any) (map[promotion.Edge]any, error)
 	SignImages(*options.Options, map[promotion.Edge]any) error
+	CopyFreshSignatures(*options.Options, map[promotion.Edge]any) error
 	ReplicateSignatures(*options.Options, map[promotion.Edge]any) error
 	WriteSBOMs(*options.Options, map[promotion.Edge]any) error
 	WriteProvenanceAttestations(*options.Options, map[promotion.Edge]any, provenance.Generator) error
@@ -254,10 +255,10 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 		return nil
 	}))
 
-	// Replicate phase: copy signatures to mirror registries.
+	// Replicate phase: copy freshly created signatures to mirror registries.
 	pipe.AddPhase(pipeline.NewPhase("replicate", func(_ context.Context) error {
-		if err := p.impl.ReplicateSignatures(opts, promotionEdges); err != nil {
-			return fmt.Errorf("replicating signatures: %w", err)
+		if err := p.impl.CopyFreshSignatures(opts, promotionEdges); err != nil {
+			return fmt.Errorf("copying fresh signatures: %w", err)
 		}
 
 		return nil
@@ -453,7 +454,7 @@ func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Option
 		return nil
 	}))
 
-	// Replicate phase: copy signatures to mirror registries.
+	// Replicate phase: batch-list tags and copy only missing signatures.
 	pipe.AddPhase(pipeline.NewPhase("replicate", func(_ context.Context) error {
 		if err := p.impl.ReplicateSignatures(opts, promotionEdges); err != nil {
 			return fmt.Errorf("replicating signatures: %w", err)

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -104,11 +104,11 @@ func TestPromoteImages(t *testing.T) {
 			},
 		},
 		{
-			// ReplicateSignatures fails
+			// CopyFreshSignatures fails
 			shouldErr: true,
-			msg:       "ReplicateSignatures fails",
+			msg:       "CopyFreshSignatures fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
-				fpi.ReplicateSignaturesReturns(testErr)
+				fpi.CopyFreshSignaturesReturns(testErr)
 			},
 		},
 		{

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -38,6 +38,18 @@ const (
 	// target to leave headroom for retries and other API consumers.
 	MaxEvents rate.Limit = 50
 
+	// ListingLimit is a higher rate limit used during read-only phases
+	// (e.g. batch tag listing) where no write operations compete for
+	// quota. Still below the AR hard limit of ~83 req/sec.
+	ListingLimit rate.Limit = 80
+
+	// ListingBurst allows higher burst during listing phases.
+	ListingBurst = 10
+
+	// ListingConcurrency is the maximum number of concurrent goroutines
+	// during read-only listing phases.
+	ListingConcurrency = 80
+
 	// backoffDuration is how long to pause after receiving a 429 response.
 	backoffDuration = 10 * time.Second
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Optimizes image signature replication by splitting `ReplicateSignatures` into two code paths:

- **Inline promotion**: copies all signatures directly without existence checks (freshly created)
- **Standalone replicate**: batch-lists tags across all repositories at higher rate limits (80 req/sec, 80 concurrency), filters locally, copies only missing signatures

Replaces per-group HEAD requests with per-repository tag listings, reducing API calls from O(groups × mirrors) to O(unique_repos × registries).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Optimize signature replication by splitting into two paths: inline promotion copies signatures unconditionally, while standalone replication batch-lists tags and copies only missing signatures, reducing API calls significantly.
```