### PR TITLE
Adopt remote.Reuse for OCI operations

### DIFF
--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/release-sdk/sign"
 	"sigs.k8s.io/release-utils/version"
@@ -48,6 +49,12 @@ type DefaultPromoterImplementation struct {
 	// transport is the rate-limited HTTP transport shared by all phases.
 	transport *ratelimit.RoundTripper
 
+	// puller reuses HTTP auth/transport state across pull operations.
+	puller *remote.Puller
+
+	// pusher reuses HTTP auth/transport state across push operations.
+	pusher *remote.Pusher
+
 	// registryProvider abstracts registry operations (read inventory, copy images).
 	registryProvider registry.Provider
 
@@ -68,9 +75,11 @@ func NewDefaultPromoterImplementation(opts *options.Options) *DefaultPromoterImp
 	}
 }
 
-// SetTransport sets the rate-limited HTTP transport for all phases.
+// SetTransport sets the rate-limited HTTP transport for all phases
+// and initializes the shared puller/pusher for connection reuse.
 func (di *DefaultPromoterImplementation) SetTransport(rt *ratelimit.RoundTripper) {
 	di.transport = rt
+	di.initRemote()
 }
 
 // SetRegistryProvider sets the registry provider for image operations.
@@ -161,15 +170,75 @@ func (di *DefaultPromoterImplementation) getTransport() *ratelimit.RoundTripper 
 	return di.transport
 }
 
+// initRemote creates a shared puller and pusher that reuse HTTP
+// auth/transport state across OCI operations.
+func (di *DefaultPromoterImplementation) initRemote() {
+	remoteOpts := di.remoteOptions()
+
+	if p, err := remote.NewPuller(remoteOpts...); err == nil {
+		di.puller = p
+	} else {
+		logrus.Warnf("Failed to create shared puller: %v", err)
+	}
+
+	if p, err := remote.NewPusher(remoteOpts...); err == nil {
+		di.pusher = p
+	} else {
+		logrus.Warnf("Failed to create shared pusher: %v", err)
+	}
+}
+
+// remoteOptions returns common remote options for OCI operations,
+// including authentication, user-agent, transport, and reuse of
+// puller/pusher state when available.
+func (di *DefaultPromoterImplementation) remoteOptions() []remote.Option {
+	opts := []remote.Option{
+		remote.WithAuthFromKeychain(gcrane.Keychain),
+		remote.WithUserAgent(image.UserAgent),
+	}
+
+	if di.transport != nil {
+		opts = append(opts, remote.WithTransport(di.transport))
+	}
+
+	if di.puller != nil {
+		opts = append(opts, remote.Reuse(di.puller))
+	}
+
+	if di.pusher != nil {
+		opts = append(opts, remote.Reuse(di.pusher))
+	}
+
+	return opts
+}
+
 // craneOptions returns common crane options for registry operations,
-// including authentication and rate-limited transport.
+// including authentication, rate-limited transport, and reuse of
+// puller/pusher state when available.
 func (di *DefaultPromoterImplementation) craneOptions() []crane.Option {
 	opts := []crane.Option{
 		crane.WithAuthFromKeychain(gcrane.Keychain),
 		crane.WithUserAgent(image.UserAgent),
 	}
+
 	if di.transport != nil {
 		opts = append(opts, crane.WithTransport(di.transport))
+	}
+
+	if di.puller != nil || di.pusher != nil {
+		var remoteOpts []remote.Option
+
+		if di.puller != nil {
+			remoteOpts = append(remoteOpts, remote.Reuse(di.puller))
+		}
+
+		if di.pusher != nil {
+			remoteOpts = append(remoteOpts, remote.Reuse(di.pusher))
+		}
+
+		opts = append(opts, func(o *crane.Options) {
+			o.Remote = append(o.Remote, remoteOpts...)
+		})
 	}
 
 	return opts

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -274,13 +273,7 @@ func (di *DefaultPromoterImplementation) executeCopies(
 
 	for _, c := range copies {
 		g.Go(func() error {
-			craneOpts := []crane.Option{
-				crane.WithAuthFromKeychain(gcrane.Keychain),
-				crane.WithUserAgent(image.UserAgent),
-				crane.WithTransport(di.getTransport()),
-			}
-
-			if err := di.copyWithRetry(c.src, c.dst, craneOpts); err != nil {
+			if err := di.copyWithRetry(c.src, c.dst, di.craneOptions()); err != nil {
 				var terr *transport.Error
 				if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
 					logrus.Debugf("Signature %s not found, skipping (%d/%d)",
@@ -519,14 +512,8 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *promotion.Edg
 
 	logrus.Infof("Signature pre copy: %s to %s", srcRefString, dstRefString)
 
-	craneOpts := []crane.Option{
-		crane.WithAuthFromKeychain(gcrane.Keychain),
-		crane.WithUserAgent(image.UserAgent),
-		crane.WithTransport(di.getTransport()),
-	}
-
 	if err := ratelimit.WithRetry(func() error {
-		return crane.Copy(srcRef.String(), dstRef.String(), craneOpts...)
+		return crane.Copy(srcRef.String(), dstRef.String(), di.craneOptions()...)
 	}); err != nil {
 		// If the signature layer does not exist it means that the src image
 		// is not signed, so we catch the error and return nil
@@ -570,10 +557,7 @@ func (di *DefaultPromoterImplementation) listTagsWithRetry(repo string) ([]strin
 	if err := ratelimit.WithRetry(func() error {
 		var err error
 
-		tags, err = crane.ListTags(repo,
-			crane.WithAuthFromKeychain(gcrane.Keychain),
-			crane.WithTransport(di.getTransport()),
-		)
+		tags, err = crane.ListTags(repo, di.craneOptions()...)
 		if err != nil {
 			return fmt.Errorf("listing tags for %s: %w", repo, err)
 		}
@@ -643,16 +627,10 @@ func (di *DefaultPromoterImplementation) copySBOM(edge *promotion.Edge) error {
 		"%s/%s:%s", edge.DstRegistry.Name, edge.DstImageTag.Name, sbomTag,
 	)
 
-	craneOpts := []crane.Option{
-		crane.WithAuthFromKeychain(gcrane.Keychain),
-		crane.WithUserAgent(image.UserAgent),
-		crane.WithTransport(di.getTransport()),
-	}
-
 	logrus.Infof("SBOM copy: %s to %s", srcRefString, dstRefString)
 
 	if err := ratelimit.WithRetry(func() error {
-		return crane.Copy(srcRefString, dstRefString, craneOpts...)
+		return crane.Copy(srcRefString, dstRefString, di.craneOptions()...)
 	}); err != nil {
 		// If the SBOM does not exist in staging, skip silently
 		var terr *transport.Error
@@ -767,7 +745,7 @@ func (di *DefaultPromoterImplementation) pushAttestation(
 	}
 
 	// Check if attestation already exists (idempotent)
-	if _, err := remote.Head(ref, remote.WithAuthFromKeychain(gcrane.Keychain)); err == nil {
+	if _, err := remote.Head(ref, di.remoteOptions()...); err == nil {
 		logrus.Debugf("Attestation %s already exists, skipping", dstRefString)
 
 		return nil
@@ -788,11 +766,7 @@ func (di *DefaultPromoterImplementation) pushAttestation(
 	logrus.Infof("Provenance attestation: pushing %s", dstRefString)
 
 	if err := ratelimit.WithRetry(func() error {
-		return remote.Write(ref, img,
-			remote.WithAuthFromKeychain(gcrane.Keychain),
-			remote.WithUserAgent(image.UserAgent),
-			remote.WithTransport(di.getTransport()),
-		)
+		return remote.Write(ref, img, di.remoteOptions()...)
 	}); err != nil {
 		return fmt.Errorf("pushing attestation %s: %w", dstRefString, err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adopts `remote.Reuse` from go-containerregistry to reuse HTTP auth/transport state across OCI remote operations. This avoids redundant auth token exchanges and HEAD requests, improving performance for batch operations like signature replication.

Changes:
- Add shared `remote.Puller` and `remote.Pusher` to `DefaultPromoterImplementation`
- Add `remoteOptions()` and update `craneOptions()` to include `remote.Reuse`
- Replace all inline crane/remote option construction in `sign.go` with centralized helpers

#### Which issue(s) this PR fixes:

Fixes #842

#### Special notes for your reviewer:

`remote.Reuse` is already available in go-containerregistry v0.21.1 (current dep). No dependency bump needed. The rate-limited transport is fully compatible since `remote.Reuse` operates at a higher level (caching auth negotiations).

#### Does this PR introduce a user-facing change?

```release-note
None
```