### PR TITLE
Remove inline signature replication from promotion pipeline

### DIFF
--- a/docs/image-promotion.md
+++ b/docs/image-promotion.md
@@ -173,8 +173,7 @@ The promotion flow is organized into sequential pipeline phases:
 | 4 | **validate** | Validate staging image signatures |
 | 5 | **promote** | Copy images from staging to production |
 | 6 | **sign** | Sign promoted images with cosign (primary registry only) |
-| 7 | **replicate** | Copy signatures to mirror registries (see [Standalone signature replication](#standalone-signature-replication)) |
-| 8 | **attest** | Copy pre-generated SBOMs from staging to production, generate promotion provenance |
+| 7 | **attest** | Copy pre-generated SBOMs from staging to production, generate promotion provenance |
 
 Without `--confirm`, the pipeline stops after the validate phase (dry-run
 precheck). With `--parse-only`, it stops after parsing manifests.
@@ -201,7 +200,9 @@ pushed back up. This is important for two reasons:
 
 After promotion, images are signed using [cosign](https://github.com/sigstore/cosign)
 with a keyless (OIDC) identity. Signatures are replicated to all mirror
-registries. The signing identity is configured with `--signer-account`.
+registries by a dedicated periodic Prow job (see
+[Standalone signature replication](#standalone-signature-replication)).
+The signing identity is configured with `--signer-account`.
 
 Pre-generated SBOMs are copied from staging to production using the cosign SBOM
 tag convention (`sha256-<hash>.sbom`). Missing SBOMs are skipped gracefully.
@@ -218,9 +219,9 @@ Related flags:
 ## Standalone signature replication
 
 When images are promoted to multiple mirror registries, signatures must be
-replicated from the primary registry to all mirrors. This normally happens
-inline during promotion (in the sign phase), but can also be run standalone
-via the `replicate-signatures` subcommand:
+replicated from the primary registry to all mirrors. This is handled by a
+dedicated periodic Prow job ([`ci-k8sio-image-signature-replication`](https://prow.k8s.io/?job=ci-k8sio-image-signature-replication)) using
+the `replicate-signatures` subcommand:
 
 ```console
 kpromo cip replicate-signatures \
@@ -233,9 +234,12 @@ computes edges, but does not copy any signatures.
 
 The standalone mode reads **all** edges from the manifests (not just unsynced
 ones), so it works even when images were promoted long ago. Each signature copy
-is idempotent -- existing signatures are detected via a HEAD request and
-skipped. This makes it safe to run frequently (e.g. via a periodic Prow job)
-alongside the main promotion pipeline.
+is idempotent -- existing signatures are detected via batch tag listing and
+skipped. This makes it safe to run frequently via the periodic Prow job.
+
+Job health dashboards:
+- [sig-release-releng-informing](https://testgrid.k8s.io/sig-release-releng-informing#ci-k8sio-image-signature-replication)
+- [sig-k8s-infra-k8sio](https://testgrid.k8s.io/sig-k8s-infra-k8sio#ci-k8sio-image-signature-replication)
 
 ## Provenance verification
 

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -198,61 +198,6 @@ func (di *DefaultPromoterImplementation) signFirst(signOpts *sign.Options, ident
 	return nil
 }
 
-// CopyFreshSignatures copies freshly created signatures from the primary
-// destination registry to all mirror registries. It copies every signature
-// unconditionally, which is optimal during inline promotion where signatures
-// were just created and mirrors are known to be empty.
-func (di *DefaultPromoterImplementation) CopyFreshSignatures(
-	opts *options.Options, edges map[promotion.Edge]any,
-) error {
-	if !opts.SignImages {
-		logrus.Info("Signing disabled, skipping signature copy")
-
-		return nil
-	}
-
-	if len(edges) == 0 {
-		logrus.Info("No images were promoted. Nothing to copy.")
-
-		return nil
-	}
-
-	multiGroups := collectMultiRegistryGroups(edges)
-	if len(multiGroups) == 0 {
-		logrus.Info("No multi-registry groups to copy")
-
-		return nil
-	}
-
-	var copies []copyItem
-
-	seen := map[string]struct{}{}
-
-	for _, group := range multiGroups {
-		src := group[0]
-		sigTag := digestToSignatureTag(src.Digest)
-		srcRef := fmt.Sprintf("%s/%s:%s",
-			src.DstRegistry.Name, src.DstImageTag.Name, sigTag)
-
-		for _, dst := range group[1:] {
-			dstRef := fmt.Sprintf("%s/%s:%s",
-				dst.DstRegistry.Name, dst.DstImageTag.Name, sigTag)
-
-			if _, ok := seen[dstRef]; ok {
-				continue
-			}
-
-			seen[dstRef] = struct{}{}
-			copies = append(copies, copyItem{srcRef, dstRef})
-		}
-	}
-
-	logrus.Infof("Copying fresh signatures for %d groups (%d copies)",
-		len(multiGroups), len(copies))
-
-	return di.executeCopies(opts, copies)
-}
-
 // ReplicateSignatures batch-lists tags for all image repositories across all
 // registries in a single concurrent pass, then copies only the signatures
 // that are missing from the mirrors. This is used by the standalone

--- a/internal/promoter/image/sign_integration_test.go
+++ b/internal/promoter/image/sign_integration_test.go
@@ -329,54 +329,6 @@ func TestPromoteImagesCraneProvider(t *testing.T) {
 	require.ElementsMatch(t, []string{"v1.0", "v2.0"}, tags)
 }
 
-// --- CopyFreshSignatures integration tests ---
-
-// TestCopyFreshSignaturesCopiesUnconditionally verifies that CopyFreshSignatures
-// copies signatures from the primary to all mirrors without checking whether
-// they already exist. This exercises the inline promotion path.
-func TestCopyFreshSignaturesCopiesUnconditionally(t *testing.T) {
-	t.Parallel()
-
-	host, di := newTLSTestRegistry(t)
-
-	primary := prodPath("aa-primary")
-	mirror1 := prodPath("bb-mirror1")
-	mirror2 := prodPath("bb-mirror2")
-
-	// Push an image and its signature to the primary.
-	digest := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
-	sigTag := digestToSignatureTag(image.Digest(digest))
-	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTag))
-
-	// Push images to mirrors (no signatures).
-	pushTestImage(t, di, host+"/"+mirror1+"/app:v1.0")
-	pushTestImage(t, di, host+"/"+mirror2+"/app:v1.0")
-
-	edges := map[promotion.Edge]any{
-		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(digest)): nil,
-		makeProdEdge(host, "bb-mirror1", "app", "v1.0", image.Digest(digest)): nil,
-		makeProdEdge(host, "bb-mirror2", "app", "v1.0", image.Digest(digest)): nil,
-	}
-
-	opts := &options.Options{
-		SignImages:         true,
-		MaxSignatureCopies: 10,
-	}
-
-	err := di.CopyFreshSignatures(opts, edges)
-	require.NoError(t, err)
-
-	// Verify signatures landed on both mirrors.
-	for _, m := range []string{mirror1, mirror2} {
-		refStr := fmt.Sprintf("%s/%s/app:%s", host, m, sigTag)
-		ref, err := name.ParseReference(refStr)
-		require.NoError(t, err)
-
-		_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
-		require.NoError(t, err, "signature should exist on %s", m)
-	}
-}
-
 // --- ReplicateSignatures (batch-listing path) integration tests ---
 
 // prodPath returns a registry path that includes the production repository

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -54,18 +54,6 @@ type FakePromoterImplementation struct {
 		result1 []schema.Manifest
 		result2 error
 	}
-	CopyFreshSignaturesStub        func(*imagepromotera.Options, map[promotion.Edge]any) error
-	copyFreshSignaturesMutex       sync.RWMutex
-	copyFreshSignaturesArgsForCall []struct {
-		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]any
-	}
-	copyFreshSignaturesReturns struct {
-		result1 error
-	}
-	copyFreshSignaturesReturnsOnCall map[int]struct {
-		result1 error
-	}
 	EdgesFromManifestsStub        func([]schema.Manifest) (map[promotion.Edge]any, error)
 	edgesFromManifestsMutex       sync.RWMutex
 	edgesFromManifestsArgsForCall []struct {
@@ -457,68 +445,6 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i 
 		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *FakePromoterImplementation) CopyFreshSignatures(arg1 *imagepromotera.Options, arg2 map[promotion.Edge]any) error {
-	fake.copyFreshSignaturesMutex.Lock()
-	ret, specificReturn := fake.copyFreshSignaturesReturnsOnCall[len(fake.copyFreshSignaturesArgsForCall)]
-	fake.copyFreshSignaturesArgsForCall = append(fake.copyFreshSignaturesArgsForCall, struct {
-		arg1 *imagepromotera.Options
-		arg2 map[promotion.Edge]any
-	}{arg1, arg2})
-	stub := fake.CopyFreshSignaturesStub
-	fakeReturns := fake.copyFreshSignaturesReturns
-	fake.recordInvocation("CopyFreshSignatures", []interface{}{arg1, arg2})
-	fake.copyFreshSignaturesMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakePromoterImplementation) CopyFreshSignaturesCallCount() int {
-	fake.copyFreshSignaturesMutex.RLock()
-	defer fake.copyFreshSignaturesMutex.RUnlock()
-	return len(fake.copyFreshSignaturesArgsForCall)
-}
-
-func (fake *FakePromoterImplementation) CopyFreshSignaturesCalls(stub func(*imagepromotera.Options, map[promotion.Edge]any) error) {
-	fake.copyFreshSignaturesMutex.Lock()
-	defer fake.copyFreshSignaturesMutex.Unlock()
-	fake.CopyFreshSignaturesStub = stub
-}
-
-func (fake *FakePromoterImplementation) CopyFreshSignaturesArgsForCall(i int) (*imagepromotera.Options, map[promotion.Edge]any) {
-	fake.copyFreshSignaturesMutex.RLock()
-	defer fake.copyFreshSignaturesMutex.RUnlock()
-	argsForCall := fake.copyFreshSignaturesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakePromoterImplementation) CopyFreshSignaturesReturns(result1 error) {
-	fake.copyFreshSignaturesMutex.Lock()
-	defer fake.copyFreshSignaturesMutex.Unlock()
-	fake.CopyFreshSignaturesStub = nil
-	fake.copyFreshSignaturesReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakePromoterImplementation) CopyFreshSignaturesReturnsOnCall(i int, result1 error) {
-	fake.copyFreshSignaturesMutex.Lock()
-	defer fake.copyFreshSignaturesMutex.Unlock()
-	fake.CopyFreshSignaturesStub = nil
-	if fake.copyFreshSignaturesReturnsOnCall == nil {
-		fake.copyFreshSignaturesReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.copyFreshSignaturesReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakePromoterImplementation) EdgesFromManifests(arg1 []schema.Manifest) (map[promotion.Edge]any, error) {

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -120,7 +120,6 @@ type promoterImplementation interface {
 	PrewarmTUFCache() error
 	ValidateStagingSignatures(map[promotion.Edge]any) (map[promotion.Edge]any, error)
 	SignImages(*options.Options, map[promotion.Edge]any) error
-	CopyFreshSignatures(*options.Options, map[promotion.Edge]any) error
 	ReplicateSignatures(*options.Options, map[promotion.Edge]any) error
 	WriteSBOMs(*options.Options, map[promotion.Edge]any) error
 	WriteProvenanceAttestations(*options.Options, map[promotion.Edge]any, provenance.Generator) error
@@ -250,15 +249,6 @@ func (p *Promoter) PromoteImages(ctx context.Context, opts *options.Options) err
 	pipe.AddPhase(pipeline.NewPhase("sign", func(_ context.Context) error {
 		if err := p.impl.SignImages(opts, promotionEdges); err != nil {
 			return fmt.Errorf("signing images: %w", err)
-		}
-
-		return nil
-	}))
-
-	// Replicate phase: copy freshly created signatures to mirror registries.
-	pipe.AddPhase(pipeline.NewPhase("replicate", func(_ context.Context) error {
-		if err := p.impl.CopyFreshSignatures(opts, promotionEdges); err != nil {
-			return fmt.Errorf("copying fresh signatures: %w", err)
 		}
 
 		return nil
@@ -404,9 +394,8 @@ func (p *Promoter) CheckSignatures(opts *options.Options) error {
 
 // ReplicateSignatures is a standalone mode that copies image signatures
 // from the primary destination registry to all mirror registries.
-// Unlike the inline replicate phase in PromoteImages, this method reads
-// ALL edges from manifests (not just unsynced ones) so it can run
-// independently of the promotion job.
+// It reads ALL edges from manifests (not just unsynced ones) so it can
+// run independently of the promotion job.
 func (p *Promoter) ReplicateSignatures(ctx context.Context, opts *options.Options) error {
 	var promotionEdges map[promotion.Edge]any
 

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -104,14 +104,6 @@ func TestPromoteImages(t *testing.T) {
 			},
 		},
 		{
-			// CopyFreshSignatures fails
-			shouldErr: true,
-			msg:       "CopyFreshSignatures fails",
-			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
-				fpi.CopyFreshSignaturesReturns(testErr)
-			},
-		},
-		{
 			// WriteSBOMs fails
 			shouldErr: true,
 			msg:       "WriteSBOMs fails",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove the inline `replicate` phase from the `PromoteImages()` pipeline. Signature replication is now handled by the dedicated periodic `ci-k8sio-image-signature-replication` Prow job using `kpromo cip replicate-signatures`.

The promotion pipeline drops from 8 to 7 phases:
setup → plan → provenance → validate → promote → sign → attest

#### Which issue(s) this PR fixes:

Part of #1714

#### Special notes for your reviewer:

The periodic replication job has been verified to work correctly, completing in ~11 minutes and processing 987k edges with 0 errors. A subsequent idempotent run confirmed all signatures were replicated (`0 copies needed`).

#### Does this PR introduce a user-facing change?

```release-note
Remove inline signature replication from the promotion pipeline in favor of the dedicated periodic ci-k8sio-image-signature-replication Prow job.
```