### PR TITLE
Add `--manifest-diff-since` flag for time-bounded promotion

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -91,6 +91,13 @@ the 'images: ...' contents`,
 		"use only the latest diff for the manifest dir. Works only on prow.",
 	)
 
+	CipCmd.PersistentFlags().StringVar(
+		&runOpts.ManifestDiffSince,
+		"manifest-diff-since",
+		"",
+		`only promote digests from manifests changed within this duration (uses git date format, e.g. "7 days", "24 hours", "1 week")`,
+	)
+
 	CipCmd.PersistentFlags().BoolVar(
 		&runOpts.ParseOnly,
 		"parse-only",

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -196,7 +196,7 @@ func Find(o *GrowOptions) (schema.Manifest, error) {
 		manifests []schema.Manifest
 	)
 
-	manifests, err = schema.ParseThinManifestsFromDir(o.BaseDir, false)
+	manifests, err = schema.ParseThinManifestsFromDir(o.BaseDir, false, "")
 	if err != nil {
 		return schema.Manifest{}, fmt.Errorf("parsing thin manifests from %s: %w", o.BaseDir, err)
 	}

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -51,7 +51,7 @@ func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (
 
 	// The thin manifests
 	if opts.ThinManifestDir != "" {
-		mfests, err := schema.ParseThinManifestsFromDir(opts.ThinManifestDir, opts.UseProwManifestDiff)
+		mfests, err := schema.ParseThinManifestsFromDir(opts.ThinManifestDir, opts.UseProwManifestDiff, opts.ManifestDiffSince)
 		if err != nil {
 			return nil, fmt.Errorf("parsing thin manifest directory: %w", err)
 		}

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -33,6 +33,10 @@ type Options struct {
 	// Use only the latest diff for the manifests. Works only when running in prow.
 	UseProwManifestDiff bool
 
+	// ManifestDiffSince limits promotion to digests added within this
+	// duration (uses git date format, e.g. "7 days", "24 hours").
+	ManifestDiffSince string
+
 	// Manifest is the path of a manifest file
 	Manifest string
 

--- a/promoter/image/schema/manifest.go
+++ b/promoter/image/schema/manifest.go
@@ -251,13 +251,14 @@ func (m *Manifest) srcRegistryName() image.Registry {
 // We effectively have to create a map of manifests, keyed by the source
 // registry (there can only be 1 source registry).
 func ParseThinManifestsFromDir(
-	dir string, onlyProwDiff bool,
+	dir string, onlyProwDiff bool, diffSince string,
 ) ([]Manifest, error) {
 	var mfests []Manifest
 
 	digestsToCheck := []string{}
 
-	if onlyProwDiff {
+	switch {
+	case onlyProwDiff:
 		var err error
 
 		digestsToCheck, err = diffProwFiles(dir)
@@ -267,6 +268,20 @@ func ParseThinManifestsFromDir(
 
 		if len(digestsToCheck) == 0 {
 			logrus.Info("No digests found in prow diff, nothing to promote")
+
+			return []Manifest{}, nil
+		}
+
+	case diffSince != "":
+		var err error
+
+		digestsToCheck, err = diffSinceFiles(dir, diffSince)
+		if err != nil {
+			return nil, fmt.Errorf("get diff since %s: %w", diffSince, err)
+		}
+
+		if len(digestsToCheck) == 0 {
+			logrus.Infof("No digests found in the last %s, nothing to promote", diffSince)
 
 			return []Manifest{}, nil
 		}
@@ -344,7 +359,6 @@ func diffProwFiles(dir string) ([]string, error) {
 	logrus.Info("Using prow diff")
 
 	const (
-		git               = "git"
 		pullBaseSHAEnv    = "PULL_BASE_SHA"
 		jobTypeEnv        = "JOB_TYPE"
 		jobTypePostsubmit = "postsubmit"
@@ -373,6 +387,53 @@ func diffProwFiles(dir string) ([]string, error) {
 		return nil, fmt.Errorf("unknown job type: %s", jobType)
 	}
 
+	return digestsFromDiff(dir, base)
+}
+
+func diffSinceFiles(dir, since string) ([]string, error) {
+	logrus.Infof("Using manifest diff since %s", since)
+
+	const git = "git"
+
+	workdirRes, err := command.NewWithWorkDir(
+		dir, git, "rev-parse", "--show-toplevel",
+	).RunSilentSuccessOutput()
+	if err != nil {
+		return nil, fmt.Errorf("running git rev-parse: %w", err)
+	}
+
+	workdir := workdirRes.OutputTrimNL()
+
+	logRes, err := command.NewWithWorkDir(
+		workdir, git, "log", "--since="+since, "--format=%H",
+	).RunSilentSuccessOutput()
+	if err != nil {
+		return nil, fmt.Errorf("running git log: %w", err)
+	}
+
+	lines := strings.TrimSpace(logRes.OutputTrimNL())
+	if lines == "" {
+		return nil, nil
+	}
+
+	commits := strings.Split(lines, "\n")
+	oldest := commits[len(commits)-1]
+
+	parentRes, err := command.NewWithWorkDir(
+		workdir, git, "rev-parse", "--verify", oldest+"~1",
+	).RunSilentSuccessOutput()
+
+	base := oldest
+	if err == nil {
+		base = parentRes.OutputTrimNL()
+	}
+
+	return digestsFromDiff(dir, base)
+}
+
+func digestsFromDiff(dir, base string) ([]string, error) {
+	const git = "git"
+
 	workdirRes, err := command.NewWithWorkDir(
 		dir, git, "rev-parse", "--show-toplevel",
 	).RunSilentSuccessOutput()
@@ -389,7 +450,6 @@ func diffProwFiles(dir string) ([]string, error) {
 		return nil, fmt.Errorf("running git diff: %w", err)
 	}
 
-	// Normalize the digests
 	var digests []string
 
 	for line := range strings.SplitSeq(diff.OutputTrimNL(), "\n") {

--- a/promoter/image/schema/manifest_test.go
+++ b/promoter/image/schema/manifest_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schema
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
 
 	for _, onlyProwDiff := range []bool{true, false} {
 		manifests, err := ParseThinManifestsFromDir(
-			filepath.Join(testDir, "k8s.gcr.io"), onlyProwDiff,
+			filepath.Join(testDir, "k8s.gcr.io"), onlyProwDiff, "",
 		)
 
 		require.NoError(t, err)
@@ -64,4 +65,77 @@ func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
 		assert.Equal(t, expectedDigestCount, digestCount)
 		assert.Equal(t, 623, imageCount)
 	}
+}
+
+func TestDiffSinceFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	const git = "git"
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "init").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "config", "user.email", "test@test.com").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "config", "user.name", "test").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "config", "commit.gpgsign", "false").RunSilentSuccess())
+
+	imagesDir := filepath.Join(tmpDir, "images", "test")
+	require.NoError(t, os.MkdirAll(imagesDir, 0o755))
+
+	imagesFile := filepath.Join(imagesDir, "images.yaml")
+	require.NoError(t, os.WriteFile(imagesFile, []byte("initial\n"), 0o600))
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "add", ".").RunSilentSuccess())
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "commit", "-m", "initial",
+		"--date", "2020-01-01T00:00:00Z").
+		Env("GIT_COMMITTER_DATE=2020-01-01T00:00:00Z").
+		RunSilentSuccess())
+
+	contentA := `- name: test-image
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["v1.0"]
+`
+	require.NoError(t, os.WriteFile(imagesFile, []byte(contentA), 0o600))
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "add", ".").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "commit", "-m", "add digest A").RunSilentSuccess())
+
+	contentB := `- name: test-image
+  dmap:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": ["v1.0"]
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": ["v2.0"]
+`
+	require.NoError(t, os.WriteFile(imagesFile, []byte(contentB), 0o600))
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "add", ".").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "commit", "-m", "add digest B").RunSilentSuccess())
+
+	digests, err := diffSinceFiles(tmpDir, "1 day")
+	require.NoError(t, err)
+	assert.Len(t, digests, 2)
+	assert.Contains(t, digests, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	assert.Contains(t, digests, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+}
+
+func TestDiffSinceFilesNoChanges(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	const git = "git"
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "init").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "config", "user.email", "test@test.com").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "config", "user.name", "test").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "config", "commit.gpgsign", "false").RunSilentSuccess())
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("test\n"), 0o600))
+
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "add", ".").RunSilentSuccess())
+	require.NoError(t, command.NewWithWorkDir(tmpDir, git, "commit", "-m", "initial").RunSilentSuccess())
+
+	digests, err := diffSinceFiles(tmpDir, "1 second")
+	require.NoError(t, err)
+	assert.Empty(t, digests)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The periodic `ci-k8sio-image-promo` job processes the entire manifest universe, making it fragile: any single broken image (tag moves, `_LOST_` sources) blocks all promotions (kubernetes/k8s.io#9563).

This adds a `--manifest-diff-since` flag that limits promotion to digests added within a time window (e.g. `--manifest-diff-since="7 days"`). It uses `git log --since` to find the oldest commit in the window and diffs against it, reusing the existing digest filtering path.

#### Which issue(s) this PR fixes:

Related: kubernetes/k8s.io#9563

#### Special notes for your reviewer:

The flag value is passed directly to git's `--since` argument, so it supports any git date format ("7 days", "24 hours", "1 week", etc.).
A follow-up PR in test-infra will update the periodic job to use this flag.

#### Does this PR introduce a user-facing change?

```release-note
Add --manifest-diff-since flag to limit promotion to recently changed digests
```