### PR TITLE
Use two-phase tag listing for signature replication

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"sort"
@@ -198,10 +199,10 @@ func (di *DefaultPromoterImplementation) signFirst(signOpts *sign.Options, ident
 	return nil
 }
 
-// ReplicateSignatures batch-lists tags for all image repositories across all
-// registries in a single concurrent pass, then copies only the signatures
-// that are missing from the mirrors. This is used by the standalone
-// replication pipeline where most signatures already exist.
+// ReplicateSignatures lists tags for source repositories first, then only
+// for mirror repositories of signed groups, and copies the signatures that
+// are missing from the mirrors. This is used by the standalone replication
+// pipeline where most signatures already exist.
 func (di *DefaultPromoterImplementation) ReplicateSignatures(
 	opts *options.Options, edges map[promotion.Edge]any,
 ) error {
@@ -309,33 +310,21 @@ func (di *DefaultPromoterImplementation) executeCopies(
 
 type copyItem struct{ src, dst string }
 
-// computeCopiesFromInventory batch-lists tags for all repositories across
-// source and mirrors in a single concurrent pass, then returns only the
-// copies where the source has a signature tag that the mirror is missing.
+type repoKey struct{ registry, image string }
+
+// computeCopiesFromInventory uses a two-phase tag listing strategy to
+// minimise API requests against Artifact Registry:
+//
+//  1. List tags for source repositories only (group[0] per group).
+//  2. Filter to groups whose source has a signature tag.
+//  3. List tags for mirror repositories of signed groups only.
+//
+// This avoids listing mirror repos for unsigned images (~57 % of groups in
+// practice), cutting the total number of API calls roughly in half.
 func (di *DefaultPromoterImplementation) computeCopiesFromInventory(
 	multiGroups [][]promotion.Edge,
 ) ([]copyItem, error) {
-	type repoKey struct{ registry, image string }
-
-	type tagSet = map[string]struct{}
-
-	allRepos := map[repoKey]struct{}{}
-
-	for _, group := range multiGroups {
-		for _, edge := range group {
-			key := repoKey{string(edge.DstRegistry.Name), string(edge.DstImageTag.Name)}
-			allRepos[key] = struct{}{}
-		}
-	}
-
-	totalRepos := len(allRepos)
-
-	logrus.Infof("Listing tags for %d repositories across %d groups",
-		totalRepos, len(multiGroups))
-
 	// Temporarily increase the rate limit during read-only listing.
-	// The AR quota is ~83 req/sec; we use 80 for headroom. The normal
-	// limit (50) is restored after the batch completes.
 	rt := di.getTransport()
 	rt.SetLimit(ratelimit.ListingLimit)
 	rt.SetBurst(ratelimit.ListingBurst)
@@ -345,7 +334,123 @@ func (di *DefaultPromoterImplementation) computeCopiesFromInventory(
 		rt.SetBurst(ratelimit.DefaultBurst)
 	}()
 
-	allTags := make(map[repoKey]tagSet, totalRepos)
+	// Phase 1: list tags for source repositories only.
+
+	srcRepos := map[repoKey]struct{}{}
+
+	for _, group := range multiGroups {
+		src := group[0]
+		srcRepos[repoKey{string(src.DstRegistry.Name), string(src.DstImageTag.Name)}] = struct{}{}
+	}
+
+	logrus.Infof("Phase 1: listing tags for %d source repositories", len(srcRepos))
+
+	srcTags, err := di.batchListTags(srcRepos)
+	if err != nil {
+		return nil, fmt.Errorf("listing source repositories: %w", err)
+	}
+
+	// Filter: keep only groups whose source has a signature.
+
+	type signedGroup struct {
+		group  []promotion.Edge
+		sigTag string
+	}
+
+	var signed []signedGroup
+
+	for _, group := range multiGroups {
+		src := group[0]
+		srcKey := repoKey{string(src.DstRegistry.Name), string(src.DstImageTag.Name)}
+		sigTag := digestToSignatureTag(src.Digest)
+
+		if _, ok := srcTags[srcKey][sigTag]; ok {
+			signed = append(signed, signedGroup{group, sigTag})
+		}
+	}
+
+	logrus.Infof("Signature status: %d/%d groups signed",
+		len(signed), len(multiGroups))
+
+	if len(signed) == 0 {
+		logrus.Info("No signed groups, skipping mirror listing")
+
+		return nil, nil
+	}
+
+	// Phase 2: list tags for mirror repositories of signed groups only.
+
+	mirrorRepos := map[repoKey]struct{}{}
+
+	for _, sg := range signed {
+		for _, dst := range sg.group[1:] {
+			key := repoKey{string(dst.DstRegistry.Name), string(dst.DstImageTag.Name)}
+			if _, ok := srcTags[key]; !ok {
+				mirrorRepos[key] = struct{}{}
+			}
+		}
+	}
+
+	// Build a single lookup map for all destinations.
+	allTags := make(map[repoKey]map[string]struct{}, len(srcTags)+len(mirrorRepos))
+
+	maps.Copy(allTags, srcTags)
+
+	if len(mirrorRepos) > 0 {
+		logrus.Infof("Phase 2: listing tags for %d mirror repositories", len(mirrorRepos))
+
+		mirrorTags, err := di.batchListTags(mirrorRepos)
+		if err != nil {
+			return nil, fmt.Errorf("listing mirror repositories: %w", err)
+		}
+
+		maps.Copy(allTags, mirrorTags)
+	}
+
+	// Compute copies.
+
+	var (
+		copies []copyItem
+		seen   = map[string]struct{}{}
+	)
+
+	for _, sg := range signed {
+		src := sg.group[0]
+		srcRef := fmt.Sprintf("%s/%s:%s",
+			src.DstRegistry.Name, src.DstImageTag.Name, sg.sigTag)
+
+		for _, dst := range sg.group[1:] {
+			dstRef := fmt.Sprintf("%s/%s:%s",
+				dst.DstRegistry.Name, dst.DstImageTag.Name, sg.sigTag)
+
+			if _, ok := seen[dstRef]; ok {
+				continue
+			}
+
+			seen[dstRef] = struct{}{}
+
+			dstKey := repoKey{string(dst.DstRegistry.Name), string(dst.DstImageTag.Name)}
+
+			if _, ok := allTags[dstKey][sg.sigTag]; !ok {
+				copies = append(copies, copyItem{srcRef, dstRef})
+			}
+		}
+	}
+
+	logrus.Infof("%d copies needed", len(copies))
+
+	return copies, nil
+}
+
+// batchListTags concurrently lists tags for the given repositories and
+// returns a map from repo key to the set of tags found.
+func (di *DefaultPromoterImplementation) batchListTags(
+	repos map[repoKey]struct{},
+) (map[repoKey]map[string]struct{}, error) {
+	type tagSet = map[string]struct{}
+
+	total := len(repos)
+	result := make(map[repoKey]tagSet, total)
 
 	var (
 		mu     sync.Mutex
@@ -355,7 +460,7 @@ func (di *DefaultPromoterImplementation) computeCopiesFromInventory(
 	g := new(errgroup.Group)
 	g.SetLimit(ratelimit.ListingConcurrency)
 
-	for key := range allRepos {
+	for key := range repos {
 		g.Go(func() error {
 			tags, err := di.listTagsWithRetry(
 				fmt.Sprintf("%s/%s", key.registry, key.image),
@@ -370,11 +475,11 @@ func (di *DefaultPromoterImplementation) computeCopiesFromInventory(
 			}
 
 			mu.Lock()
-			allTags[key] = set
+			result[key] = set
 			mu.Unlock()
 
 			if n := listed.Add(1); n%1000 == 0 {
-				logrus.Infof("Listed %d/%d repositories", n, totalRepos)
+				logrus.Infof("Listed %d/%d repositories", n, total)
 			}
 
 			return nil
@@ -382,53 +487,12 @@ func (di *DefaultPromoterImplementation) computeCopiesFromInventory(
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("listing repositories: %w", err)
+		return nil, fmt.Errorf("listing tags: %w", err)
 	}
 
-	logrus.Infof("Listed %d repositories", totalRepos)
+	logrus.Infof("Listed %d repositories", total)
 
-	var (
-		copies      []copyItem
-		seen        = map[string]struct{}{}
-		signedCount int
-	)
-
-	for _, group := range multiGroups {
-		src := group[0]
-		srcKey := repoKey{string(src.DstRegistry.Name), string(src.DstImageTag.Name)}
-		sigTag := digestToSignatureTag(src.Digest)
-
-		if _, ok := allTags[srcKey][sigTag]; !ok {
-			continue
-		}
-
-		signedCount++
-
-		srcRef := fmt.Sprintf("%s/%s:%s",
-			src.DstRegistry.Name, src.DstImageTag.Name, sigTag)
-
-		for _, dst := range group[1:] {
-			dstRef := fmt.Sprintf("%s/%s:%s",
-				dst.DstRegistry.Name, dst.DstImageTag.Name, sigTag)
-
-			if _, ok := seen[dstRef]; ok {
-				continue
-			}
-
-			seen[dstRef] = struct{}{}
-
-			dstKey := repoKey{string(dst.DstRegistry.Name), string(dst.DstImageTag.Name)}
-
-			if _, ok := allTags[dstKey][sigTag]; !ok {
-				copies = append(copies, copyItem{srcRef, dstRef})
-			}
-		}
-	}
-
-	logrus.Infof("Signature status: %d/%d groups signed, %d copies needed",
-		signedCount, len(multiGroups), len(copies))
-
-	return copies, nil
+	return result, nil
 }
 
 // targetIdentity returns the production identity for a promotion edge.

--- a/internal/promoter/image/sign_integration_test.go
+++ b/internal/promoter/image/sign_integration_test.go
@@ -584,3 +584,129 @@ func TestReplicateSignaturesBatchIdempotent(t *testing.T) {
 	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
 	require.NoError(t, err, "signature should exist on mirror")
 }
+
+// TestReplicateSignaturesMixedSignedUnsigned verifies the two-phase listing:
+// only mirror repos for signed groups are listed, unsigned groups are skipped
+// entirely in phase 2.
+func TestReplicateSignaturesMixedSignedUnsigned(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror := prodPath("bb-mirror")
+
+	// "app" has a signature, "web" does not.
+	dApp := pushTestImage(t, di, host+"/"+primary+"/app:v1.0")
+	dWeb := pushTestImage(t, di, host+"/"+primary+"/web:latest")
+
+	sigTagApp := digestToSignatureTag(image.Digest(dApp))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/app:%s", host, primary, sigTagApp))
+
+	// Push images to the mirror (no signatures).
+	pushTestImage(t, di, host+"/"+mirror+"/app:v1.0")
+	pushTestImage(t, di, host+"/"+mirror+"/web:latest")
+
+	edges := map[promotion.Edge]any{
+		makeProdEdge(host, "aa-primary", "app", "v1.0", image.Digest(dApp)):   nil,
+		makeProdEdge(host, "bb-mirror", "app", "v1.0", image.Digest(dApp)):    nil,
+		makeProdEdge(host, "aa-primary", "web", "latest", image.Digest(dWeb)): nil,
+		makeProdEdge(host, "bb-mirror", "web", "latest", image.Digest(dWeb)):  nil,
+	}
+
+	opts := &options.Options{
+		SignImages:         true,
+		MaxSignatureCopies: 10,
+	}
+
+	err := di.ReplicateSignatures(opts, edges)
+	require.NoError(t, err)
+
+	// "app" signature should be replicated to the mirror.
+	refStr := fmt.Sprintf("%s/%s/app:%s", host, mirror, sigTagApp)
+	ref, err := name.ParseReference(refStr)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.NoError(t, err, "app signature should exist on mirror")
+
+	// "web" should have no signature on the mirror (none existed on primary).
+	sigTagWeb := digestToSignatureTag(image.Digest(dWeb))
+	refStr = fmt.Sprintf("%s/%s/web:%s", host, mirror, sigTagWeb)
+	ref, err = name.ParseReference(refStr)
+	require.NoError(t, err)
+
+	_, err = remote.Head(ref, remote.WithTransport(di.getTransport()))
+	require.Error(t, err, "web signature should NOT exist on mirror")
+}
+
+// TestComputeCopiesFromInventoryTwoPhase directly tests computeCopiesFromInventory
+// to verify it produces the correct copies with the two-phase listing strategy.
+func TestComputeCopiesFromInventoryTwoPhase(t *testing.T) {
+	t.Parallel()
+
+	host, di := newTLSTestRegistry(t)
+
+	primary := prodPath("aa-primary")
+	mirror1 := prodPath("bb-mirror1")
+	mirror2 := prodPath("cc-mirror2")
+
+	// Push three images: img1 and img2 are signed, img3 is not.
+	d1 := pushTestImage(t, di, host+"/"+primary+"/img1:v1")
+	d2 := pushTestImage(t, di, host+"/"+primary+"/img2:v1")
+	d3 := pushTestImage(t, di, host+"/"+primary+"/img3:v1")
+
+	sigTag1 := digestToSignatureTag(image.Digest(d1))
+	sigTag2 := digestToSignatureTag(image.Digest(d2))
+
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/img1:%s", host, primary, sigTag1))
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/img2:%s", host, primary, sigTag2))
+
+	// Push images to mirrors (no signatures).
+	for _, m := range []string{mirror1, mirror2} {
+		pushTestImage(t, di, host+"/"+m+"/img1:v1")
+		pushTestImage(t, di, host+"/"+m+"/img2:v1")
+		pushTestImage(t, di, host+"/"+m+"/img3:v1")
+	}
+
+	// img2 signature already exists on mirror1 (partially replicated).
+	pushTestImage(t, di, fmt.Sprintf("%s/%s/img2:%s", host, mirror1, sigTag2))
+
+	// Build edges for all three images across all three registries.
+	edges := map[promotion.Edge]any{}
+
+	for _, img := range []struct {
+		name   string
+		tag    image.Tag
+		digest image.Digest
+	}{
+		{"img1", "v1", image.Digest(d1)},
+		{"img2", "v1", image.Digest(d2)},
+		{"img3", "v1", image.Digest(d3)},
+	} {
+		for _, prefix := range []string{"aa-primary", "bb-mirror1", "cc-mirror2"} {
+			edges[makeProdEdge(host, prefix, img.name, img.tag, img.digest)] = nil
+		}
+	}
+
+	multiGroups := collectMultiRegistryGroups(edges)
+
+	copies, err := di.computeCopiesFromInventory(multiGroups)
+	require.NoError(t, err)
+
+	// Expected copies:
+	// - img1 signature → mirror1 and mirror2 (2 copies)
+	// - img2 signature → mirror2 only (mirror1 already has it) (1 copy)
+	// - img3 → no signature, no copies
+	require.Len(t, copies, 3)
+
+	// Verify the exact copy destinations.
+	dsts := make(map[string]struct{}, len(copies))
+	for _, c := range copies {
+		dsts[c.dst] = struct{}{}
+	}
+
+	require.Contains(t, dsts, fmt.Sprintf("%s/%s/img1:%s", host, mirror1, sigTag1))
+	require.Contains(t, dsts, fmt.Sprintf("%s/%s/img1:%s", host, mirror2, sigTag1))
+	require.Contains(t, dsts, fmt.Sprintf("%s/%s/img2:%s", host, mirror2, sigTag2))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Uses a two-phase tag listing strategy in `computeCopiesFromInventory` to reduce Artifact Registry API calls during signature replication:

1. List tags for source repositories only
2. Filter to groups whose source has a signature
3. List tags for mirror repositories of signed groups only

This skips listing mirror repos for unsigned images (~57% of groups), cutting the total API calls roughly in half.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```