### PR TITLE
Update Dockerfile to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG GO_VERSION
 ARG OS_CODENAME
-FROM golang:1.25-trixie AS builder
+FROM golang:1.26-trixie AS builder
 
 # Copy the sources
 WORKDIR /go/src/app

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,13 +38,13 @@ dependencies:
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
   - name: "golang: 1.<major>"
-    version: 1.25
+    version: 1.26
     refPaths:
     - path: Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(trixie)
 
   - name: "golang: go.mod"
-    version: 1.25
+    version: 1.26
     refPaths:
     - path: go.mod
       match: go \d+.\d+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/promo-tools/v4
 
-go 1.25.7
+go 1.26.0
 
 require (
 	cloud.google.com/go/containeranalysis v0.17.0


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the Dockerfile builder image from `golang:1.25-trixie` to `golang:1.26-trixie` to match the Go 1.26.0 requirement from the k8s.io/apimachinery v0.36.0 bump in #1827.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Depends on kubernetes/test-infra CI image update for the `pull-cip-verify` job.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```