### PR TITLE
Replace xerrors with stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
-	golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9
 	google.golang.org/api v0.269.0
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1047,8 +1047,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9 h1:LLhsEBxRTBLuKlQxFBYUOU8xyFgXv6cOTp2HASDlsDk=
-golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/api v0.269.0 h1:qDrTOxKUQ/P0MveH6a7vZ+DNHxJQjtGm/uvdbdGXCQg=

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -18,6 +18,7 @@ package manifest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -25,7 +26,6 @@ import (
 	"slices"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/xerrors"
 
 	"sigs.k8s.io/promo-tools/v4/promoter/image/registry"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/schema"
@@ -109,11 +109,11 @@ func toDigests(digestStrings []string) []image.Digest {
 // Validate validates the options.
 func (o *GrowOptions) Validate() error {
 	if o.BaseDir == "" {
-		return xerrors.New("must specify --base_dir")
+		return errors.New("must specify --base_dir")
 	}
 
 	if o.StagingRepo == "" {
-		return xerrors.New("must specify --staging_repo")
+		return errors.New("must specify --staging_repo")
 	}
 
 	if containsTag(o.FilterTags, latestTag) {
@@ -262,7 +262,7 @@ func ApplyFilters(o *GrowOptions, rii registry.RegInvImage) (registry.RegInvImag
 	rii = ExcludeTags(rii, excludeTags)
 
 	if len(rii) == 0 {
-		return registry.RegInvImage{}, xerrors.New(
+		return registry.RegInvImage{}, errors.New(
 			"no images survived filtering; double-check your --filter_* flag(s) for typos",
 		)
 	}

--- a/image/manifest/manifest_test.go
+++ b/image/manifest/manifest_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"sigs.k8s.io/promo-tools/v4/image/manifest"
 	"sigs.k8s.io/promo-tools/v4/promoter/image/registry"
@@ -233,7 +232,7 @@ func TestApplyFilters(t *testing.T) {
 				},
 			},
 			registry.RegInvImage{},
-			xerrors.New("no images survived filtering; double-check your --filter_* flag(s) for typos"),
+			errors.New("no images survived filtering; double-check your --filter_* flag(s) for typos"),
 		},
 		{
 			"filter on digest",

--- a/promobot/hash.go
+++ b/promobot/hash.go
@@ -18,12 +18,12 @@ package promobot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/xerrors"
 	"sigs.k8s.io/release-utils/hash"
 
 	api "sigs.k8s.io/promo-tools/v4/api/files"
@@ -53,7 +53,7 @@ func GenerateManifest(_ context.Context, options GenerateManifestOptions) (*api.
 	manifest := &api.Manifest{}
 
 	if options.BaseDir == "" {
-		return nil, xerrors.New("must specify BaseDir")
+		return nil, errors.New("must specify BaseDir")
 	}
 
 	basedir := options.BaseDir


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces `golang.org/x/xerrors` with stdlib `errors`. All usages were trivial `xerrors.New()` calls, which are identical to `errors.New()`. Removes the dependency from go.mod.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```