### PR TITLE
Fix typos across the codebase

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -61,7 +61,7 @@ mapfile -t packages < <(go list ./... | grep -v 'sigs.k8s.io/promo-tools/cmd\|te
 
 export GO111MODULE=on
 
-# If the user rquests failing fast (so that they can iterate on the failing test
+# If the user requests failing fast (so that they can iterate on the failing test
 # quickly without having to swim across the verbose log outputs from parallel
 # tests), then iterate through each module serially.
 if [[ -n "${TEST_FAILFAST:-}" ]]; then

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -23,7 +23,7 @@ URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=${URL_BASE}/${VERSION}/install.sh
 # If you update the version above you might need to update the checksum
 # if it does not match. We say might because in the past the install script
-# has been unchanged even if there is a new verion of golangci-lint.
+# has been unchanged even if there is a new version of golangci-lint.
 # To obtain the checksum, download the install script and run the following
 # command:
 # > sha256sum <path-to-install-script>

--- a/image/image.go
+++ b/image/image.go
@@ -85,7 +85,7 @@ func (imagesList *ManifestList) ToYAML() ([]byte, error) {
 	// Images are sorted by:
 	//	  1. Name 2. Tag
 	// If there are multiple tags for a single image digest, the smallest tag is used in the sort.''
-	// Image tags are sorted lexicographically as they are not guaranteed to be Semver compliant. See https://github.com/opencontainers/distribution-spec/issues/154 fpr more details.
+	// Image tags are sorted lexicographically as they are not guaranteed to be Semver compliant. See https://github.com/opencontainers/distribution-spec/issues/154 for more details.
 
 	// First, sort by name (sort #1)
 	sort.Slice(*imagesList, func(i, j int) bool {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -34,7 +34,7 @@ func TestNewManifestListFromFile(t *testing.T) {
 	require.NoError(t, err, "creating temp file")
 
 	_, err = tempFile.WriteString(listYAML)
-	require.NoError(t, err, "wrinting temporary promoter image list")
+	require.NoError(t, err, "writing temporary promoter image list")
 
 	imageList, err := NewManifestListFromFile(tempFile.Name())
 	require.NoError(t, err)

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
-const vulnerabilityDiscalimer = `DISCLAIMER: Vulnerabilities are found as issues with package
+const vulnerabilityDisclaimer = `DISCLAIMER: Vulnerabilities are found as issues with package
 binaries within image layers, not necessarily with the image layers themselves.
 So a 'fixable' vulnerability may not necessarily be immediately actionable. For
 example, even though a fixed version of the binary is available, it doesn't
@@ -153,7 +153,7 @@ func (di *DefaultPromoterImplementation) PrintVersion() {
 // PrintSecDisclaimer prints a disclaimer about false positives
 // that may be found in container image layers.
 func (di *DefaultPromoterImplementation) PrintSecDisclaimer() {
-	logrus.Info(vulnerabilityDiscalimer)
+	logrus.Info(vulnerabilityDisclaimer)
 }
 
 // getTransport returns the rate-limited transport.

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -76,7 +76,7 @@ type Options struct {
 	// before promoting or generating a snapshot when set to true
 	ParseOnly bool
 
-	// When tru, sign the container images using the sigstore cosign libraries
+	// When true, sign the container images using the sigstore cosign libraries
 	SignImages bool
 
 	// SignerAccount is a service account that will provide the identity


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Fix various typos found via `typos-cli` across Go source, tests, and shell scripts.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```